### PR TITLE
Add log file support to pie scripts

### DIFF
--- a/app/shell/py/pie/pie/gen_markdown_index.py
+++ b/app/shell/py/pie/pie/gen_markdown_index.py
@@ -6,6 +6,7 @@ import argparse
 from typing import Iterable, Mapping, List
 
 from xmera.utils import read_json
+from pie.utils import add_file_logger, logger
 
 
 def generate_lines(index: Mapping[str, Mapping[str, str]]) -> List[str]:
@@ -28,12 +29,19 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
         description="Generate a Markdown index from a JSON index file"
     )
     parser.add_argument("index", help="Path to index.json")
+    parser.add_argument(
+        "-l",
+        "--log",
+        help="Write logs to the specified file",
+    )
     return parser.parse_args(list(argv) if argv is not None else None)
 
 
 def main(argv: Iterable[str] | None = None) -> None:
     """Entry point used by the ``gen-markdown-index`` console script."""
     args = parse_args(argv)
+    if args.log:
+        add_file_logger(args.log, level="DEBUG")
     index = read_json(args.index)
     for line in generate_lines(index):
         print(line)

--- a/app/shell/py/pie/pie/include_filter.py
+++ b/app/shell/py/pie/pie/include_filter.py
@@ -14,9 +14,10 @@ directly to Pandoc.  The command is primarily driven via ``preprocess`` and the
 import os
 import re
 import sys
+import argparse
 
 import yaml
-from pie.utils import logger
+from pie.utils import add_file_logger, logger
 
 figcount = 0
 heading_level = 0
@@ -111,12 +112,36 @@ def md_to_html_links(line):
     return result
 
 
-def main():
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Expand Python directives inside a Markdown file",
+    )
+    parser.add_argument("outdir", help="Output directory for diagrams")
+    parser.add_argument("infile", help="Input Markdown file")
+    parser.add_argument("outfile", help="Output Markdown file")
+    parser.add_argument(
+        "-l",
+        "--log",
+        help="Write logs to the specified file",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Process a Markdown file and expand custom directives."""
+
     global outdir, infilename, outfilename, infile, outfile
 
-    outdir = sys.argv[1]
-    infilename = sys.argv[2]
-    outfilename = sys.argv[3]
+    args = parse_args(argv)
+
+    if args.log:
+        add_file_logger(args.log, level="DEBUG")
+
+    outdir = args.outdir
+    infilename = args.infile
+    outfilename = args.outfile
 
     with open(infilename, "r", encoding="utf-8") as infile, open(
         outfilename, "w", encoding="utf-8"

--- a/app/shell/py/pie/pie/picasso.py
+++ b/app/shell/py/pie/pie/picasso.py
@@ -11,7 +11,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from pie.utils import logger
+from pie.utils import add_file_logger, logger
 
 
 def generate_rule(
@@ -68,6 +68,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="build",
         help="Directory where build artifacts are written",
     )
+    parser.add_argument(
+        "-l",
+        "--log",
+        help="Write logs to the specified file",
+    )
     return parser.parse_args(argv)
 
 
@@ -75,6 +80,8 @@ def main(argv: list[str] | None = None) -> None:
     """Entry point: print Makefile rules for ``.yml`` files under ``src_root``."""
 
     args = parse_args(argv)
+    if args.log:
+        add_file_logger(args.log, level="DEBUG")
     src_root = Path(args.src)
     build_root = Path(args.build)
 

--- a/app/shell/py/pie/pie/render_study_json.py
+++ b/app/shell/py/pie/pie/render_study_json.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Iterable, List
 
 from xmera.utils import read_json
+from pie.utils import add_file_logger, logger
 
 from .render_template import create_env
 
@@ -58,6 +59,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--output",
         help="Optional file to write the rendered JSON (defaults to stdout)",
     )
+    parser.add_argument(
+        "-l",
+        "--log",
+        help="Write logs to the specified file",
+    )
     return parser.parse_args(argv)
 
 
@@ -65,6 +71,8 @@ def main(argv: list[str] | None = None) -> None:
     """Entry point for the ``pie.render_study_json`` module."""
 
     args = parse_args(argv)
+    if args.log:
+        add_file_logger(args.log, level="DEBUG")
 
     index_json = read_json(args.index)
     study_json = read_json(args.study)

--- a/app/shell/py/pie/pie/render_template.py
+++ b/app/shell/py/pie/pie/render_template.py
@@ -4,11 +4,12 @@ import json
 import os
 import re
 import sys
+import argparse
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from xmera.utils import read_json, read_utf8
-from pie.utils import logger
+from pie.utils import add_file_logger, logger
 
 index_json = None  # See main().
 
@@ -247,10 +248,33 @@ def create_env():
 env = create_env()
 
 
-def main():
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Render a template using variables from an index JSON file",
+    )
+    parser.add_argument("index", help="Path to index.json")
+    parser.add_argument("template", help="Template file to render")
+    parser.add_argument(
+        "-l",
+        "--log",
+        help="Write logs to the specified file",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Render the specified template using variables from ``index.json``."""
+
     global index_json
-    index_json = read_json(sys.argv[1])
-    template = env.get_template(sys.argv[2])
+    args = parse_args(argv)
+
+    if args.log:
+        add_file_logger(args.log, level="DEBUG")
+
+    index_json = read_json(args.index)
+    template = env.get_template(args.template)
     print(template.render(**index_json))
 
 

--- a/app/shell/py/pie/tests/test_gen_markdown_index.py
+++ b/app/shell/py/pie/tests/test_gen_markdown_index.py
@@ -21,3 +21,14 @@ def test_main_outputs_lines(tmp_path, capsys):
     gen_markdown_index.main([str(path)])
     out = capsys.readouterr().out.strip()
     assert out == "- [Foo](/foo)"
+
+
+def test_main_writes_log_file(tmp_path):
+    data = {"item": {"name": "Foo", "url": "/foo"}}
+    index_path = tmp_path / "index.json"
+    log_path = tmp_path / "index.log"
+    index_path.write_text(json.dumps(data))
+
+    gen_markdown_index.main([str(index_path), "--log", str(log_path)])
+
+    assert log_path.exists()

--- a/app/shell/py/pie/tests/test_include_filter.py
+++ b/app/shell/py/pie/tests/test_include_filter.py
@@ -63,3 +63,23 @@ def test_mermaid_creates_files(tmp_path):
     assert (tmp_path / "diagram0.mmd").read_text() == "A-->B\n"
     assert include_filter.outfile.getvalue().strip() == f"![alt](./diagram0.png){{ #id }}"
     assert include_filter.figcount == 1
+
+
+def test_main_writes_log_file(tmp_path):
+    outdir = tmp_path / "out"
+    outdir.mkdir()
+    infile = tmp_path / "doc.md"
+    infile.write_text("Hello")
+    outfile = tmp_path / "out.md"
+    log = tmp_path / "inc.log"
+
+    include_filter.main([
+        str(outdir),
+        str(infile),
+        str(outfile),
+        "--log",
+        str(log),
+    ])
+
+    assert outfile.exists()
+    assert log.exists()

--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -25,3 +25,15 @@ def test_main_prints_rules(tmp_path, capsys):
     out = capsys.readouterr().out.strip()
     expected = picasso.generate_rule(src / "doc.yml", src_root=src, build_root=build).strip()
     assert out == expected
+
+
+def test_main_writes_log_file(tmp_path):
+    src = tmp_path / "src"
+    build = tmp_path / "build"
+    src.mkdir()
+    (src / "doc.yml").write_text("{}")
+    log = tmp_path / "picasso.log"
+
+    picasso.main(["--src", str(src), "--build", str(build), "--log", str(log)])
+
+    assert log.exists()

--- a/app/shell/py/pie/tests/test_render_study_json.py
+++ b/app/shell/py/pie/tests/test_render_study_json.py
@@ -36,3 +36,20 @@ def test_main_writes_file(tmp_path):
     render_study_json.main([str(index_file), str(study_file), "-o", str(out_file)])
     data = json.loads(out_file.read_text())
     assert data == [{"q": "Baz", "c": ["Y"], "a": [0, ""]}]
+
+
+def test_main_writes_log_file(tmp_path):
+    index_file = tmp_path / "index.json"
+    study_file = tmp_path / "study.json"
+    log_file = tmp_path / "study.log"
+    index_file.write_text(json.dumps({"x": {"name": "Baz"}}))
+    study_file.write_text(json.dumps([{"q": "{{x['name']}}", "c": ["Y"], "a": [0, ""]}]))
+
+    render_study_json.main([
+        str(index_file),
+        str(study_file),
+        "--log",
+        str(log_file),
+    ])
+
+    assert log_file.exists()


### PR DESCRIPTION
## Summary
- allow all `pie` console scripts to write log output to a file
- extend tests for each script to verify the new `--log` option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ec94561083219dbb8863f272b936