### PR TITLE
Add tests for include_filter

### DIFF
--- a/app/shell/py/pie/tests/test_include_filter.py
+++ b/app/shell/py/pie/tests/test_include_filter.py
@@ -1,0 +1,65 @@
+import os
+import io
+from unittest import mock
+
+import pytest
+
+from pie import include_filter
+
+
+def test_parse_metadata_returns_dict():
+    include_filter.outfile = io.StringIO()
+    f = io.StringIO("---\n{\"title\": \"Foo\"}\n---\nBody")
+    data = include_filter.parse_metadata_or_print_first_line(f)
+    assert data == {"title": "Foo"}
+    assert include_filter.outfile.getvalue() == ""
+
+
+def test_parse_metadata_prints_line():
+    out = io.StringIO()
+    include_filter.outfile = out
+    f = io.StringIO("First line\nSecond")
+    data = include_filter.parse_metadata_or_print_first_line(f)
+    assert data is None
+    assert out.getvalue() == "First line\n"
+
+
+def test_md_to_html_links():
+    line = "See [Doc](docs/file.md) and [X](x.md)"
+    converted = include_filter.md_to_html_links(line)
+    assert converted == "See [Doc](docs/file.html) and [X](x.html)"
+
+
+def test_new_filestem_skips_existing(tmp_path):
+    (tmp_path / "diagram0.svg").write_text("")
+    (tmp_path / "diagram1.mmd").write_text("")
+    stem = include_filter.new_filestem(str(tmp_path / "diagram"))
+    assert stem == str(tmp_path / "diagram2")
+
+
+def test_include_writes_output(tmp_path):
+    md = tmp_path / "doc.md"
+    md.write_text("---\n{\"title\": \"Title\"}\n---\n# H1\nText\n")
+    include_filter.outfile = io.StringIO()
+    include_filter.heading_level = 0
+    include_filter.include(str(md))
+    expected = "# Title\n# H1\nText\n"
+    assert include_filter.outfile.getvalue() == expected
+
+
+def test_mermaid_creates_files(tmp_path):
+    include_filter.figcount = 0
+    include_filter.outdir = str(tmp_path)
+    include_filter.outfile = io.StringIO()
+
+    mmd = tmp_path / "src.mmd"
+    mmd.write_text("```mermaid\nA-->B\n```\n")
+
+    with mock.patch("pie.include_filter.new_filestem", return_value=str(tmp_path / "diagram0")) as nf, \
+         mock.patch("os.system") as os_sys:
+        include_filter.mermaid(str(mmd), "alt", "#id")
+
+    os_sys.assert_called_once_with(f"npx mmdc -i {tmp_path/'diagram0.mmd'} -o {tmp_path/'diagram0.png'}")
+    assert (tmp_path / "diagram0.mmd").read_text() == "A-->B\n"
+    assert include_filter.outfile.getvalue().strip() == f"![alt](./diagram0.png){{ #id }}"
+    assert include_filter.figcount == 1


### PR DESCRIPTION
## Summary
- add unit tests for `include_filter` covering metadata parsing, link rewriting and mermaid helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881665c74ec8321a8d27d838cc19a85