### PR TITLE
Fix pattern rule dependencies

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -89,9 +89,7 @@ build/%.css: %.css | build
 	cp $< $@
 
 # Include and preprocess Markdown files up to three levels deep
-build/%.md: | build
-build/%.md: build/static/index.json
-build/%.md: %.md
+build/%.md: %.md build/static/index.json | build
 	preprocess $<
 
 # Generate HTML from processed Markdown using Pandoc


### PR DESCRIPTION
## Summary
- ensure the markdown preprocessing rule lists all dependencies in one place

## Testing
- `make -n -f app/shell/mk/build.mk`
- `make -n -f app/shell/mk/build.mk test`

------
https://chatgpt.com/codex/tasks/task_e_688137723b008321841fca881ce3ab40