### PR TITLE
Add metadata field reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ If you don’t provide these, Pandoc (or your build tooling) will generate them 
 - `id`: A unique identifier for cross-document linking (e.g., when using Jinja templates).
 - `citation`: The default inline text used for hyperlinks to this document.
 
+See [docs/metadata-fields.md](docs/metadata-fields.md) for a complete list of supported fields and defaults.
+
 ### Examples
 - **Sidecar metadata**  
   Store metadata in `index.yml` and content in `index.md`.  

--- a/docs/build-index.md
+++ b/docs/build-index.md
@@ -3,7 +3,8 @@
 A command-line tool to scan directories for Markdown (`.md`) and YAML
 (`.yml`/`.yaml`) files, extract their metadata, generate URLs for Markdown
 sources, and build a consolidated JSON index mapping each document’s `id` to its
-metadata.
+metadata. See [Metadata Fields](metadata-fields.md) for an overview of the
+supported keys and defaults.
 
 ## Usage
 

--- a/docs/gen-markdown-index.md
+++ b/docs/gen-markdown-index.md
@@ -1,6 +1,6 @@
 # gen-markdown-index
 
-Generate a Jinja formatted list from `index.json`.
+Generate a Jinja formatted list from `index.json`. The fields available in the index are described in [Metadata Fields](metadata-fields.md).
 
 ```
 usage: gen-markdown-index <index.json>

--- a/docs/jinja-filters.md
+++ b/docs/jinja-filters.md
@@ -1,6 +1,6 @@
 # Jinja Filters for Link Formatting
 
-Several build scripts provide custom Jinja filters that transform Markdown links. They operate on strings of the form `[text](url)` and return HTML anchors. This document describes the `linktitle` filter which capitalizes every word in the link text.
+Several build scripts provide custom Jinja filters that transform Markdown links. They operate on strings of the form `[text](url)` and return HTML anchors. This document describes the `linktitle` filter which capitalizes every word in the link text. For an overview of the metadata fields used by these filters, see [Metadata Fields](metadata-fields.md).
 
 ## `linktitle`
 

--- a/docs/jinja-globals.md
+++ b/docs/jinja-globals.md
@@ -2,7 +2,8 @@
 
 The template environment provides several helper functions that can be invoked
 from any Jinja template. They expose metadata from the build index or offer
-small utilities used during rendering.
+small utilities used during rendering. See [Metadata Fields](metadata-fields.md)
+for details on the structure of this metadata.
 
 ## Available Globals
 

--- a/docs/keyterms.md
+++ b/docs/keyterms.md
@@ -1,6 +1,6 @@
 # Key Terms Data Flow
 
-This document explains how the `keyterms.json` file is transformed into the final `keyterms.html` page.
+This document explains how the `keyterms.json` file is transformed into the final `keyterms.html` page. See [Metadata Fields](metadata-fields.md) for a description of the metadata associated with each term.
 
 ## Source JSON
 

--- a/docs/link-metadata.md
+++ b/docs/link-metadata.md
@@ -1,6 +1,6 @@
 # Link Metadata Files
 
-This document explains how to describe external links using YAML files and how the build scripts interpret them.
+This document explains how to describe external links using YAML files and how the build scripts interpret them. A list of all metadata keys can be found in [Metadata Fields](metadata-fields.md).
 
 ## Creating a Metadata File
 

--- a/docs/metadata-fields.md
+++ b/docs/metadata-fields.md
@@ -1,0 +1,33 @@
+# Metadata Fields
+
+This document lists the common metadata keys used by Press and explains how missing values are automatically generated.
+
+## Required
+
+- `name` – Display name used in navigation and indexes.
+
+## Optional Fields
+
+- `title` – Heading shown in the rendered page.
+- `author` – Author string passed to Pandoc.
+- `description` – Short summary used for meta tags.
+- `og_image` – OpenGraph image path.
+- `meta` – Array of additional `<meta>` tag definitions for Pandoc.
+- `icon` – Emoji or icon displayed by link filters.
+- `link.tracking` – Boolean controlling external link behaviour.
+- `link.class` – CSS class for rendered links.
+
+## Auto‑Generated Values
+
+During indexing, `build_index.py` fills in several fields when they are missing:
+
+| Field      | Default value                                  |
+| ---------- | ---------------------------------------------- |
+| `id`       | Filename without the extension                 |
+| `citation` | Lowercase form of the `name` value             |
+| `url`      | Derived from the source path (e.g. `src/foo.md` → `/foo.html`) |
+
+The helper that assigns these defaults lives in `process_yaml` within `pie.build_index`.
+
+`link.tracking` defaults to `true`, meaning links open in the same tab. `link.class` defaults to `internal-link`.
+

--- a/docs/picasso.md
+++ b/docs/picasso.md
@@ -3,6 +3,7 @@
 `picasso` scans the `src/` directory for YAML metadata files and emits Makefile
 rules that convert them to HTML using Pandoc. The generated rules are written to
 `build/picasso.mk` and included by `app/shell/mk/build.mk` during the build.
+Refer to [Metadata Fields](metadata-fields.md) for the supported metadata keys.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- document metadata fields and defaults
- link metadata reference from multiple docs

## Testing
- `make -f redo.mk test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887f8140ad08321a580e515d462b47a