### PR TITLE
Add logger usage

### DIFF
--- a/app/shell/py/pie/pie/error_on_python_dict.py
+++ b/app/shell/py/pie/pie/error_on_python_dict.py
@@ -1,6 +1,7 @@
 import sys
 import re
 from bs4 import BeautifulSoup
+from pie.utils import logger
 
 def contains_python_dict(text):
     # Regex pattern to detect simple Python dict-like strings
@@ -15,14 +16,14 @@ def main(html_file_path):
     texts = soup.stripped_strings
     for line in texts:
         if contains_python_dict(line):
-            print("Error: Found Python dictionary in HTML text:", line)
+            logger.error("Found Python dictionary in HTML text", line=line)
             sys.exit(1)
 
-    print("No Python dictionaries found in HTML.")
+    logger.info("No Python dictionaries found in HTML.")
     sys.exit(0)
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: python check_html_dicts.py <html_file>")
+        logger.error("Usage: python check_html_dicts.py <html_file>")
         sys.exit(2)
     main(sys.argv[1])

--- a/app/shell/py/pie/pie/include_filter.py
+++ b/app/shell/py/pie/pie/include_filter.py
@@ -16,6 +16,7 @@ import re
 import sys
 
 import yaml
+from pie.utils import logger
 
 figcount = 0
 heading_level = 0
@@ -42,7 +43,7 @@ def parse_metadata_or_print_first_line(f):
 
 
 def include(filename):
-    print("include", filename)
+    logger.info("include", filename=filename)
     with open(filename, "r", encoding="utf-8") as f:
         metadata = parse_metadata_or_print_first_line(f)
         if metadata and metadata.get("title"):
@@ -78,7 +79,7 @@ def new_filestem(stem):
 
 
 def mermaid(mmd_filename, alt_text, ref_id):
-    print(mmd_filename)
+    logger.info("Processing mermaid file", filename=mmd_filename)
     global figcount
     stem = new_filestem(f"{outdir}/diagram")
     with open(mmd_filename, "r", encoding="utf-8") as inmmd, open(

--- a/app/shell/py/pie/pie/picasso.py
+++ b/app/shell/py/pie/pie/picasso.py
@@ -11,6 +11,8 @@ import argparse
 import sys
 from pathlib import Path
 
+from pie.utils import logger
+
 
 def generate_rule(
     input_path: Path,
@@ -77,7 +79,7 @@ def main(argv: list[str] | None = None) -> None:
     build_root = Path(args.build)
 
     if not src_root.is_dir():
-        sys.stderr.write(f"Directory {src_root!s} does not exist\n")
+        logger.error("Directory does not exist", directory=str(src_root))
         sys.exit(1)
 
     for yml_file in src_root.rglob("*.yml"):

--- a/app/shell/py/pie/pie/render_template.py
+++ b/app/shell/py/pie/pie/render_template.py
@@ -164,10 +164,14 @@ def process_directory(root_dir: str) -> None:
             fm = extract_front_matter(full_path)
 
             if fm and isinstance(fm, dict) and "title" in fm:
-                print(f'TITLE: {fm["title"]} | FILE: {full_path}')
+                logger.info(
+                    "TITLE: {title} | FILE: {file}",
+                    title=fm["title"],
+                    file=full_path,
+                )
             else:
-                print(
-                    f"WARNING: No front matter or title in {full_path}", file=sys.stderr
+                logger.warning(
+                    "No front matter or title", file=full_path
                 )
 
 


### PR DESCRIPTION
## Summary
- import `logger` from `pie.utils` where needed
- log file inclusion and Mermaid processing in include-filter
- log HTML dictionary checker and picasso errors
- log missing front matter in render-template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e84823b88321bb41d35f27ce0b48