### PR TITLE
Switch metadata name field to title

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Pandoc lets you define document metadata in two ways:
 2. **Sidecar**: Place a separate `.yml` file alongside your Markdown.
 
 ### Required Field
-- `name`: The display name of the document.
+- `title`: The display name of the document.
 
 ### Auto-Generated Fields
 If you don’t provide these, Pandoc (or your build tooling) will generate them automatically:

--- a/app/shell/py/pie/pie/build_index.py
+++ b/app/shell/py/pie/pie/build_index.py
@@ -110,8 +110,8 @@ def process_yaml(filepath: str) -> Optional[Dict[str, Any]]:
                 metadata["url"] = get_url(filepath)
             if "citation" not in metadata:
                 # Intentionally use indexing so we get an exception here.
-                # The name field must exist.
-                metadata["citation"] = metadata["name"].lower()
+                # The title field must exist.
+                metadata["citation"] = metadata["title"].lower()
             if "id" not in metadata:
                 base, _ = os.path.splitext(filepath)
                 metadata["id"] = base.split(os.sep)[-1]

--- a/app/shell/py/pie/pie/gen_markdown_index.py
+++ b/app/shell/py/pie/pie/gen_markdown_index.py
@@ -9,16 +9,16 @@ from xmera.utils import read_json
 
 
 def generate_lines(index: Mapping[str, Mapping[str, str]]) -> List[str]:
-    """Return Markdown list items sorted by the ``name`` field."""
+    """Return Markdown list items sorted by the ``title`` field."""
     lines: List[str] = []
-    for _, item in sorted(index.items(), key=lambda p: p[1]["name"]):
-        name = item["name"]
+    for _, item in sorted(index.items(), key=lambda p: p[1]["title"]):
+        title = item["title"]
         url = item["url"]
         icon = item.get("icon")
         if icon:
-            lines.append(f"- [{icon} {name}]({url})")
+            lines.append(f"- [{icon} {title}]({url})")
         else:
-            lines.append(f"- [{name}]({url})")
+            lines.append(f"- [{title}]({url})")
     return lines
 
 

--- a/app/shell/py/pie/tests/test_build_index.py
+++ b/app/shell/py/pie/tests/test_build_index.py
@@ -43,13 +43,13 @@ def test_process_markdown_parses_frontmatter(tmp_path):
 def test_process_yaml_generates_fields(tmp_path):
     yml = tmp_path / "src" / "item.yml"
     yml.parent.mkdir(parents=True)
-    yml.write_text('{"name": "Foo"}')
+    yml.write_text('{"title": "Foo"}')
     os.chdir(tmp_path)
     try:
         data = build_index.process_yaml("src/item.yml")
     finally:
         os.chdir("/tmp")
-    assert data["name"] == "Foo"
+    assert data["title"] == "Foo"
     assert data["url"] == "/item.html"
     assert data["citation"] == "foo"
     assert data["id"] == "item"

--- a/app/shell/py/pie/tests/test_gen_markdown_index.py
+++ b/app/shell/py/pie/tests/test_gen_markdown_index.py
@@ -4,8 +4,8 @@ from pie import gen_markdown_index
 
 def test_generate_lines_sorted_and_icon():
     index = {
-        "b": {"name": "Beta", "url": "/b"},
-        "a": {"name": "Alpha", "url": "/a", "icon": "*"},
+        "b": {"title": "Beta", "url": "/b"},
+        "a": {"title": "Alpha", "url": "/a", "icon": "*"},
     }
     lines = gen_markdown_index.generate_lines(index)
     assert lines == ["- [* Alpha](/a)", "- [Beta](/b)"]
@@ -13,7 +13,7 @@ def test_generate_lines_sorted_and_icon():
 
 def test_main_outputs_lines(tmp_path, capsys):
     data = {
-        "item": {"name": "Foo", "url": "/foo"}
+        "item": {"title": "Foo", "url": "/foo"}
     }
     path = tmp_path / "index.json"
     path.write_text(json.dumps(data))

--- a/app/shell/py/pie/tests/test_render_study_json.py
+++ b/app/shell/py/pie/tests/test_render_study_json.py
@@ -5,9 +5,9 @@ from pie import render_study_json
 
 
 def test_render_study_basic():
-    index = {"item": {"name": "Foo"}}
+    index = {"item": {"title": "Foo"}}
     questions = [
-        {"q": "Name {{item['name']}}", "c": ["A", "B"], "a": [0, "Because {{item['name']}}"]}
+        {"q": "Name {{item['title']}}", "c": ["A", "B"], "a": [0, "Because {{item['title']}}"]}
     ]
     rendered = render_study_json.render_study(index, questions)
     assert rendered == [{"q": "Name Foo", "c": ["A", "B"], "a": [0, "Because Foo"]}]
@@ -16,8 +16,8 @@ def test_render_study_basic():
 def test_main_outputs_stdout(tmp_path, capsys):
     index_file = tmp_path / "index.json"
     study_file = tmp_path / "study.json"
-    index = {"val": {"name": "Bar"}}
-    study = [{"q": "{{val['name']}}?", "c": ["X"], "a": [0, "{{val['name']}}"]}]
+    index = {"val": {"title": "Bar"}}
+    study = [{"q": "{{val['title']}}?", "c": ["X"], "a": [0, "{{val['title']}}"]}]
     index_file.write_text(json.dumps(index))
     study_file.write_text(json.dumps(study))
 
@@ -30,8 +30,8 @@ def test_main_writes_file(tmp_path):
     index_file = tmp_path / "index.json"
     study_file = tmp_path / "study.json"
     out_file = tmp_path / "out.json"
-    index_file.write_text(json.dumps({"x": {"name": "Baz"}}))
-    study_file.write_text(json.dumps([{"q": "{{x['name']}}", "c": ["Y"], "a": [0, ""]}]))
+    index_file.write_text(json.dumps({"x": {"title": "Baz"}}))
+    study_file.write_text(json.dumps([{"q": "{{x['title']}}", "c": ["Y"], "a": [0, ""]}]))
 
     render_study_json.main([str(index_file), str(study_file), "-o", str(out_file)])
     data = json.loads(out_file.read_text())

--- a/docs/gen-markdown-index.md
+++ b/docs/gen-markdown-index.md
@@ -7,5 +7,5 @@ usage: gen-markdown-index <index.json>
 ```
 
 The command reads the JSON index file produced by `build-index` and prints
-a bullet list of links sorted by the `name` field. If an entry contains
+a bullet list of links sorted by the `title` field. If an entry contains
 an `icon` value it is prefixed to the link text.

--- a/docs/quiz-workflow.md
+++ b/docs/quiz-workflow.md
@@ -15,7 +15,7 @@ Example from `src/quiz/demo.json`:
 ```json
 [
   {
-    "q": "Which of the following best describes the {{sagittal['name']|lower}} plane?",
+    "q": "Which of the following best describes the {{sagittal['title']|lower}} plane?",
     "c": [
       "Divides the body into anterior and posterior portions",
       "Divides the body into superior and inferior portions",

--- a/src/index.yml
+++ b/src/index.yml
@@ -1,2 +1,2 @@
-name: Home
+title: Home
 author: Brian Lee

--- a/src/quickstart.md
+++ b/src/quickstart.md
@@ -1,5 +1,5 @@
 ---
-name: Quickstart
+title: Quickstart
 author: Brian Lee
 id: quickstart
 citation: quickstart


### PR DESCRIPTION
## Summary
- document that `title` is the required metadata field
- ensure `process_yaml` uses `title` when deriving citation
- sort markdown index by `title`
- rename sample metadata fields in docs and sources
- update tests for new metadata field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a79ed75c83219bdb6c3456894085