### PR TITLE
Add gen-markdown-index utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ build. Use `--src DIR` to search a different directory for `.yml` files and
 - [Jinja Filters](docs/jinja-filters.md)
 - [Jinja Globals](docs/jinja-globals.md)
 - [Build Index](docs/build-index.md)
+- [gen-markdown-index](docs/gen-markdown-index.md)
 - [Quiz Workflow](docs/quiz-workflow.md)
 - [include-filter](docs/include-filter.md)
 - [preprocess](docs/preprocess.md)

--- a/app/shell/py/pie/pie/build_index.py
+++ b/app/shell/py/pie/pie/build_index.py
@@ -35,7 +35,7 @@ def get_url(filename: str) -> Optional[str]:
     if filename.startswith(prefix):
         relative_path = filename[len(prefix) :]
         base, ext = os.path.splitext(relative_path)
-        if ext.lower() in (".md", ".yml"):
+        if ext.lower() in (".md", ".yml", ".yaml"):
             html_path = base + ".html"
             return "/" + html_path
     logger.warning("Can't create a url.", filename=filename)

--- a/app/shell/py/pie/pie/gen_markdown_index.py
+++ b/app/shell/py/pie/pie/gen_markdown_index.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Generate a Markdown list from an index JSON file."""
+
+import argparse
+import json
+from typing import Dict, Any
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a Markdown index from build index JSON",
+    )
+    parser.add_argument(
+        "index_json",
+        help="Path to index.json produced by build-index",
+    )
+    return parser.parse_args(argv)
+
+
+def load_index(path: str) -> Dict[str, Any]:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def emit_markdown(index: Dict[str, Any]) -> None:
+    for key in sorted(index.keys()):
+        meta = index[key]
+        title = meta.get("title") or meta.get("name", key)
+        url = meta.get("url", "#")
+        print(f"- [{title}]({url})")
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    data = load_index(args.index_json)
+    emit_markdown(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -18,6 +18,7 @@ setup(
     entry_points={
         'console_scripts': [
             'build-index=pie.build_index:main',
+            'gen-markdown-index=pie.gen_markdown_index:main',
             'picasso=pie.picasso:main',
             'render-template=pie.render_template:main',
             'render-study-json=pie.render_study_json:main',

--- a/app/shell/py/pie/tests/test_gen_markdown_index.py
+++ b/app/shell/py/pie/tests/test_gen_markdown_index.py
@@ -1,0 +1,17 @@
+import json
+from pie import gen_markdown_index
+
+
+def test_main_outputs_markdown(tmp_path, capsys):
+    index_file = tmp_path / "index.json"
+    index_file.write_text(json.dumps({
+        "guide": {"name": "Guide", "url": "/guide.html"},
+        "intro": {"title": "Introduction", "url": "/intro.html"},
+    }))
+
+    gen_markdown_index.main([str(index_file)])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out == [
+        "- [Guide](/guide.html)",
+        "- [Introduction](/intro.html)",
+    ]

--- a/docs/gen-markdown-index.md
+++ b/docs/gen-markdown-index.md
@@ -1,0 +1,20 @@
+# gen-markdown-index
+
+`gen-markdown-index` reads `index.json` produced by `build-index` and prints a simple Markdown list linking to each document. This can be redirected to create an overview page.
+
+## Usage
+
+```bash
+gen-markdown-index build/static/index.json > build/README.md
+```
+
+The command expects a single argument – the path to the JSON index. It outputs one bullet point per entry in alphabetical order by identifier, using either the `title` or `name` field as the link text.
+
+### Example Output
+
+```markdown
+- [Quickstart](/quickstart.html)
+- [Study Guide](/study.html)
+```
+
+This utility is primarily for generating a lightweight site map that can be included in other pages or served directly.


### PR DESCRIPTION
## Summary
- add `gen-markdown-index` CLI for creating a Markdown list from the JSON index
- document usage of the new tool
- expose CLI via setup.py and mention it in README
- cover new command with tests
- minor bug fix in `build_index.get_url`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688271771a188321813ac3a7c0caa6de