### PR TITLE
Add nested output for gen-markdown-index

### DIFF
--- a/app/shell/py/pie/pie/gen_markdown_index.py
+++ b/app/shell/py/pie/pie/gen_markdown_index.py
@@ -3,30 +3,112 @@
 from __future__ import annotations
 
 import argparse
-from typing import Iterable, Mapping, List
+from typing import Iterable, Mapping, List, Dict, Any
 import json
 
 from xmera.utils import read_json
 from pie.utils import add_file_logger, logger
 
 
-def generate_lines(index: Mapping[str, Mapping[str, str]]) -> List[str]:
-    """Return Jinja list items sorted by the ``name`` field."""
+def _parse_segments(url: str) -> List[str]:
+    """Return path segments for an internal URL."""
+    if not url.startswith("/"):
+        return []
+    path = url.lstrip("/")
+    if path.endswith(".html"):
+        path = path[:-5]
+    parts = path.split("/")
+    if parts and parts[-1] == "index":
+        parts = parts[:-1]
+    return parts
+
+
+def _common_prefix(lists: List[List[str]]) -> List[str]:
+    """Return the common path prefix for all lists."""
+    if not lists:
+        return []
+    prefix = lists[0]
+    for lst in lists[1:]:
+        i = 0
+        while i < len(prefix) and i < len(lst) and prefix[i] == lst[i]:
+            i += 1
+        prefix = prefix[:i]
+        if not prefix:
+            break
+    return prefix
+
+
+def _add_to_tree(tree: Dict[str, Any], parts: List[str], item: Mapping[str, Any]) -> None:
+    node = tree
+    for part in parts:
+        node = node.setdefault("_children", {}).setdefault(part, {"_item": None, "_children": {}})
+    node["_item"] = item
+
+
+def _build_tree(index: Mapping[str, Mapping[str, Any]]) -> Dict[str, Any]:
+    entries: List[tuple[List[str], Mapping[str, Any]]] = []
+    internal_paths: List[List[str]] = []
+    for item in index.values():
+        parts = _parse_segments(item.get("url", ""))
+        entries.append((parts, item))
+        if parts:
+            internal_paths.append(parts)
+
+    prefix = _common_prefix(internal_paths)
+
+    tree: Dict[str, Any] = {"_item": None, "_children": {}}
+    for parts, item in entries:
+        rel_parts = parts[len(prefix) :] if parts[: len(prefix)] == prefix else parts
+        _add_to_tree(tree, rel_parts, item)
+
+    return tree
+
+
+def _desc_from_item(item: Mapping[str, Any]) -> Dict[str, Any]:
+    desc = {
+        "citation": item["name"],
+        "url": item["url"],
+    }
+    icon = item.get("icon")
+    if icon is not None:
+        desc["icon"] = icon
+    link = item.get("link")
+    if isinstance(link, dict) and "tracking" in link:
+        desc["link"] = {"tracking": link["tracking"]}
+    return desc
+
+
+def _generate_from_tree(tree: Dict[str, Any], indent: int = 0, include_self: bool = False) -> List[str]:
     lines: List[str] = []
-    for _, item in sorted(index.items(), key=lambda p: p[1]["name"]):
-        desc = {
-            "citation": item["name"],
-            "url": item["url"],
-        }
-        icon = item.get("icon")
-        if icon is not None:
-            desc["icon"] = icon
-        link = item.get("link")
-        if isinstance(link, dict) and "tracking" in link:
-            desc["link"] = {"tracking": link["tracking"]}
+    if include_self and tree.get("_item"):
+        desc = _desc_from_item(tree["_item"])
         snippet = "{{ " + json.dumps(desc, ensure_ascii=False) + " | linktitle }}"
-        lines.append(f"- {snippet}")
+        lines.append(f"{'  ' * indent}- {snippet}")
+
+    children = tree.get("_children", {})
+    def sort_key(item):
+        node = item[1]
+        meta = node.get("_item")
+        if meta is not None:
+            return meta.get("name", "")
+        return item[0]
+
+    for key, child in sorted(children.items(), key=sort_key):
+        meta = child.get("_item")
+        if meta is not None:
+            desc = _desc_from_item(meta)
+            snippet = "{{ " + json.dumps(desc, ensure_ascii=False) + " | linktitle }}"
+            lines.append(f"{'  ' * indent}- {snippet}")
+        else:
+            lines.append(f"{'  ' * indent}- {key}")
+        lines.extend(_generate_from_tree(child, indent + 1, include_self=False))
     return lines
+
+
+def generate_lines(index: Mapping[str, Mapping[str, Any]]) -> List[str]:
+    """Return Jinja list items mirroring the directory structure."""
+    tree = _build_tree(index)
+    return _generate_from_tree(tree, include_self=True)
 
 
 def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:

--- a/app/shell/py/pie/tests/test_gen_markdown_index.py
+++ b/app/shell/py/pie/tests/test_gen_markdown_index.py
@@ -60,3 +60,22 @@ def test_main_writes_log_file(tmp_path):
     gen_markdown_index.main([str(index_path), "--log", str(log_path)])
 
     assert log_path.exists()
+
+
+def test_generate_lines_nested_dirs():
+    index = {
+        "foo": {"name": "Foo", "url": "/jp/foo.html"},
+        "a": {"name": "A", "url": "/jp/a/index.html"},
+        "bar": {"name": "Bar", "url": "/jp/a/bar.html"},
+    }
+    lines = gen_markdown_index.generate_lines(index)
+    foo = {"citation": "Foo", "url": "/jp/foo.html"}
+    a = {"citation": "A", "url": "/jp/a/index.html"}
+    bar = {"citation": "Bar", "url": "/jp/a/bar.html"}
+    expected = [
+        "- {{ " + json.dumps(a, ensure_ascii=False) + " | linktitle }}",
+        "  - {{ " + json.dumps(bar, ensure_ascii=False) + " | linktitle }}",
+        "- {{ " + json.dumps(foo, ensure_ascii=False) + " | linktitle }}",
+    ]
+    assert lines == expected
+


### PR DESCRIPTION
## Summary
- make `gen_markdown_index` output reflect directory structure
- test nested list generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f7293d988321b8af1c2f81e17c98