### PR TITLE
Add HTML page title checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,4 @@ build. Use `--src DIR` to search a different directory for `.yml` files and
 - [gen-markdown-index](docs/gen-markdown-index.md)
 - [Nginx Dockerfile](docs/nginx.md)
 - [docker-make](docs/docker-make.md)
+- [check-page-title](docs/check-page-title.md)

--- a/app/shell/Dockerfile
+++ b/app/shell/Dockerfile
@@ -49,6 +49,7 @@ ENV LANG=en_US.UTF-8 \
 COPY ./py /press/py
 # Install all Press plugins in one step
 RUN pip install --break-system-packages \
+        beautifulsoup4 \
         -e /press/py/pie \
         -r /press/py/pie/requirements.txt \
         -r /press/py/xmera/backend/requirements.txt \

--- a/app/shell/bin/check-page-title
+++ b/app/shell/bin/check-page-title
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Check that HTML files contain non-empty <h1> tags."""
+import sys
+from pathlib import Path
+from bs4 import BeautifulSoup
+
+
+def check_file(path: Path) -> bool:
+    with open(path, "r", encoding="utf-8") as f:
+        soup = BeautifulSoup(f, "html.parser")
+    h1 = soup.find("h1")
+    if h1 is None or not h1.get_text(strip=True):
+        print(f"Missing or empty <h1> in {path}")
+        return False
+    return True
+
+
+def main(argv: list[str]) -> int:
+    directory = Path(argv[0]) if argv else Path("build")
+    html_files = list(directory.rglob("*.html"))
+    ok = True
+    for html_file in html_files:
+        if not check_file(html_file):
+            ok = False
+    if ok:
+        print("All pages have <h1> titles.")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -81,6 +81,7 @@ build/.minify: $(HTMLS) $(CSS)
 # Triggered by the test target in redo.mk; see docs/redo-mk.md.
 test: $(HTMLS) $(CSS) build/.minify | log
 	$(CHECKLINKS_CMD) http://nginx-dev 2>&1 | tee log/checklinks.txt
+	check-page-title build 2>&1 | tee log/check-page-title.txt
 
 # Create necessary build directories
 build: | $(BUILD_SUBDIRS)

--- a/docs/check-page-title.md
+++ b/docs/check-page-title.md
@@ -1,0 +1,11 @@
+# check-page-title
+
+`check-page-title` verifies that each HTML file under `build/` contains a non-empty first level heading. It exits with a non-zero status if any file is missing a `<h1>` tag or the tag contains no text.
+
+## Usage
+
+```bash
+check-page-title [directory]
+```
+
+If no directory is given, `build/` is assumed. The command prints messages for files that fail the check and returns `1` when a problem is found.


### PR DESCRIPTION
## Summary
- ensure all generated pages contain a non-empty `<h1>`
- install BeautifulSoup in the shell image
- log page title checks during `make test`
- document the `check-page-title` command

## Testing
- `make -f app/shell/mk/build.mk test` *(fails: build-index missing)*

------
https://chatgpt.com/codex/tasks/task_e_6883b6c758f883219a2c783683ef7d5c