### PR TITLE
Handle Markdown/YAML pairs only once

### DIFF
--- a/dist/app/shell/py/pie/pie/update_index.py
+++ b/dist/app/shell/py/pie/pie/update_index.py
@@ -140,8 +140,13 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     if path.is_dir():
         index: dict[str, dict[str, Any]] = {}
+        processed: set[Path] = set()
         for pattern in ("**/*.md", "**/*.yml", "**/*.yaml"):
             for p in path.glob(pattern):
+                base = p.with_suffix("")
+                if base in processed:
+                    continue
+                processed.add(base)
                 metadata = load_metadata_pair(p)
                 if metadata:
                     index[metadata["id"]] = metadata

--- a/dist/docs/update-index.md
+++ b/dist/docs/update-index.md
@@ -4,13 +4,13 @@ Load a JSON index and insert each value into DragonflyDB or Redis. Keys use a do
 
 ## Usage
 
-```bash
+- ```bash
 update-index index.json [--host HOST] [--port PORT] [-l LOGFILE]
 ```
 
-- `index` path to the JSON index file
+- `index` path to the JSON index file or a directory of metadata
 - `--host` Redis host (default `localhost`)
 - `--port` Redis port (default `6379`)
 - `-l, --log` optional log file
 
-The command expects an index produced by [`build-index`](build-index.md). Each entry is written to the configured Redis instance using separate keys.
+When a directory is given, `update-index` scans recursively for `.md`, `.yml`, and `.yaml` files, processing each Markdown/YAML pair only once. The command expects an index produced by [`build-index`](build-index.md). Each entry is written to the configured Redis instance using separate keys.


### PR DESCRIPTION
## Summary
- avoid duplicate processing of Markdown and YAML when a directory is given to `update-index`
- update documentation for new directory behavior
- refresh tests for generated IDs and add coverage for Markdown/YAML pairs

## Testing
- `pytest dist/app/shell/py/pie/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688c1b3ce7e88321a8c87e7da644d873