### PR TITLE
Add preprocess documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,5 +122,6 @@ If you don’t provide these, Pandoc (or your build tooling) will generate them 
 - [Build Index](docs/build-index.md)
 - [Quiz Workflow](docs/quiz-workflow.md)
 - [include-filter](docs/include-filter.md)
+- [preprocess](docs/preprocess.md)
 - [Nginx Dockerfile](docs/nginx.md)
 - [docker-make](docs/docker-make.md)

--- a/docs/preprocess.md
+++ b/docs/preprocess.md
@@ -1,0 +1,34 @@
+# preprocess Script
+
+`preprocess` prepares Markdown files for Pandoc. It expands includes, renders
+internal links, and emojifies the text. The output mirrors the directory
+structure under `build/` so that `src/foo/bar.md` becomes
+`build/foo/bar.md`.
+
+## Usage
+
+```bash
+preprocess <markdown-file> [more-files...]
+```
+
+Each input file is processed in place:
+
+1. **Expand includes** – `include-filter` runs three times to resolve nested
+   `include()` blocks and render Mermaid diagrams.
+2. **Render links** – `render-template build/static/index.json` converts
+   special link syntax using the build index.
+3. **Emoji conversion** – `emojify` replaces `:emoji:` codes with Unicode
+   characters.
+
+### Makefile Integration
+
+`app/shell/mk/build.mk` invokes `preprocess` when building `.md` targets:
+
+```make
+build/%.md: %.md build/static/index.json | build
+    preprocess $<
+```
+
+Running `preprocess src/guide/intro.md` will create
+`build/guide/intro.md` ready for Pandoc.
+


### PR DESCRIPTION
## Summary
- document the `preprocess` script used in the build
- reference the new documentation from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881643b28c4832185d11685780ac829