### PR TITLE
Add nginx Dockerfile docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,4 @@ If you don’t provide these, Pandoc (or your build tooling) will generate them 
 - [Build Index](docs/build-index.md)
 - [Quiz Workflow](docs/quiz-workflow.md)
 - [include-filter](docs/include-filter.md)
+- [Nginx Dockerfile](docs/nginx.md)

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -1,0 +1,26 @@
+# Nginx Dockerfile
+
+The `app/nginx/Dockerfile` builds a minimal image for serving the static site.
+It starts from `nginx:alpine-slim` and copies the generated `build/` directory
+into Nginx's default web root. Both the `nginx` and `nginx-dev` services in
+`docker-compose.yml` use this image.
+
+```Dockerfile
+FROM nginx:alpine-slim
+COPY ./build /usr/share/nginx/html
+```
+
+### Build and run
+
+To test the container directly:
+
+```bash
+docker build -f app/nginx/Dockerfile -t press-nginx .
+docker run -p 80:80 press-nginx
+```
+
+During development `nginx-dev` mounts `./build` so pages update automatically.
+For production, build the image and run the `nginx` service.
+
+You can also run `r docker` to build and push the image to your configured
+registry. See [DigitalOcean Setup](digitalocean.md) for an example.


### PR DESCRIPTION
## Summary
- document the nginx Dockerfile
- link to the new docs from README

## Testing
- `make -f redo.mk test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68814bd9a8908321a16207b4302e81c8