### PR TITLE
Enable overriding link CSS class

### DIFF
--- a/app/shell/py/pie/pie/render_template.py
+++ b/app/shell/py/pie/pie/render_template.py
@@ -28,6 +28,14 @@ def get_tracking_options(desc):
     return ""
 
 
+def get_link_class(desc):
+    if "link" in desc:
+        link_options = desc["link"]
+        if isinstance(link_options, dict) and "class" in link_options:
+            return link_options["class"]
+    return "internal-link"
+
+
 def linktitle(desc):
     """
     Capitalize the first character of each word in the string,
@@ -50,8 +58,8 @@ def linktitle(desc):
     citation = _whitespace_word_pattern.sub(cap_match, citation)
 
     if icon:
-        return f"""<a href="{url}" class="internal-link" {a_attribs}>{icon} {citation}</a>"""
-    return f"""<a href="{url}" class="internal-link" {a_attribs}>{citation}</a>"""
+        return f"""<a href="{url}" class="{get_link_class(desc)}" {a_attribs}>{icon} {citation}</a>"""
+    return f"""<a href="{url}" class="{get_link_class(desc)}" {a_attribs}>{citation}</a>"""
 
 
 def link_icon_title(desc):
@@ -70,7 +78,7 @@ def link_icon_title(desc):
 
     citation = _whitespace_word_pattern.sub(cap_match, citation)
     return (
-        f"""<a href="{url}" class="internal-link" {a_attribs}>{icon} {citation}</a>"""
+        f"""<a href="{url}" class="{get_link_class(desc)}" {a_attribs}>{icon} {citation}</a>"""
     )
 
 
@@ -88,8 +96,8 @@ def linkcap(desc):
     icon = desc.get("icon")
     a_attribs = get_tracking_options(desc)
     if icon:
-        return f"""<a href="{url}" class="internal-link" {a_attribs}>{icon} {citation}</a>"""
-    return f"""<a href="{url}" class="internal-link" {a_attribs}>{citation}</a>"""
+        return f"""<a href="{url}" class="{get_link_class(desc)}" {a_attribs}>{icon} {citation}</a>"""
+    return f"""<a href="{url}" class="{get_link_class(desc)}" {a_attribs}>{citation}</a>"""
 
 
 def linkicon(desc):
@@ -102,8 +110,8 @@ def linkicon(desc):
     icon = desc.get("icon")
     a_attribs = get_tracking_options(desc)
     if icon:
-        return f"""<a href="{url}" class="internal-link" {a_attribs}>{icon} {citation}</a>"""
-    return f"""<a href="{url}" class="internal-link" {a_attribs}>{citation}</a>"""
+        return f"""<a href="{url}" class="{get_link_class(desc)}" {a_attribs}>{icon} {citation}</a>"""
+    return f"""<a href="{url}" class="{get_link_class(desc)}" {a_attribs}>{citation}</a>"""
 
 
 def link(desc):

--- a/app/shell/py/pie/tests/test_render_template.py
+++ b/app/shell/py/pie/tests/test_render_template.py
@@ -1,0 +1,14 @@
+import pytest
+from pie import render_template
+
+
+def test_default_class():
+    desc = {"citation": "foo", "url": "/f"}
+    html = render_template.linktitle(desc)
+    assert 'class="internal-link"' in html
+
+
+def test_override_class():
+    desc = {"citation": "foo", "url": "/f", "link": {"class": "external"}}
+    html = render_template.linktitle(desc)
+    assert 'class="external"' in html

--- a/docs/link-metadata.md
+++ b/docs/link-metadata.md
@@ -13,6 +13,7 @@ name: press.io home
 url: https://press.io
 link:
   tracking: false
+  class: external-link
 ```
 
 This file generates an entry with the `id` `press_io_home` because the filename (without extension) is used when the `id` field is missing.
@@ -28,6 +29,15 @@ if "link" in desc:
     if "tracking" in desc:
         if desc["tracking"] == False:
             return 'rel="noopener noreferrer" target="_blank"'
+```
+
+## Link Class
+
+By default, rendered links use the CSS class `internal-link`. You can override this by specifying `link.class` in the metadata. For example:
+
+```yaml
+link:
+  class: external-link
 ```
 
 ## How IDs Are Generated


### PR DESCRIPTION
## Summary
- support `link.class` metadata override
- add helper `get_link_class`
- document new `link.class` field
- test default and override behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c94bbf088321bd5b126d28ea9b41