### PR TITLE
Add picasso documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,5 +123,6 @@ If you don’t provide these, Pandoc (or your build tooling) will generate them 
 - [Quiz Workflow](docs/quiz-workflow.md)
 - [include-filter](docs/include-filter.md)
 - [preprocess](docs/preprocess.md)
+- [picasso](docs/picasso.md)
 - [Nginx Dockerfile](docs/nginx.md)
 - [docker-make](docs/docker-make.md)

--- a/docs/picasso.md
+++ b/docs/picasso.md
@@ -1,0 +1,31 @@
+# picasso Makefile Generator
+
+`picasso` scans the `src/` directory for YAML metadata files and emits Makefile
+rules that convert them to HTML using Pandoc. The generated rules are written to
+`build/picasso.mk` and included by `app/shell/mk/build.mk` during the build.
+
+## Usage
+
+Run the command and redirect its output to `build/picasso.mk`:
+
+```bash
+picasso > build/picasso.mk
+```
+
+This happens automatically in `build.mk` whenever any `.yml` file under `src/`
+changes.
+
+## Example Output
+
+For a source file `src/index.yml` the output looks like:
+
+```make
+build/index.yml: src/index.yml
+    emojify < $< > $@
+build/index.html: build/index.md build/index.yml
+    $(PANDOC_CMD) $(PANDOC_OPTS) --metadata-file=build/index.yml -o $@ $<
+    python3 -m pie.error_on_python_dict $@
+```
+
+Each `.yml` file produces similar targets for preprocessing the metadata and
+rendering the final HTML.


### PR DESCRIPTION
## Summary
- document the `picasso` command used to generate Makefile rules
- reference the new doc from the README

## Testing
- `pytest -q app/shell/py/pie/tests`

------
https://chatgpt.com/codex/tasks/task_e_68816a25cd8c8321b8743863978a2f17