### PR TITLE
Add help target and default goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 4. Optionally customize `src/pandoc-template.html` for your project.
 5. Edit `docker` rule in `redo.mk` if you'd like to push docker images to a
    container registry.
-6. See `docs/redo-mk.md` for descriptions of the available `make` targets.
+6. Run `r help` (or `make -f redo.mk help`) to see available tasks. See
+   `docs/redo-mk.md` for more details.
 
 ### General Setup
 

--- a/redo.mk
+++ b/redo.mk
@@ -2,8 +2,8 @@
 
 # Override MAKEFLAGS (so your settings can’t be clobbered by the environment)
 override MAKEFLAGS += --warn-undefined-variables  \
-                      --no-builtin-rules        \
-                      -j16                      \
+	              --no-builtin-rules        \
+	              -j16                      \
 
 # Export it so sub-makes see the same flags
 export MAKEFLAGS
@@ -15,12 +15,15 @@ VPATH := src
 
 MAKE_CMD := docker compose run --rm --entrypoint make -u $(shell id -u) -T --build shell
 
+# Default make target
+.DEFAULT_GOAL := all
+
 # Define the default target to build everything
 .PHONY: all
-all:
+all: ## Build the site by invoking /app/mk/build.mk inside the shell container
 	$(MAKE_CMD) -f /app/mk/build.mk
 
-build:
+build: ## Helper target used by other rules
 	mkdir -p $@
 
 # Docker-related targets
@@ -32,62 +35,66 @@ build:
 CONTAINER_REGISTRY := registry.digitalocean.com/artisticanatomy
 
 .PHONY: docker
-docker: test
+docker: test ## Build and push the Nginx image after running test
 	docker compose build nginx
 	docker tag koreanbriancom-nginx $(CONTAINER_REGISTRY)/koreanbrian.com:latest
 	docker push registry.digitalocean.com/artisticanatomy/koreanbrian.com:latest
 
 .PHONY: test
-test:
+test: ## Restart nginx-dev and run tests
 	docker compose restart nginx-dev
 	$(MAKE_CMD) -f /app/mk/build.mk test
 
 # Target to bring up the development Nginx container
 .PHONY: up
-up:
+up: ## Start development containers defined in SERVICES
 	docker compose up $(SERVICES) --build --remove-orphans
 
 .PHONY: upd
-upd:
+upd: ## Start development containers in detached mode
 	docker compose up $(SERVICES) --build --remove-orphans -d
 
 .PHONY: down
-down:
+down: ## Stop and remove the compose stack
 	docker compose down
 
 # Clean the build directory by removing all build artifacts
 .PHONY: clean
-clean:
+clean: ## Remove everything under build/
 	-rm -rf build/*
 
 .PHONY: prune
-prune:
+prune: ## Run docker system prune -f to clean unused resources
 	docker system prune -f
 
 .PHONY: setup
-setup:
+setup: ## Build the service framework image and prepare app/webp directories
 	docker compose build service-framework
 	mkdir -p app/webp/input
 	mkdir -p app/webp/output
 	docker compose build
 
 .PHONY: seed
-seed:
+seed: ## Run the seed container to populate initial data
 	docker compose run --build --rm -T seed
 
 .PHONY: sync
-sync:
+sync: ## Upload site files to S3 using the sync container
 	docker compose run --build --rm -T sync
 
 .PHONY: webp
-webp:
+webp: ## Convert images to webp format
 	docker compose run --build --rm -T webp
 
 .PHONY: shell
-shell:
+shell: ## Open an interactive shell container
 	docker compose run --build --rm shell
 
 .PHONY: rmi
-
-rmi:
+rmi: ## Remove Docker images matching press-*
 	./bin/docker-rmi-pattern 'press-*'
+
+.PHONY: help
+help: ## List available tasks
+	@grep -E '^[a-zA-Z0-9_-]+:.*##' $(MAKEFILE_LIST) | \
+	awk -F ':.*##' '{printf "%-10s %s\n", $$1, $$2}'


### PR DESCRIPTION
## Summary
- set `.DEFAULT_GOAL := all`
- list all tasks via a new `help` target
- mention `help` in the quickstart

## Testing
- `make -f redo.mk help`

------
https://chatgpt.com/codex/tasks/task_e_685edd5d3adc83219dcb08fa3c86ef69