### PR TITLE
Refactor picasso path handling

### DIFF
--- a/app/shell/py/pie/pie/picasso.py
+++ b/app/shell/py/pie/pie/picasso.py
@@ -1,18 +1,27 @@
 """
-This script traverses the `src` directory for `.yml` files and generates
-Makefile rules to process them with `pandoc`. Each `.yml` file produces
-corresponding `.md` and `.html` targets in the `build` directory.
+Generate Makefile rules for processing ``.yml`` files with ``pandoc``.
+
+By default the script scans the ``src`` directory and writes rules that
+produce preprocessed ``.md`` and rendered ``.html`` files under ``build``.
+Both the source root and build root can be overridden via function
+parameters or command–line arguments.
 """
 
 import sys
 from pathlib import Path
 
 
-def generate_rule(input_path: Path) -> str:
+def generate_rule(
+    input_path: Path,
+    src_root: Path = Path("src"),
+    build_root: Path = Path("build"),
+) -> str:
     """Generate a Makefile rule for a given YAML metadata file.
 
     Args:
         input_path (Path): Path to the source `.yml` file.
+        src_root (Path): Directory that contains the source files.
+        build_root (Path): Directory where build artifacts are written.
 
     Returns:
         str: A multi-line string defining the Makefile rule.
@@ -21,14 +30,15 @@ def generate_rule(input_path: Path) -> str:
         >>> from pathlib import Path
         >>> print(generate_rule(Path("src/foo/bar.yml")))
         build/foo/bar.html: build/foo/bar.md src/foo/bar.yml
-            $(PANDOC_CMD) $(PANDOC_OPTS) --metadata-file=src/foo/bar.yml -o $@ $<
+            $(PANDOC_CMD) $(PANDOC_OPTS) --metadata-file=build/foo/bar.yml -o $@ $<
     """
-    # Build output paths under `build/`, preserving subdirectory structure
-    output_html = input_path.with_suffix(".html").as_posix().replace("src/", "build/")
-    preprocessed_md = input_path.with_suffix(".md").as_posix().replace("src/", "build/")
-    preprocessed_yml = (
-        input_path.with_suffix(".yml").as_posix().replace("src/", "build/")
-    )
+    # Compute the path of ``input_path`` relative to the source root
+    relative = input_path.relative_to(src_root)
+
+    # Build output paths under ``build_root`` while preserving directory layout
+    output_html = (build_root / relative.with_suffix(".html")).as_posix()
+    preprocessed_md = (build_root / relative.with_suffix(".md")).as_posix()
+    preprocessed_yml = (build_root / relative.with_suffix(".yml")).as_posix()
 
     return f"""
 {preprocessed_yml}: {input_path}
@@ -39,16 +49,19 @@ def generate_rule(input_path: Path) -> str:
 """
 
 
-def main() -> None:
-    """Entry point: find all `.yml` files under `src/` and print Makefile rules."""
-    src_root = Path("src")
+def main(src_root: Path = Path("src"), build_root: Path = Path("build")) -> None:
+    """Entry point: print Makefile rules for ``.yml`` files under ``src_root``."""
+
     if not src_root.is_dir():
         sys.stderr.write(f"Directory {src_root!s} does not exist\n")
         sys.exit(1)
 
     for yml_file in src_root.rglob("*.yml"):
-        print(generate_rule(yml_file))
+        print(generate_rule(yml_file, src_root=src_root, build_root=build_root))
 
 
 if __name__ == "__main__":
-    main()
+    argv = sys.argv[1:]
+    src = Path(argv[0]) if len(argv) >= 1 else Path("src")
+    build = Path(argv[1]) if len(argv) >= 2 else Path("build")
+    main(src_root=src, build_root=build)


### PR DESCRIPTION
## Summary
- allow specifying source and build directories when generating rules
- compute outputs using `Path.relative_to` and `Path.with_suffix`
- support optional CLI arguments for custom roots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68816ae1493c83218e28be657c4f5ae9