### PR TITLE
Rename search-root to quiz-root

### DIFF
--- a/app/quiz/src/main.jsx
+++ b/app/quiz/src/main.jsx
@@ -3,7 +3,7 @@
  * Entry point for the SearchIndex React application.
  *
  * This module waits for the DOM to be fully loaded, locates the
- * `#search-root` element, and renders the [`SearchIndex`](./SearchIndex) component
+ * `#quiz-root` element, and renders the [`SearchIndex`](./SearchIndex) component
  * into it, passing along any `data-name` attribute as a prop.
  */
 
@@ -16,14 +16,14 @@ import Quiz from './Quiz'
  * Bootstraps and renders the SearchIndex component into the DOM.
  *
  * Waits for the `DOMContentLoaded` event, then:
- * 1. Queries the `#search-root` element.
+ * 1. Queries the `#quiz-root` element.
  * 2. If found, creates a React root and renders the application.
  * 3. Passes the element's `data-name` attribute as the `name` prop.
  *
  * @returns {void}
  */
 function initializeSearchIndex() {
-  const mount = document.getElementById('search-root')
+  const mount = document.getElementById('quiz-root')
   if (!mount) {
     return
   }

--- a/docs/quiz-workflow.md
+++ b/docs/quiz-workflow.md
@@ -130,11 +130,11 @@ It renders each question, lets the user pick choices, and displays the score whe
 A page can embed the quiz with:
 
 ```html
-<div id="search-root" data-src="/study/deltoid.json"></div>
+<div id="quiz-root" data-src="/study/deltoid.json"></div>
 <script type="module" src="/static/js/bundle.js" defer></script>
 ```
 
-`main.jsx` mounts the `Quiz` component onto `#search-root` using the `data-src` attribute to locate the JSON file.
+`main.jsx` mounts the `Quiz` component onto `#quiz-root` using the `data-src` attribute to locate the JSON file.
 
 ## 5. Styling
 

--- a/src/quiz/index.md
+++ b/src/quiz/index.md
@@ -1,2 +1,2 @@
-<div id="search-root" data-src="/quiz/demo.json"></div>
+<div id="quiz-root" data-src="/quiz/demo.json"></div>
 <script type="module" src="/quiz/quiz.js" defer></script>


### PR DESCRIPTION
## Summary
- update docs and React entry point to use `quiz-root`

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6881608cd6e08321b3e6bb72038286e9