### PR TITLE
Add nested index storage for Redis

### DIFF
--- a/dist/app/shell/py/pie/pie/build_index_2.py
+++ b/dist/app/shell/py/pie/pie/build_index_2.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Load an index JSON file and insert values into DragonflyDB/Redis.
+
+This command reads a JSON index mapping document ``id`` to metadata and
+inserts each value into a Redis compatible database using keys of the form
+``<id>.<property>``. Complex values are stored as JSON strings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import redis
+from pie.utils import add_file_logger, logger
+
+
+def load_index(path: str | Path) -> Mapping[str, Mapping[str, Any]]:
+    """Return the parsed JSON index from *path*."""
+    text = Path(path).read_text(encoding="utf-8")
+    return json.loads(text)
+
+
+def flatten_index(index: Mapping[str, Mapping[str, Any]]) -> Iterable[tuple[str, str]]:
+    """Yield ``(key, value)`` pairs for insertion into Redis.
+
+    Nested dictionaries are flattened using dot-separated keys. Values that are
+    not strings are encoded as JSON.
+    """
+
+    def _walk(prefix: str, obj: Any) -> Iterable[tuple[str, str]]:
+        if isinstance(obj, Mapping):
+            for k, v in obj.items():
+                yield from _walk(f"{prefix}.{k}", v)
+        elif isinstance(obj, list):
+            for i, item in enumerate(obj):
+                yield from _walk(f"{prefix}.{i}", item)
+        else:
+            val = obj if isinstance(obj, str) else json.dumps(obj, ensure_ascii=False)
+            yield prefix, val
+
+    for doc_id, props in index.items():
+        yield from _walk(doc_id, props)
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Insert index values into a DragonflyDB/Redis instance",
+    )
+    parser.add_argument("index", help="Path to index.json")
+    parser.add_argument("-l", "--log", help="Write logs to the specified file")
+    parser.add_argument(
+        "--host",
+        default="localhost",
+        help="Redis host (default: localhost)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=6379,
+        help="Redis port (default: 6379)",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """Entry point for the ``build-index-2`` console script."""
+    args = parse_args(argv)
+    if args.log:
+        add_file_logger(args.log, level="DEBUG")
+
+    index = load_index(args.index)
+    r = redis.Redis(host=args.host, port=args.port, decode_responses=True)
+    for key, value in flatten_index(index):
+        r.set(key, value)
+        logger.debug("Inserted", key=key, value=value)
+
+
+if __name__ == "__main__":
+    main()

--- a/dist/app/shell/py/pie/requirements.txt
+++ b/dist/app/shell/py/pie/requirements.txt
@@ -1,2 +1,4 @@
 PyYAML
 loguru
+redis
+fakeredis

--- a/dist/app/shell/py/pie/setup.py
+++ b/dist/app/shell/py/pie/setup.py
@@ -18,6 +18,7 @@ setup(
     entry_points={
         'console_scripts': [
             'build-index=pie.build_index:main',
+            'build-index-2=pie.build_index_2:main',
             'picasso=pie.picasso:main',
             'render-jinja-template=pie.render_jinja_template:main',
             'render-study-json=pie.render_study_json:main',

--- a/dist/app/shell/py/pie/tests/test_build_index_2.py
+++ b/dist/app/shell/py/pie/tests/test_build_index_2.py
@@ -1,0 +1,52 @@
+import json
+import fakeredis
+from pie import build_index_2
+
+
+def test_main_inserts_keys(tmp_path, monkeypatch):
+    index_data = {
+        "quickstart": {
+            "title": "Quickstart",
+            "url": "/quickstart.html",
+            "meta": {
+                "subtitle": "Intro",
+                "author": {"name": "Alice"},
+            },
+        }
+    }
+    idx = tmp_path / "index.json"
+    idx.write_text(json.dumps(index_data))
+
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(build_index_2.redis, "Redis", lambda *a, **kw: fake)
+
+    build_index_2.main([str(idx)])
+
+    assert fake.get("quickstart.title") == "Quickstart"
+    assert fake.get("quickstart.url") == "/quickstart.html"
+    assert fake.get("quickstart.meta.subtitle") == "Intro"
+    assert fake.get("quickstart.meta.author.name") == "Alice"
+
+
+def test_main_handles_arrays(tmp_path, monkeypatch):
+    index_data = {
+        "quickstart": {
+            "tags": ["foo", "bar"],
+            "authors": [
+                {"name": "Alice"},
+                {"name": "Bob"},
+            ],
+        }
+    }
+    idx = tmp_path / "index.json"
+    idx.write_text(json.dumps(index_data))
+
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(build_index_2.redis, "Redis", lambda *a, **kw: fake)
+
+    build_index_2.main([str(idx)])
+
+    assert fake.get("quickstart.tags.0") == "foo"
+    assert fake.get("quickstart.tags.1") == "bar"
+    assert fake.get("quickstart.authors.0.name") == "Alice"
+    assert fake.get("quickstart.authors.1.name") == "Bob"


### PR DESCRIPTION
## Summary
- flatten nested dictionaries when inserting into Redis
- test build-index-2 with nested metadata
- index arrays by position

## Testing
- `pytest dist/app/shell/py/pie/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688bfdabf91883218c25166318690123