### PR TITLE
docs: flesh out DigitalOcean instructions

### DIFF
--- a/docs/digitalocean.md
+++ b/docs/digitalocean.md
@@ -1,2 +1,12 @@
-https://docs.digitalocean.com/reference/doctl/how-to/install/
-https://docs.digitalocean.com/products/container-registry/how-to/use-registry-docker-kubernetes/
+# DigitalOcean Setup
+
+The project pushes its Nginx image to DigitalOcean's container registry. Follow the [doctl install guide](https://docs.digitalocean.com/reference/doctl/how-to/install/) to set up the CLI and the [registry documentation](https://docs.digitalocean.com/products/container-registry/how-to/use-registry-docker-kubernetes/) for instructions on uploading images and using them with Kubernetes.
+
+In `redo.mk`, `CONTAINER_REGISTRY` is set to `registry.digitalocean.com/artisticanatomy`. Authenticate before pushing with:
+
+```bash
+doctl auth init
+doctl registry login
+```
+
+After logging in, run `r docker` to build and push the latest image.


### PR DESCRIPTION
## Summary
- explain how to install `doctl` and push images to DigitalOcean Container Registry
- document authentication steps and repo-specific registry info

## Testing
- `make -f redo.mk test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68813311c3708321aa919d7ed3f333bb