### PR TITLE
Add process-yaml command

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ build. Use `--src DIR` to search a different directory for `.yml` files and
 - [preprocess](docs/preprocess.md)
 - [picasso](docs/picasso.md)
 - [gen-markdown-index](docs/gen-markdown-index.md)
+- [process-yaml](docs/process-yaml.md)
 - [Nginx Dockerfile](docs/nginx.md)
 - [docker-make](docs/docker-make.md)
 - [check-page-title](docs/check-page-title.md)

--- a/app/shell/py/pie/pie/process_yaml.py
+++ b/app/shell/py/pie/pie/process_yaml.py
@@ -1,0 +1,53 @@
+"""Fill missing metadata fields in a YAML file."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Iterable
+
+import yaml
+
+from pie.utils import add_file_logger, logger
+from pie import build_index
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Generate missing metadata fields for a YAML file",
+    )
+    parser.add_argument("input", help="Source YAML file")
+    parser.add_argument("output", help="Destination file to write")
+    parser.add_argument(
+        "-l",
+        "--log",
+        help="Write logs to the specified file",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """Entry point used by the ``process-yaml`` console script."""
+    args = parse_args(argv)
+    if args.log:
+        add_file_logger(args.log, level="DEBUG")
+
+    try:
+        metadata = build_index.process_yaml(args.input)
+    except Exception as exc:  # pragma: no cover - pass through message
+        logger.error("Failed to process YAML", filename=args.input)
+        raise SystemExit(1) from exc
+
+    if metadata is None:
+        logger.error("No metadata found", filename=args.input)
+        sys.exit(1)
+
+    with open(args.output, "w", encoding="utf-8") as out:
+        yaml.safe_dump(metadata, out, allow_unicode=True, sort_keys=False)
+
+    logger.info("Processed YAML written", path=args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -23,6 +23,7 @@ setup(
             'render-study-json=pie.render_study_json:main',
             'include-filter=pie.include_filter:main',
             'gen-markdown-index=pie.gen_markdown_index:main',
+            'process-yaml=pie.process_yaml:main',
         ],
     },
 )

--- a/app/shell/py/pie/tests/test_process_yaml.py
+++ b/app/shell/py/pie/tests/test_process_yaml.py
@@ -1,0 +1,43 @@
+import os
+import yaml
+from pie import process_yaml
+
+
+def test_main_generates_metadata(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    inp = src / "item.yml"
+    inp.write_text("{\"name\": \"Foo\"}")
+    out = tmp_path / "out.yml"
+    os.chdir(tmp_path)
+    try:
+        process_yaml.main([str(inp.relative_to(tmp_path)), str(out.relative_to(tmp_path))])
+    finally:
+        os.chdir("/tmp")
+
+    data = yaml.safe_load(out.read_text())
+    assert data["name"] == "Foo"
+    assert data["url"] == "/item.html"
+    assert data["citation"] == "foo"
+    assert data["id"] == "item"
+
+
+def test_main_writes_log_file(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    inp = src / "doc.yml"
+    inp.write_text("{\"name\": \"Foo\"}")
+    out = tmp_path / "out.yml"
+    log = tmp_path / "proc.log"
+    os.chdir(tmp_path)
+    try:
+        process_yaml.main([
+            str(inp.relative_to(tmp_path)),
+            str(out.relative_to(tmp_path)),
+            "--log",
+            str(log.relative_to(tmp_path)),
+        ])
+    finally:
+        os.chdir("/tmp")
+
+    assert log.exists()

--- a/docs/process-yaml.md
+++ b/docs/process-yaml.md
@@ -1,0 +1,15 @@
+# process-yaml
+
+Fill in missing metadata fields in a YAML file.
+
+```
+usage: process-yaml <input.yml> <output.yml>
+```
+
+The command reads the input YAML file, generates any missing values as described in [Metadata Fields](metadata-fields.md), and writes the result to the output file. Use `--log` to save verbose logs.
+
+Example:
+
+```bash
+process-yaml in.yml out.yml --log build.log
+```


### PR DESCRIPTION
## Summary
- implement `process-yaml` console script
- document script usage
- expose the command via setup.py
- reference doc from README
- test generating metadata and logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68880039be388321b44cbb6e9fe45a7d