### PR TITLE
Switch to centralized logging

### DIFF
--- a/app/shell/bin/render_template
+++ b/app/shell/bin/render_template
@@ -15,10 +15,7 @@ import json
 from typing import Any, Dict, Mapping
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
-import logging
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger('render_template')
+from pie.utils import logger
 
 # Precompile regex patterns for performance
 _WHITESPACE_WORD_PATTERN = re.compile(r"(\S+)")

--- a/app/shell/py/pie/pie/render_template.py
+++ b/app/shell/py/pie/pie/render_template.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import json
-import logging
 import os
 import re
 import sys
@@ -9,12 +8,8 @@ import sys
 import yaml
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from xmera.utils import read_json, read_utf8
+from pie.utils import logger
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(name)s - %(funcName)s - %(message)s",
-)
-logger = logging.getLogger("render")
 index_json = None  # See main().
 
 _whitespace_word_pattern = re.compile(r"(\S+)")
@@ -222,7 +217,7 @@ def to_alpha_index(i):
 
 def read_yaml(filename):
     y = yaml.safe_load(read_utf8(filename))
-    logging.info(y["toc"])
+    logger.info(y["toc"])
     yield from y["toc"]
 
 


### PR DESCRIPTION
## Summary
- use `pie.utils.logger` in render_template module
- use same logger in the render_template CLI script

## Testing
- `pytest -q app/shell/py/pie/tests/test_render_template.py` *(fails: ModuleNotFoundError: No module named 'loguru')*
- `pip install loguru` *(fails: Could not find a version)*

------
https://chatgpt.com/codex/tasks/task_e_6883e314dd408321a07b5d65c92b0c6b