### PR TITLE
Quote linktitle inputs

### DIFF
--- a/dist/app/shell/bin/gen-markdown-index-2
+++ b/dist/app/shell/bin/gen-markdown-index-2
@@ -62,7 +62,7 @@ def process_dir(directory):
         entry_title = entry[1]
         entry_link = entry[3]
         if entry_link:
-            print("  " * level + f"- {{{{{entry_id}|linktitle}}}}")
+            print("  " * level + f"- {{{{\"{entry_id}\"|linktitle}}}}")
         else:
             print("  " * level + f"- {{{{'{entry_title}'|title}}}}")
         entry_path = entry[2]

--- a/dist/docs/jinja-filters.md
+++ b/dist/docs/jinja-filters.md
@@ -29,7 +29,7 @@ You can also use it inside YAML fragments that feed into Jinja templates:
 
 ```yaml
 toc:
-  - "{{deltoid_tuberosity|linktitle}}"
+  - "{{\"deltoid_tuberosity\"|linktitle}}"
 ```
 
 This filter lives in `pie.render_jinja_template` and is also exposed by the

--- a/dist/docs/keyterms.md
+++ b/dist/docs/keyterms.md
@@ -10,7 +10,7 @@ The canonical list of terms lives at `src/keyterms/index.json`. Each entry maps 
 {
   "abduction": {
     "term": "Abduction",
-    "def": "Movement of a limb or body part away from the midline.<br>Opposite: {{adduction|linktitle}}."
+    "def": "Movement of a limb or body part away from the midline.<br>Opposite: {{\"adduction\"|linktitle}}."
   },
   ...
 }

--- a/src/index.md
+++ b/src/index.md
@@ -25,7 +25,7 @@
 {{press_io_home|link}}
 
 ## Quiz Example
-{{quiz|linktitle}}
+{{"quiz"|linktitle}}
 
 ## include-filter example
 


### PR DESCRIPTION
## Summary
- quote arguments for `linktitle` filter across docs and scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c204389148321a81100ef2daf7aab