### PR TITLE
Remove build/static index.json usage

### DIFF
--- a/dist/app/shell/bin/preprocess
+++ b/dist/app/shell/bin/preprocess
@@ -21,8 +21,8 @@ process_file() {
         include-filter build "$input" "$output"
     done
 
-    # Render links
-    render-jinja-template build/static/index.json "$output" > "$output.$$"
+    # Render links using metadata from Redis
+    render-jinja-template "$output" > "$output.$$"
     mv "$output.$$" "$output"
     if [ $DEBUG -eq 1 ]; then cat "$output"; fi
 

--- a/dist/app/shell/mk/build.mk
+++ b/dist/app/shell/mk/build.mk
@@ -83,14 +83,8 @@ CSS := $(patsubst src/%.css,build/%.css, $(CSS))
 all: | build $(BUILD_SUBDIRS)
 all: $(HTMLS)
 all: $(CSS)
-all: build/static/index.json
 	update-index --host $(REDIS_HOST) --port $(REDIS_PORT) --log=log/update-index src
 
-.PRECIOUS: build/static/index.json
-# See dist/docs/build-index.md for how the index is generated.
-build/static/index.json: $(MARKDOWNS) $(YAMLS) | build/static
-	$(call status,Build index $@)
-	$(Q)build-index src -o $@ --log log/build-index
 
 # Target to minify HTML and CSS files
 # Modifies file timestamps. The preserve option doesn't seem to work.
@@ -122,7 +116,7 @@ build/%.css: %.css | build
 
 # Include and preprocess Markdown files up to three levels deep
 # See dist/docs/preprocess.md for preprocessing details
-build/%.md: %.md build/static/index.json | build
+build/%.md: %.md | build
 	$(call status,Preprocess $<)
 	$(Q)preprocess $<
 

--- a/dist/app/shell/py/pie/pie/render_jinja_template.py
+++ b/dist/app/shell/py/pie/pie/render_jinja_template.py
@@ -4,7 +4,7 @@
 
 This module exposes a set of Jinja2 filters and global functions used by the
 press build scripts.  It can also be executed as a small CLI to render a
-template using variables loaded from ``index.json``.
+template. Metadata is loaded from Redis and an optional ``index.json`` file.
 """
 
 import json
@@ -399,10 +399,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
 
     parser = argparse.ArgumentParser(
-        description="Render a template using variables from an index JSON file",
+        description="Render a template using metadata from Redis and an optional index file",
     )
-    parser.add_argument("index", help="Path to index.json")
     parser.add_argument("template", help="Template file to render")
+    parser.add_argument(
+        "-i",
+        "--index",
+        help="Optional path to index.json",
+    )
     parser.add_argument(
         "-l",
         "--log",
@@ -412,7 +416,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> None:
-    """Render the specified template using variables from ``index.json``."""
+    """Render the specified template using Redis and an optional ``index.json``."""
 
     global index_json
     args = parse_args(argv)
@@ -420,7 +424,7 @@ def main(argv: list[str] | None = None) -> None:
     if args.log:
         add_file_logger(args.log, level="DEBUG")
 
-    index_json = read_json(args.index)
+    index_json = read_json(args.index) if args.index else {}
     template = env.get_template(args.template)
     print(template.render(**index_json))
 

--- a/dist/docs/preprocess.md
+++ b/dist/docs/preprocess.md
@@ -15,8 +15,8 @@ Each input file is processed in place:
 
 1. **Expand includes** – `include-filter` runs three times to resolve nested
    `include()` blocks and render Mermaid diagrams.
-2. **Render links** – `render-jinja-template build/static/index.json` converts
-   special link syntax using the build index.
+2. **Render links** – `render-jinja-template` converts special link syntax
+   using metadata from Redis.
 3. **Emoji conversion** – `emojify` replaces `:emoji:` codes with Unicode
    characters.
 
@@ -25,7 +25,7 @@ Each input file is processed in place:
 `dist/app/shell/mk/build.mk` invokes `preprocess` when building `.md` targets:
 
 ```make
-build/%.md: %.md build/static/index.json | build
+build/%.md: %.md | build
     preprocess $<
 ```
 


### PR DESCRIPTION
## Summary
- drop the build/static/index.json dependency
- adjust preprocess script to run render-jinja-template without the index
- make `render-jinja-template` accept optional `--index`
- update docs and build rules accordingly
- fix Makefile tab indentation

## Testing
- `pytest dist/app/shell/py/pie/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688c260a69a88321992b99ed6c9e927b