### PR TITLE
Clarify citation usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Pandoc lets you define document metadata in two ways:
 ### Auto-Generated Fields
 If you don’t provide these, Pandoc (or your build tooling) will generate them automatically:
 - `id`: A unique identifier for cross-document linking (e.g., when using Jinja templates).
-- `citation`: The default inline text used for hyperlinks to this document.
+- `citation`: Default anchor text for cross-document links. Jinja filters such as `linktitle` use this value.
 
 See [docs/metadata-fields.md](docs/metadata-fields.md) for a complete list of supported fields and defaults.
 

--- a/docs/jinja-filters.md
+++ b/docs/jinja-filters.md
@@ -1,15 +1,22 @@
 # Jinja Filters for Link Formatting
 
-Several build scripts provide custom Jinja filters that transform Markdown links. They operate on strings of the form `[text](url)` and return HTML anchors. This document describes the `linktitle` filter which capitalizes every word in the link text. For an overview of the metadata fields used by these filters, see [Metadata Fields](metadata-fields.md).
+Several build scripts provide custom Jinja filters that convert metadata
+dictionaries into HTML anchors. Each dictionary is pulled from
+`index.json` and must include a `citation` field which supplies the anchor
+text, along with a `url` field. Optional keys like `icon`,
+`link.tracking`, and `link.class` customize the output.  For an overview of
+these metadata fields, see [Metadata Fields](metadata-fields.md).
 
 ## `linktitle`
 
-The `linktitle` filter capitalizes the first character of **each** word in the link text while preserving all whitespace. Values that do not match the Markdown link pattern are returned unchanged.
+`linktitle` capitalizes the first character of **each** word in the
+`citation` field. It returns an HTML `<a>` element using the supplied
+`url` and optional `icon`, `link.class`, or `link.tracking` fields.
 
 Example:
 
 ```jinja
-{{ "[deltoid tuberosity](/humerus.html#deltoid_tuberosity)" | linktitle }}
+{{ {"citation": "deltoid tuberosity", "url": "/humerus.html#deltoid_tuberosity"} | linktitle }}
 ```
 
 renders as:
@@ -18,32 +25,16 @@ renders as:
 <a href="/humerus.html#deltoid_tuberosity" class="internal-link">Deltoid Tuberosity</a>
 ```
 
-You can also use it inside YAML fragments that feed into Jinja templates:
-
-```yaml
-toc:
-  - "{{deltoid_tuberosity|linktitle}}"
-```
-
-The filter implementation lives in `pie.render_jinja_template` and is available via the `render-jinja-template` command. It uses a regular expression to extract the link text and URL:
-
-```python
-match = _LINK_PATTERN.match(value)
-...
-transformed = _WHITESPACE_WORD_PATTERN.sub(_capitalize_word, link_text)
-return f"[{transformed}]({url})"
-```
-
-This ensures that each word is capitalized without altering spacing or punctuation.
+This filter lives in `pie.render_jinja_template` and is also exposed by the
+`render-jinja-template` command.
 
 ## `linkcap`
 
-The `linkcap` filter capitalizes only the first character of the link text.
-It expects the same `[text](url)` syntax and leaves the rest of the string
-untouched.
+`linkcap` capitalizes only the first character of the `citation` text. It uses
+the same metadata fields as `linktitle` and returns an anchor element.
 
 ```jinja
-{{ "[deltoid tuberosity](/humerus.html#deltoid_tuberosity)" | linkcap }}
+{{ {"citation": "deltoid tuberosity", "url": "/humerus.html#deltoid_tuberosity"} | linkcap }}
 ```
 
 renders as:
@@ -54,19 +45,21 @@ renders as:
 
 ## `linkicon`
 
-`linkicon` leaves the link text unchanged but allows emoji or other icons to be
-included. It is useful when the source metadata provides an `icon` field that
-should appear before the link text.
+`linkicon` leaves the `citation` text unchanged but allows emoji or other icons
+to appear before it. Provide the optional `icon` field in the metadata to prefix
+the link text.
 
 ## `link_icon_title`
 
 This filter combines the behavior of `linkicon` with word capitalization. It is
-primarily used when a metadata entry defines both an icon and link text.
+primarily used when the metadata includes both an `icon` and a `citation`
+value.
 
 ## `link`
 
-A simple filter that returns the raw HTML `<a>` tag without any additional
-transformation.
+`link` renders the `citation` field as-is without altering capitalization.
+It is useful when no formatting is desired but you still want an anchor
+element with the correct `url` and optional link attributes.
 
 ## `get_desc`
 

--- a/docs/metadata-fields.md
+++ b/docs/metadata-fields.md
@@ -27,6 +27,7 @@ During indexing, `build_index.py` fills in several fields when they are missing:
 | `citation` | Lowercase form of the `name` value             |
 | `url`      | Derived from the source path (e.g. `src/foo.md` → `/foo.html`) |
 
+The `citation` value is used as the anchor text when other pages link to this document using Jinja filters such as `linktitle`.
 The helper that assigns these defaults lives in `process_yaml` within `pie.build_index`.
 
 `link.tracking` defaults to `true`, meaning links open in the same tab. `link.class` defaults to `internal-link`.


### PR DESCRIPTION
## Summary
- explain citation metadata usage in README
- document how citation serves as link text in metadata fields doc
- expand jinja filter docs to show citation field as required anchor text

## Testing
- `pip install -r app/shell/py/pie/requirements.txt pytest`
- `pip install beautifulsoup4`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888f5f6fe9c832181d3bd064393988c