### PR TITLE
Update build.mk log flag usage

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -70,7 +70,7 @@ all: build/static/index.json
 .PRECIOUS: build/static/index.json
 # See docs/build-index.md for how the index is generated.
 build/static/index.json: $(MARKDOWNS) $(YAMLS) | build/static
-	build-index src -o $@ 2> log/build-index
+	build-index src -o $@ --log log/build-index
 
 # Target to minify HTML and CSS files
 build/.minify: $(HTMLS) $(CSS)

--- a/app/shell/py/pie/pie/build_index.py
+++ b/app/shell/py/pie/pie/build_index.py
@@ -9,6 +9,7 @@ import argparse
 import glob
 import json
 import os
+import sys
 from typing import Any, Dict, Optional
 
 import yaml
@@ -201,8 +202,8 @@ def build_index(source_dir: str, file_pattern: str = "**/*.md") -> Dict[str, Any
     return index
 
 
-def main() -> None:
-    """Parse command-line arguments, build the index, and write JSON output."""
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
     parser = argparse.ArgumentParser(
         description="Build a JSON index from Markdown/YAML files' metadata."
     )
@@ -215,7 +216,22 @@ def main() -> None:
         "--output",
         help="Path to write the JSON index (defaults to stdout)",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "-l",
+        "--log",
+        help="Write logs to the specified file",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Build the index and write JSON output."""
+    args = parse_args(argv)
+
+    log_fp = None
+    if args.log:
+        log_fp = open(args.log, "w", encoding="utf-8")
+        sys.stderr = log_fp
 
     # Build index for Markdown and YAML separately
     md_index = build_index(args.source_dir, file_pattern="**/*.md")
@@ -230,6 +246,9 @@ def main() -> None:
         logger.info("Index written to file", path=args.output)
     else:
         print(output_json)
+
+    if log_fp is not None:
+        log_fp.close()
 
 
 if __name__ == "__main__":

--- a/app/shell/py/pie/tests/test_build_index.py
+++ b/app/shell/py/pie/tests/test_build_index.py
@@ -59,3 +59,21 @@ def test_validate_and_insert_duplicate(tmp_path):
     index = {"a": {"id": "a"}}
     with pytest.raises(KeyError):
         build_index.validate_and_insert_metadata({"id": "a"}, "file", index)
+
+
+def test_main_writes_log_file(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    md = src / "doc.md"
+    md.write_text("---\n{\"title\": \"T\"}\n---\n")
+    out = tmp_path / "index.json"
+    log = tmp_path / "build.log"
+
+    os.chdir(tmp_path)
+    try:
+        build_index.main(["src", "-o", str(out), "--log", str(log)])
+    finally:
+        os.chdir("/tmp")
+
+    assert out.exists()
+    assert log.exists()

--- a/docs/build-index.md
+++ b/docs/build-index.md
@@ -13,6 +13,9 @@ metadata.
 
 # Scan 'docs/' and write the index to 'index.json'
 ./build_index.py docs/ --output index.json
+
+# Write logs to a file
+./build_index.py docs/ -o index.json --log build-index.log
 ```
 
 ### Arguments
@@ -20,8 +23,11 @@ metadata.
 - `<source_dir>`  
   Root directory to scan for Markdown and YAML files.
 
-- `-o, --output <path>`  
+- `-o, --output <path>`
   (Optional) Path to write the resulting JSON index. Defaults to stdout if omitted.
+
+- `-l, --log <path>`
+  (Optional) Write logs to the specified file.
 
 ## Example Output
 


### PR DESCRIPTION
## Summary
- use the `--log` argument when calling `build-index`
- indent build-index command with a tab

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883d13a3ff08321867ceaef94a0995e