### PR TITLE
Update gen-markdown-index

### DIFF
--- a/app/shell/py/pie/pie/gen_markdown_index.py
+++ b/app/shell/py/pie/pie/gen_markdown_index.py
@@ -1,25 +1,31 @@
-"""Generate a Markdown list from an index JSON file."""
+"""Generate a Jinja list from an index JSON file."""
 
 from __future__ import annotations
 
 import argparse
 from typing import Iterable, Mapping, List
+import json
 
 from xmera.utils import read_json
 from pie.utils import add_file_logger, logger
 
 
 def generate_lines(index: Mapping[str, Mapping[str, str]]) -> List[str]:
-    """Return Markdown list items sorted by the ``name`` field."""
+    """Return Jinja list items sorted by the ``name`` field."""
     lines: List[str] = []
     for _, item in sorted(index.items(), key=lambda p: p[1]["name"]):
-        name = item["name"]
-        url = item["url"]
+        desc = {
+            "citation": item["name"],
+            "url": item["url"],
+        }
         icon = item.get("icon")
-        if icon:
-            lines.append(f"- [{icon} {name}]({url})")
-        else:
-            lines.append(f"- [{name}]({url})")
+        if icon is not None:
+            desc["icon"] = icon
+        link = item.get("link")
+        if isinstance(link, dict) and "tracking" in link:
+            desc["link"] = {"tracking": link["tracking"]}
+        snippet = "{{ " + json.dumps(desc, ensure_ascii=False) + " | linktitle }}"
+        lines.append(f"- {snippet}")
     return lines
 
 

--- a/docs/gen-markdown-index.md
+++ b/docs/gen-markdown-index.md
@@ -1,11 +1,19 @@
 # gen-markdown-index
 
-Generate a simple Markdown list from `index.json`.
+Generate a Jinja formatted list from `index.json`.
 
 ```
 usage: gen-markdown-index <index.json>
 ```
 
-The command reads the JSON index file produced by `build-index` and prints
-a bullet list of links sorted by the `name` field. If an entry contains
-an `icon` value it is prefixed to the link text.
+The command reads the JSON index file produced by `build-index` and prints a
+bullet list where each item is a Jinja expression. When a metadata entry
+provides a `link.tracking` value it is preserved so the rendered HTML uses
+`rel="noopener noreferrer"` and `target="_blank"` when set to `false`.
+Entries are sorted by the `name` field and icons are included when present.
+
+Example output:
+
+```jinja
+- {{ {"citation": "Example", "url": "/ex", "link": {"tracking": false}} | linktitle }}
+```


### PR DESCRIPTION
## Summary
- emit Jinja snippets using `linktitle` filter
- copy existing `link.tracking` metadata instead of forcing tracking off
- document the new `linktitle` output
- clarify expected strings in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879d3ea25c8321a5cc1b5d058e130c