### PR TITLE
Simpler log timestamps

### DIFF
--- a/app/shell/py/pie/pie/utils/__init__.py
+++ b/app/shell/py/pie/pie/utils/__init__.py
@@ -17,7 +17,7 @@ from loguru import logger
 logger.remove()
 
 LOG_FORMAT = (
-    "{time} {module:>25}:{function:<25}:{line:<4} {level:<5} {message} {extra}"
+    "{time:HH:mm:ss} {module:>25}:{function:<25}:{line:<4} {level:<5} {message} {extra}"
 )
 
 # Configure the console sink that all tests and scripts rely on.

--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -8,6 +8,7 @@ def test_generate_rule_basic():
     expected = (
         "build/foo/bar.yml: src/foo/bar.yml\n"
         "\t$(Q)emojify < $< > $@\n"
+        "\t$(Q)process-yaml $< $@\n"
         "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml\n"
         "\t$(Q)$(PANDOC_CMD) $(PANDOC_OPTS) --metadata-file=build/foo/bar.yml -o $@ $<\n"
         "\t$(Q)python3 -m pie.error_on_python_dict $@"


### PR DESCRIPTION
## Summary
- shorten the log timestamp column by dropping the date
- update picasso test expectations to include the process-yaml step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68880963816c832192566a3ff7d74d21