### PR TITLE
Add pie module tests with dependency stubs

### DIFF
--- a/app/shell/py/pie/tests/__init__.py
+++ b/app/shell/py/pie/tests/__init__.py
@@ -1,0 +1,62 @@
+import sys
+import json
+import types
+from pathlib import Path
+from unittest.mock import Mock
+import re
+
+# Provide minimal fallbacks for optional dependencies so test collection works
+if 'xmera' not in sys.modules:
+    xmera = types.ModuleType('xmera')
+    xmera.logger = Mock()
+    utils = types.ModuleType('xmera.utils')
+    utils.read_json = lambda p: json.loads(Path(p).read_text(encoding='utf-8'))
+    utils.read_utf8 = lambda p: Path(p).read_text(encoding='utf-8')
+    xmera.utils = utils
+    sys.modules['xmera'] = xmera
+    sys.modules['xmera.utils'] = utils
+    sys.modules['xmera.logger'] = xmera.logger
+
+if 'yaml' not in sys.modules:
+    yaml = types.ModuleType('yaml')
+    yaml.safe_load = lambda c: json.loads(c if isinstance(c, str) else c.read())
+    yaml.YAMLError = Exception
+    sys.modules['yaml'] = yaml
+
+# Simple templating fallback used when jinja2 is unavailable
+class _Template:
+    _pattern = re.compile(r"{{([^{}]+)}}")
+
+    def __init__(self, text: str):
+        self.text = text
+
+    def render(self, **ctx):
+        def repl(m):
+            expr = m.group(1)
+            return str(eval(expr, {}, ctx))
+        return self._pattern.sub(repl, self.text)
+
+class _Env:
+    def __init__(self):
+        self.filters = {}
+        self.globals = {}
+
+    def from_string(self, text: str):
+        return _Template(text)
+
+    def get_template(self, name: str):
+        return _Template(Path(name).read_text(encoding='utf-8'))
+
+if 'jinja2' not in sys.modules:
+    class _FSLoader:
+        def __init__(self, _path: str):
+            self.path = _path
+
+    class _StrictUndefined:
+        pass
+
+    jinja2 = types.ModuleType('jinja2')
+    jinja2.Environment = lambda *a, **k: _Env()
+    jinja2.FileSystemLoader = _FSLoader
+    jinja2.StrictUndefined = _StrictUndefined
+    sys.modules['jinja2'] = jinja2

--- a/app/shell/py/pie/tests/test_build_index.py
+++ b/app/shell/py/pie/tests/test_build_index.py
@@ -1,0 +1,61 @@
+import os
+import json
+from pathlib import Path
+import pytest
+
+from pie import build_index
+
+
+def test_get_url_from_src_md(tmp_path):
+    path = tmp_path / "src" / "foo.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("")
+    os.chdir(tmp_path)
+    try:
+        assert build_index.get_url("src/foo.md") == "/foo.html"
+    finally:
+        os.chdir("/workspace/press")
+
+
+def test_get_url_invalid_raises(tmp_path):
+    bad = tmp_path / "foo.md"
+    bad.write_text("")
+    os.chdir(tmp_path)
+    try:
+        with pytest.raises(Exception):
+            build_index.get_url("foo.md")
+    finally:
+        os.chdir("/workspace/press")
+
+
+def test_process_markdown_parses_frontmatter(tmp_path):
+    md = tmp_path / "src" / "doc.md"
+    md.parent.mkdir(parents=True)
+    md.write_text("---\n{\"title\": \"T\"}\n---\nbody")
+    os.chdir(tmp_path)
+    try:
+        data = build_index.process_markdown("src/doc.md")
+    finally:
+        os.chdir("/workspace/press")
+    assert data == {"title": "T", "url": "/doc.html"}
+
+
+def test_process_yaml_generates_fields(tmp_path):
+    yml = tmp_path / "src" / "item.yml"
+    yml.parent.mkdir(parents=True)
+    yml.write_text('{"name": "Foo"}')
+    os.chdir(tmp_path)
+    try:
+        data = build_index.process_yaml("src/item.yml")
+    finally:
+        os.chdir("/workspace/press")
+    assert data["name"] == "Foo"
+    assert data["url"] == "/item.html"
+    assert data["citation"] == "foo"
+    assert data["id"] == "item"
+
+
+def test_validate_and_insert_duplicate(tmp_path):
+    index = {"a": {"id": "a"}}
+    with pytest.raises(KeyError):
+        build_index.validate_and_insert_metadata({"id": "a"}, "file", index)


### PR DESCRIPTION
## Summary
- provide lightweight stubs for optional `xmera`, `yaml` and `jinja2` modules so the pie package can be tested without external dependencies
- add new tests covering `build_index` helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68813ee4c3c08321af8cb3e09bdd14af