### PR TITLE
Move docker-compose to dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The build relies on three cooperating Makefiles:
 
 1. Run `git submodule update --init --recursive` after cloning to fetch
    required submodules such as `xmera`.
-2. Edit `docker-compose.yml`. Adjust `image` as necessary. **TODO: Examples**
+2. Edit `dist/docker-compose.yml`. Adjust `image` as necessary. **TODO: Examples**
 3. Edit `redo.mk`. Update the list of services.
 4. Edit documents under `src/`.
 5. Optionally customize `src/pandoc-template.html` for your project.
@@ -93,7 +93,7 @@ Custom filters:
 
 ## Overriding Python Modules
 
-In `docker-compose.yml`, map `./app/shell/py` to `/press/py`. Python modules are
+In `dist/docker-compose.yml`, map `./app/shell/py` to `/press/py`. Python modules are
 installed using the `-e` flag so you can edit them in place without reinstalling
 Python modules.
 

--- a/dist/docker-compose.yml
+++ b/dist/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   nginx:
     build:
-      context: .
-      dockerfile: app/nginx/Dockerfile
+      context: ..
+      dockerfile: ../app/nginx/Dockerfile
     ports:
       - "80:80"
       - "443:443"
@@ -10,42 +10,42 @@ services:
 
   nginx-dev:
     build:
-      context: .
-      dockerfile: app/nginx/Dockerfile
+      context: ..
+      dockerfile: ../app/nginx/Dockerfile
     container_name: nginx-dev
     ports:
       - "80:80"
       - "443:443"
     volumes:
       # Mount your HTML files. Adjust path to match how your config is set up.
-      - ./build:/usr/share/nginx/html
+      - ../build:/usr/share/nginx/html
 
       # Mount your custom NGINX config as /etc/nginx/conf.d/default.conf
-      # - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+      # - ../nginx/default.conf:/etc/nginx/conf.d/default.conf
 
       # If you're using certbot or any Let's Encrypt management inside/outside the container
       # - /etc/letsencrypt:/etc/letsencrypt
     restart: unless-stopped
 
   sync:
-    build: app/s3
+    build: ../app/s3
     entrypoint: ["/app/bin/sync"]
     volumes:
-      - ./s3:/s3
+      - ../s3:/s3
 
   seed:
-    build: app/s3
+    build: ../app/s3
     entrypoint: ["/app/bin/seed"]
     volumes:
-      - ./s3:/s3
+      - ../s3:/s3
 
   webp:
-    build: app/webp
+    build: ../app/webp
     entrypoint: ["/app/bin/service"]
     volumes:
-      - ./app/webp/input:/app/input
-      - ./app/webp/output:/app/output
-      - ./log:/app/log
+      - ../app/webp/input:/app/input
+      - ../app/webp/output:/app/output
+      - ../log:/app/log
 
   # Default port is 6379. Not exposed to the host to avoid port conflicts.
   # You can run redis-cli within this container.
@@ -55,14 +55,14 @@ services:
     container_name: dragonfly
 
   shell:
-    build: dist/app/shell
+    build: ./app/shell
     entrypoint: ["bash"]
     environment:
       OPENAI_API_KEY: "${OPENAI_API_KEY}"
     volumes:
-      - ./:/data
-      - ./dist/app/shell/mk:/app/mk
-      - ./dist/app/shell/bin:/app/bin
-      - ./dist/app/shell/py/pie/pie:/press/py/pie/pie
-      - ./dist/app/shell/py/pie/tests:/press/py/pie/tests
-      - ./dist/dep.mk:/app/mk/dep.mk
+      - ../:/data
+      - ./app/shell/mk:/app/mk
+      - ./app/shell/bin:/app/bin
+      - ./app/shell/py/pie/pie:/press/py/pie/pie
+      - ./app/shell/py/pie/tests:/press/py/pie/tests
+      - ./dep.mk:/app/mk/dep.mk


### PR DESCRIPTION
## Summary
- relocate compose file to `dist/docker-compose.yml`
- fix relative paths inside compose file
- update README instructions for the new compose path

## Testing
- `make -f redo.mk test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c0ae063148321a754753bbedfd3c6