### PR TITLE
Introduce DOCKER_RUN shorthand for compose

### DIFF
--- a/docs/redo-mk.md
+++ b/docs/redo-mk.md
@@ -6,6 +6,7 @@
 
 - **`SERVICES`** – Containers started by `up`/`upd` (default: `nginx-dev sync webp`).
 - **`MAKE_CMD`** – Helper command to run the lower-level makefile inside the `shell` service.
+- **`DOCKER_RUN`** – Shorthand for `docker compose run --build --rm -T` used by several targets.
 
 ## Common Targets
 

--- a/redo.mk
+++ b/redo.mk
@@ -14,6 +14,7 @@ SERVICES := nginx-dev sync webp
 VPATH := src
 
 MAKE_CMD := docker compose run --rm --entrypoint make -u $(shell id -u) -T --build shell
+DOCKER_RUN := docker compose run --build --rm -T
 
 # Define the default target to build everything
 .PHONY: all
@@ -73,19 +74,19 @@ setup:
 
 .PHONY: seed
 seed:
-	docker compose run --build --rm -T seed
+       $(DOCKER_RUN) seed
 
 .PHONY: sync
 sync:
-	docker compose run --build --rm -T sync
+       $(DOCKER_RUN) sync
 
 .PHONY: webp
 webp:
-	docker compose run --build --rm -T webp
+       $(DOCKER_RUN) webp
 
 .PHONY: shell
 shell:
-	docker compose run --build --rm shell
+       $(DOCKER_RUN) shell
 
 .PHONY: rmi
 


### PR DESCRIPTION
## Summary
- add `DOCKER_RUN` variable for invoking container services
- use DOCKER_RUN in the seed, sync, webp and shell targets
- document DOCKER_RUN in docs/redo-mk.md

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685edd64d3e88321936dd4793260b75d