### PR TITLE
Refactor docker compose invocation

### DIFF
--- a/docs/redo-mk.md
+++ b/docs/redo-mk.md
@@ -18,6 +18,8 @@ This repository actually uses three Makefiles that work together:
 
 - **`SERVICES`** – Containers started by `up`/`upd` (default: `nginx-dev sync webp`).
 - **`MAKE_CMD`** – Helper command to run the lower-level makefile inside the `shell` service.
+- **`COMPOSE_FILE`** – Compose file used by commands. Defaults to `dist/docker-compose.yml` unless a local `docker-compose.yml` exists.
+- **`DOCKER_COMPOSE`** – Shortcut for `docker compose -f $(COMPOSE_FILE)`.
 - **`VERBOSE`** – Set to `1` to print each command executed by `make` in addition to status messages.
 
 ## Common Targets


### PR DESCRIPTION
## Summary
- support overriding `docker compose` file
- document new variables `COMPOSE_FILE` and `DOCKER_COMPOSE`

## Testing
- `make -f redo.mk help | head`
- `make -f redo.mk -n up`
- `mv docker-compose.yml docker-compose.yml.tmp`
- `make -f redo.mk -n up`
- `mv docker-compose.yml.tmp docker-compose.yml`

------
https://chatgpt.com/codex/tasks/task_e_688c05df70708321870017b26fbf0316