### PR TITLE
Rename build-index-2 to update-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ build. Use `--src DIR` to search a different directory for `.yml` files and
 - [Jinja Filters](docs/jinja-filters.md)
 - [Jinja Globals](docs/jinja-globals.md)
 - [Build Index](docs/build-index.md)
+- [update-index](docs/update-index.md)
 - [Quiz Workflow](docs/quiz-workflow.md)
 - [include-filter](docs/include-filter.md)
 - [preprocess](docs/preprocess.md)

--- a/dist/app/shell/py/pie/pie/update_index.py
+++ b/dist/app/shell/py/pie/pie/update_index.py
@@ -66,17 +66,22 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(list(argv) if argv is not None else None)
 
 
+def update_redis(conn: redis.Redis, index: Mapping[str, Mapping[str, Any]]) -> None:
+    """Insert each value from *index* into *conn*."""
+    for key, value in flatten_index(index):
+        conn.set(key, value)
+        logger.debug("Inserted", key=key, value=value)
+
+
 def main(argv: Iterable[str] | None = None) -> None:
-    """Entry point for the ``build-index-2`` console script."""
+    """Entry point for the ``update-index`` console script."""
     args = parse_args(argv)
     if args.log:
         add_file_logger(args.log, level="DEBUG")
 
     index = load_index(args.index)
     r = redis.Redis(host=args.host, port=args.port, decode_responses=True)
-    for key, value in flatten_index(index):
-        r.set(key, value)
-        logger.debug("Inserted", key=key, value=value)
+    update_redis(r, index)
 
 
 if __name__ == "__main__":

--- a/dist/app/shell/py/pie/setup.py
+++ b/dist/app/shell/py/pie/setup.py
@@ -18,7 +18,7 @@ setup(
     entry_points={
         'console_scripts': [
             'build-index=pie.build_index:main',
-            'build-index-2=pie.build_index_2:main',
+            'update-index=pie.update_index:main',
             'picasso=pie.picasso:main',
             'render-jinja-template=pie.render_jinja_template:main',
             'render-study-json=pie.render_study_json:main',

--- a/dist/app/shell/py/pie/tests/test_update_index.py
+++ b/dist/app/shell/py/pie/tests/test_update_index.py
@@ -1,6 +1,6 @@
 import json
 import fakeredis
-from pie import build_index_2
+from pie import update_index
 
 
 def test_main_inserts_keys(tmp_path, monkeypatch):
@@ -18,9 +18,9 @@ def test_main_inserts_keys(tmp_path, monkeypatch):
     idx.write_text(json.dumps(index_data))
 
     fake = fakeredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(build_index_2.redis, "Redis", lambda *a, **kw: fake)
+    monkeypatch.setattr(update_index.redis, "Redis", lambda *a, **kw: fake)
 
-    build_index_2.main([str(idx)])
+    update_index.main([str(idx)])
 
     assert fake.get("quickstart.title") == "Quickstart"
     assert fake.get("quickstart.url") == "/quickstart.html"
@@ -42,9 +42,9 @@ def test_main_handles_arrays(tmp_path, monkeypatch):
     idx.write_text(json.dumps(index_data))
 
     fake = fakeredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(build_index_2.redis, "Redis", lambda *a, **kw: fake)
+    monkeypatch.setattr(update_index.redis, "Redis", lambda *a, **kw: fake)
 
-    build_index_2.main([str(idx)])
+    update_index.main([str(idx)])
 
     assert fake.get("quickstart.tags.0") == "foo"
     assert fake.get("quickstart.tags.1") == "bar"

--- a/docs/build-index.md
+++ b/docs/build-index.md
@@ -63,6 +63,9 @@ supported keys and defaults.
    - Auto-fills missing `citation` (lowercased `title`) and `id` (filename without extension).  
    - Computes URL if the file lives under `src/`.
 
-4. **Indexing**  
-   - Validates that each metadata entry has a unique `id`.  
+4. **Indexing**
+   - Validates that each metadata entry has a unique `id`.
    - Aggregates all entries into a single JSON object.
+
+Once the index is generated you can insert it into Redis with
+[`update-index`](update-index.md).

--- a/docs/update-index.md
+++ b/docs/update-index.md
@@ -1,0 +1,16 @@
+# update-index
+
+Load a JSON index and insert each value into DragonflyDB or Redis. Keys use a dot-separated format of `<id>.<property>` with nested objects and arrays flattened. Complex values are stored as JSON strings.
+
+## Usage
+
+```bash
+update-index index.json [--host HOST] [--port PORT] [-l LOGFILE]
+```
+
+- `index` path to the JSON index file
+- `--host` Redis host (default `localhost`)
+- `--port` Redis port (default `6379`)
+- `-l, --log` optional log file
+
+The command expects an index produced by [`build-index`](build-index.md). Each entry is written to the configured Redis instance using separate keys.


### PR DESCRIPTION
## Summary
- rename the `build-index-2` utility to `update-index`
- refactor Redis insertion logic
- document how to use `update-index` and link from README

## Testing
- `pip install -r dist/app/shell/py/pie/requirements.txt`
- `pip install beautifulsoup4`
- `pytest -q dist/app/shell/py/pie/tests`

------
https://chatgpt.com/codex/tasks/task_e_688c09c0265083219ff67eeb6a97d691