### PR TITLE
Add docs for webp service

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ cp foo.png app/webp/input
 r webp
 ls app/webp/output
 ```
+See [docs/webp-service.md](docs/webp-service.md) for more about how the
+converter works.
 
 ## Wish List
 
@@ -145,4 +147,5 @@ build. Use `--src DIR` to search a different directory for `.yml` files and
 - [process-yaml](docs/process-yaml.md)
 - [Nginx Dockerfile](docs/nginx.md)
 - [docker-make](docs/docker-make.md)
+- [WebP Service](docs/webp-service.md)
 - [check-page-title](docs/check-page-title.md)

--- a/docs/webp-service.md
+++ b/docs/webp-service.md
@@ -1,0 +1,36 @@
+# webp image conversion service
+
+The `webp` service converts PNG and JPEG files to WebP format using
+[ImageMagick](https://imagemagick.org). The container lives under
+`app/webp` and runs `/app/bin/service` in a loop.
+
+## Directories
+
+- `app/webp/input` – place `.png` or `.jpg` files here for processing.
+- `app/webp/output` – converted `.webp` files are written here.
+- `log/webp.txt` – log of conversions when the service runs.
+
+## Running the service
+
+Use `redo.mk` to start the container:
+
+```bash
+r webp
+```
+
+The service watches `app/webp/input` and converts anything it finds.
+Once finished, the original file is removed and the WebP version
+appears under `app/webp/output`.
+
+### Example
+
+```bash
+cp foo.png app/webp/input
+r webp
+ls app/webp/output
+```
+
+This will produce `foo.webp` inside `app/webp/output`.
+
+The `setup` target creates the input and output directories if they do
+not already exist.


### PR DESCRIPTION
## Summary
- document the WebP conversion service
- link to documentation from README

## Testing
- `make -f redo.mk pytest` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688bfe0b84ac83219d59944aa24bf235