### PR TITLE
Use redis metadata in render_jinja_template

### DIFF
--- a/dist/app/shell/py/pie/requirements.txt
+++ b/dist/app/shell/py/pie/requirements.txt
@@ -2,3 +2,5 @@ PyYAML
 loguru
 redis
 fakeredis
+flatten-dict
+beautifulsoup4

--- a/dist/app/shell/py/pie/tests/test_render_template.py
+++ b/dist/app/shell/py/pie/tests/test_render_template.py
@@ -51,11 +51,10 @@ def test_linktitle_uses_redis(monkeypatch):
     assert ">Item<" in html
 
 
-def test_linktitle_fallback_index(monkeypatch):
+def test_linktitle_missing_raises(monkeypatch):
     fake = fakeredis.FakeRedis(decode_responses=True)
     monkeypatch.setattr(render_template, "redis_conn", fake)
-    render_template.index_json = {"foo": {"citation": "Foo", "url": "/f"}}
+    render_template.index_json = {}
 
-    with pytest.warns(UserWarning):
-        html = render_template.linktitle("foo")
-    assert '<a href="/f"' in html
+    with pytest.raises(SystemExit):
+        render_template.linktitle("foo")


### PR DESCRIPTION
## Summary
- pull all metadata from Redis for Jinja helpers
- stop falling back to index.json and exit on missing data
- support nested Redis keys via new helper functions
- update requirements and tests

## Testing
- `pytest dist/app/shell/py/pie/tests/test_render_template.py -q`
- `pytest dist/app/shell/py/pie/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688c22602c848321b603dd0c575907d3