### PR TITLE
Add console scripts for pie utils

### DIFF
--- a/app/shell/bin/preprocess
+++ b/app/shell/bin/preprocess
@@ -22,7 +22,7 @@ process_file() {
     done
 
     # Render links
-    python3 -m pie.render_template build/static/index.json "$output" > "$output.$$"
+    render-template build/static/index.json "$output" > "$output.$$"
     mv "$output.$$" "$output"
     if [ $DEBUG -eq 1 ]; then cat "$output"; fi
 

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -20,6 +20,8 @@ setup(
             'build-index=pie.build_index:main',
             'link=pie.link:main',
             'picasso=pie.picasso:main',
+            'render-template=pie.render_template:main',
+            'render-study-json=pie.render_study_json:main',
         ],
     },
 )

--- a/docs/jinja-filters.md
+++ b/docs/jinja-filters.md
@@ -25,7 +25,7 @@ toc:
   - "{{deltoid_tuberosity|linktitle}}"
 ```
 
-The filter implementation lives in `app/shell/bin/render_template` and uses a regular expression to extract the link text and URL:
+The filter implementation lives in `pie.render_template` and is available via the `render-template` command. It uses a regular expression to extract the link text and URL:
 
 ```python
 match = _LINK_PATTERN.match(value)

--- a/docs/quiz-workflow.md
+++ b/docs/quiz-workflow.md
@@ -32,17 +32,17 @@ Example from `src/study/key_terms.json`:
 
 ## 2. Rendering JSON
 
-During the build, these source files are processed with `pie.render_study_json`. The rule in `dep.mk` declares:
+During the build, these source files are processed with the `render-study-json` CLI. The rule in `dep.mk` declares:
 
 ```make
 BUILD_SUBDIRS += build/study
 STUDY_JSONS := $(patsubst src/%,build/%,$(wildcard src/study/*.json))
 prebuild: $(STUDY_JSONS)
 build/study/%.json: study/%.json | build/static/index.json
-        python3 -m pie.render_study_json build/static/index.json $< > $@
+        render-study-json build/static/index.json $< > $@
 ```
 
-`render_study_json.py` now provides a small CLI. It expands the quiz file using
+The `render-study-json` command expands the quiz file using
 variables from the index and optionally writes the output to a file:
 
 ```python
@@ -143,7 +143,7 @@ Both the site CSS (`src/style.css`) and the React bundle’s stylesheet (`search
 ## Summary
 
 1. Quizzes are defined as JSON under `src/study/`.
-2. `render_study_json` expands Jinja expressions and outputs `build/study/*.json`.
+2. `render-study-json` expands Jinja expressions and outputs `build/study/*.json`.
 3. Static pages use the `render_mc` Jinja macro to embed quizzes directly in Markdown.
 4. The React `Quiz` component fetches the built JSON for an interactive version and is included via `bundle.js`.
 


### PR DESCRIPTION
## Summary
- expose render-template and render-study-json console scripts in pie setup
- call render-template from preprocess helper
- document new commands for quiz workflow and jinja filters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xmera')*

------
https://chatgpt.com/codex/tasks/task_e_68813483a854832180cf55d4c1ef0929