### PR TITLE
docs: reference additional documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,10 @@ If you don’t provide these, Pandoc (or your build tooling) will generate them 
   Store metadata in `index.yml` and content in `index.md`.  
 - **Inline metadata**  
   Embed the YAML block directly at the top of `quickstart.md`.
+
+## Further Reading
+
+- [Jinja Filters](docs/jinja-filters.md)
+- [Jinja Globals](docs/jinja-globals.md)
+- [Build Index](docs/build-index.md)
+- [Quiz Workflow](docs/quiz-workflow.md)


### PR DESCRIPTION
## Summary
- add a "Further Reading" section to the README linking to additional docs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68813522da788321a8eb730df8aa39e6