### PR TITLE
Add exclude option to check-page-title

### DIFF
--- a/app/shell/bin/check-page-title
+++ b/app/shell/bin/check-page-title
@@ -4,6 +4,8 @@ import os
 import sys
 from pathlib import Path
 from bs4 import BeautifulSoup
+import argparse
+import yaml
 
 # Detect whether we should emit ANSI colour codes. We only use colours when
 # stdout is a TTY and the TERM environment variable is not set to "dumb".
@@ -28,11 +30,42 @@ def check_file(path: Path) -> bool:
     return True
 
 
-def main(argv: list[str]) -> int:
-    directory = Path(argv[0]) if argv else Path("build")
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Verify that HTML files contain non-empty <h1> tags.",
+    )
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="build",
+        help="Root directory to scan for HTML files",
+    )
+    parser.add_argument(
+        "-x",
+        "--exclude",
+        help="YAML file listing HTML files to skip",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    directory = Path(args.directory).resolve()
     html_files = list(directory.rglob("*.html"))
+    exclude: set[Path] = set()
+    if args.exclude:
+        with open(args.exclude, "r", encoding="utf-8") as exf:
+            data = yaml.safe_load(exf) or []
+        for item in data:
+            p = Path(item)
+            if not p.is_absolute():
+                p = directory / p
+            exclude.add(p.resolve())
     ok = True
     for html_file in html_files:
+        if html_file.resolve() in exclude:
+            continue
         if not check_file(html_file):
             ok = False
     if ok:

--- a/docs/check-page-title.md
+++ b/docs/check-page-title.md
@@ -5,7 +5,16 @@
 ## Usage
 
 ```bash
-check-page-title [directory]
+check-page-title [directory] [-x exclude.yml]
 ```
 
 If no directory is given, `build/` is assumed. The command prints messages for files that fail the check and returns `1` when a problem is found.
+Use `-x`/`--exclude` to provide a YAML file listing HTML files to skip. Paths
+may be absolute or relative to the directory being scanned.
+
+### Example exclude file
+
+```yaml
+- index.html
+- guide/intro.html
+```


### PR DESCRIPTION
## Summary
- extend `check-page-title` with `-x/--exclude` option that reads YAML list of files
- document the new option with an example YAML file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883da552f388321b9e9dd575d6af849