### PR TITLE
Document and standardize Redis defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ ls app/webp/output
 See [dist/docs/webp-service.md](dist/docs/webp-service.md) for more about how the
 converter works.
 
+## Redis Configuration
+
+The build tools connect to DragonflyDB/Redis using the `REDIS_HOST` and
+`REDIS_PORT` environment variables. These default to `dragonfly` and `6379`
+respectively when not set.
+
 ## Wish List
 
 - May need a wizard

--- a/dist/app/shell/mk/build.mk
+++ b/dist/app/shell/mk/build.mk
@@ -23,6 +23,12 @@ endif
 # Helper to print status messages
 status = @echo "==> $(1)"
 
+# Redis connection settings
+REDIS_HOST ?= dragonfly
+REDIS_PORT ?= 6379
+export REDIS_HOST
+export REDIS_PORT
+
 # Define the Pandoc command used inside the container
 #       -T: Don't allocate pseudo-tty. Makes parallel builds work.
 # For container setup details, see dist/docs/docker-make.md.
@@ -78,7 +84,7 @@ all: | build $(BUILD_SUBDIRS)
 all: $(HTMLS)
 all: $(CSS)
 all: build/static/index.json
-	update-index --host dragonfly --log=log/update-index src
+	update-index --host $(REDIS_HOST) --port $(REDIS_PORT) --log=log/update-index src
 
 .PRECIOUS: build/static/index.json
 # See dist/docs/build-index.md for how the index is generated.

--- a/dist/app/shell/py/pie/pie/render_jinja_template.py
+++ b/dist/app/shell/py/pie/pie/render_jinja_template.py
@@ -32,7 +32,7 @@ def _get_redis_value(key: str):
 
     global redis_conn
     if redis_conn is None:
-        host = os.getenv("REDIS_HOST", "localhost")
+        host = os.getenv("REDIS_HOST", "dragonfly")
         port = int(os.getenv("REDIS_PORT", "6379"))
         redis_conn = redis.Redis(host=host, port=port, decode_responses=True)
     try:

--- a/dist/app/shell/py/pie/pie/update_index.py
+++ b/dist/app/shell/py/pie/pie/update_index.py
@@ -9,6 +9,7 @@ inserts each value into a Redis compatible database using keys of the form
 from __future__ import annotations
 
 import argparse
+import os
 import json
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -110,14 +111,14 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     parser.add_argument("-l", "--log", help="Write logs to the specified file")
     parser.add_argument(
         "--host",
-        default="localhost",
-        help="Redis host (default: localhost)",
+        default=os.getenv("REDIS_HOST", "dragonfly"),
+        help="Redis host (default: env REDIS_HOST or 'dragonfly')",
     )
     parser.add_argument(
         "--port",
         type=int,
-        default=6379,
-        help="Redis port (default: 6379)",
+        default=int(os.getenv("REDIS_PORT", "6379")),
+        help="Redis port (default: env REDIS_PORT or 6379)",
     )
     return parser.parse_args(list(argv) if argv is not None else None)
 

--- a/dist/docs/update-index.md
+++ b/dist/docs/update-index.md
@@ -9,8 +9,11 @@ update-index index.json [--host HOST] [--port PORT] [-l LOGFILE]
 ```
 
 - `index` path to the JSON index file or a directory of metadata
-- `--host` Redis host (default `localhost`)
-- `--port` Redis port (default `6379`)
+- `--host` Redis host (default `dragonfly` or `$REDIS_HOST`)
+- `--port` Redis port (default `6379` or `$REDIS_PORT`)
 - `-l, --log` optional log file
+
+`update-index` also reads the `REDIS_HOST` and `REDIS_PORT` environment
+variables when `--host` or `--port` are not specified.
 
 When a directory is given, `update-index` scans recursively for `.md`, `.yml`, and `.yaml` files, processing each Markdown/YAML pair only once. The command expects an index produced by [`build-index`](build-index.md). Each entry is written to the configured Redis instance using separate keys.


### PR DESCRIPTION
## Summary
- use `REDIS_HOST` and `REDIS_PORT` in build scripts
- default host is `dragonfly`
- document Redis environment variables
- update `update-index` arguments
- fix Makefile tab

## Testing
- `pytest dist/app/shell/py/pie/tests`

------
https://chatgpt.com/codex/tasks/task_e_688c2088fee4832193de1602c713c8c9