### PR TITLE
Add docs for include-filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,4 @@ If you don’t provide these, Pandoc (or your build tooling) will generate them 
 - [Jinja Globals](docs/jinja-globals.md)
 - [Build Index](docs/build-index.md)
 - [Quiz Workflow](docs/quiz-workflow.md)
+- [include-filter](docs/include-filter.md)

--- a/app/shell/py/pie/pie/include_filter.py
+++ b/app/shell/py/pie/pie/include_filter.py
@@ -1,4 +1,15 @@
 #!/usr/bin/env python3
+"""Expand Python directives inside Markdown files.
+
+The ``include-filter`` command reads a source Markdown document, executes any
+fenced ``python`` code blocks, and writes the transformed output to another
+file.  Available helper functions include ``include()`` for inserting other
+Markdown files and ``mermaid()`` for converting Mermaid diagrams to images.
+
+Links that end with ``.md`` are rewritten to ``.html`` so the output can be fed
+directly to Pandoc.  The command is primarily driven via ``preprocess`` and the
+``build.mk`` makefile.
+"""
 
 import os
 import re

--- a/docs/include-filter.md
+++ b/docs/include-filter.md
@@ -1,0 +1,28 @@
+# include-filter Utility
+
+`include-filter` is a small helper that processes Markdown files and expands
+inline Python directives. It is used by the build system to resolve custom
+`include()` calls and to render Mermaid diagrams during preprocessing.
+
+The command is installed from the `pie` Python package and exposes a simple
+CLI:
+
+```bash
+include-filter <output-dir> <input> <output>
+```
+
+- `<output-dir>` – directory for any generated assets such as diagram images
+- `<input>` – source Markdown file containing Python fences
+- `<output>` – destination file that receives the transformed Markdown
+
+Within fenced `python` blocks the following functions are available:
+
+- `include(path)` – insert another Markdown file and adjust heading levels
+- `mermaid(file, alt, id)` – convert a Mermaid code block into an image using
+  `mmdc` and emit a Markdown image link
+
+Any links ending with `.md` are automatically rewritten to point at the
+corresponding `.html` file.
+
+Typical usage in `app/shell/mk/build.mk` chains the command multiple times to
+resolve nested includes before passing the final Markdown to Pandoc.


### PR DESCRIPTION
## Summary
- document include-filter script
- add usage notes to include_filter.py
- reference include-filter doc from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xmera')*

------
https://chatgpt.com/codex/tasks/task_e_68813eca4cbc8321bcbc7ffcb0724c7e