### PR TITLE
Add argparse options to picasso CLI

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -124,6 +124,6 @@ clean:
 YAMLS := $(shell find src -name "*.yml")
 
 build/picasso.mk: $(YAMLS) | build
-	picasso > $@
+        picasso --src src --build build > $@
 
 include build/picasso.mk

--- a/app/shell/py/pie/pie/picasso.py
+++ b/app/shell/py/pie/pie/picasso.py
@@ -7,6 +7,7 @@ Both the source root and build root can be overridden via function
 parameters or command–line arguments.
 """
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -49,8 +50,31 @@ def generate_rule(
 """
 
 
-def main(src_root: Path = Path("src"), build_root: Path = Path("build")) -> None:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Generate Makefile rules for processing YAML files with pandoc",
+    )
+    parser.add_argument(
+        "--src",
+        default="src",
+        help="Directory containing source `.yml` files",
+    )
+    parser.add_argument(
+        "--build",
+        default="build",
+        help="Directory where build artifacts are written",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
     """Entry point: print Makefile rules for ``.yml`` files under ``src_root``."""
+
+    args = parse_args(argv)
+    src_root = Path(args.src)
+    build_root = Path(args.build)
 
     if not src_root.is_dir():
         sys.stderr.write(f"Directory {src_root!s} does not exist\n")
@@ -61,7 +85,4 @@ def main(src_root: Path = Path("src"), build_root: Path = Path("build")) -> None
 
 
 if __name__ == "__main__":
-    argv = sys.argv[1:]
-    src = Path(argv[0]) if len(argv) >= 1 else Path("src")
-    build = Path(argv[1]) if len(argv) >= 2 else Path("build")
-    main(src_root=src, build_root=build)
+    main()

--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -21,7 +21,7 @@ def test_main_prints_rules(tmp_path, capsys):
     src.mkdir()
     (src / "doc.yml").write_text("{}")
 
-    picasso.main(src_root=src, build_root=build)
+    picasso.main(["--src", str(src), "--build", str(build)])
     out = capsys.readouterr().out.strip()
     expected = picasso.generate_rule(src / "doc.yml", src_root=src, build_root=build).strip()
     assert out == expected

--- a/docs/picasso.md
+++ b/docs/picasso.md
@@ -15,6 +15,12 @@ picasso > build/picasso.mk
 This happens automatically in `build.mk` whenever any `.yml` file under `src/`
 changes.
 
+You can override the source or build directories using `--src` and `--build`:
+
+```bash
+picasso --src path/to/src --build path/to/build > build/picasso.mk
+```
+
 ## Example Output
 
 For a source file `src/index.yml` the output looks like:


### PR DESCRIPTION
## Summary
- add argparse parser to picasso CLI with `--src` and `--build`
- update tests for new interface
- call picasso with explicit defaults in build.mk
- document optional arguments in picasso docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688253c21c148321b52ad15f34a670c3