### PR TITLE
Enhance picasso with link dependencies

### DIFF
--- a/dist/app/shell/py/pie/pie/picasso.py
+++ b/dist/app/shell/py/pie/pie/picasso.py
@@ -8,9 +8,11 @@ parameters or command–line arguments.
 """
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
+import yaml
 from pie.utils import add_file_logger, logger
 
 
@@ -43,15 +45,94 @@ def generate_rule(
     preprocessed_md = (build_root / relative.with_suffix(".md")).as_posix()
     preprocessed_yml = (build_root / relative.with_suffix(".yml")).as_posix()
 
-    return f"""
-{preprocessed_yml}: {input_path}
-	$(Q)mkdir -p $(dir {preprocessed_yml})
-	$(Q)emojify < $< > $@
-	$(Q)process-yaml $< $@
-{output_html}: {preprocessed_md} {preprocessed_yml}
-	$(Q)$(PANDOC_CMD) $(PANDOC_OPTS) --metadata-file={preprocessed_yml} -o $@ $<
-	$(Q)python3 -m pie.error_on_python_dict $@
-"""
+    return (
+        f"\n"
+        f"{preprocessed_yml}: {input_path}\n"
+        f"\t$(Q)mkdir -p $(dir {preprocessed_yml})\n"
+        f"\t$(Q)emojify < $< > $@\n"
+        f"\t$(Q)process-yaml $< $@\n"
+        f"{output_html}: {preprocessed_md} {preprocessed_yml}\n"
+        f"\t$(Q)$(PANDOC_CMD) $(PANDOC_OPTS) --metadata-file={preprocessed_yml} -o $@ $<\n"
+        f"\t$(Q)python3 -m pie.error_on_python_dict $@"
+    )
+
+
+LINK_RE = re.compile(r"\{\{\s*[\"']([^\"']+)[\"']\s*\|\s*link[\w]*")
+
+
+def collect_ids(src_root: Path) -> dict[str, Path]:
+    """Return a mapping of metadata ``id`` values to source files."""
+
+    id_map: dict[str, Path] = {}
+
+    for path in src_root.rglob("*"):
+        if path.suffix.lower() in {".md", ".yml", ".yaml"}:
+            doc_id = None
+            try:
+                if path.suffix.lower() == ".md":
+                    with open(path, "r", encoding="utf-8") as f:
+                        lines = f.readlines()
+                    if lines and lines[0].strip() == "---":
+                        y = []
+                        for line in lines[1:]:
+                            if line.strip() == "---":
+                                break
+                            y.append(line)
+                        data = yaml.safe_load("".join(y)) or {}
+                        if isinstance(data, dict):
+                            doc_id = data.get("id")
+                else:
+                    with open(path, "r", encoding="utf-8") as f:
+                        data = yaml.safe_load(f) or {}
+                        if isinstance(data, dict):
+                            doc_id = data.get("id")
+            except Exception:
+                logger.warning("Failed to parse metadata", file=str(path))
+
+            if not doc_id:
+                doc_id = path.stem
+
+            id_map[doc_id] = path
+
+    return id_map
+
+
+def generate_dependencies(src_root: Path, build_root: Path) -> list[str]:
+    """Return Makefile dependency rules based on Jinja link references."""
+
+    id_map = collect_ids(src_root)
+    rules: set[str] = set()
+
+    def build_path(p: Path) -> str:
+        rel = p.relative_to(src_root)
+        out = build_root / rel
+        if build_root.is_absolute():
+            out = Path(build_root.name) / rel
+        return out.as_posix()
+
+    for path in src_root.rglob("*"):
+        if path.suffix.lower() not in {".md", ".yml", ".yaml"}:
+            continue
+
+        try:
+            text = path.read_text(encoding="utf-8")
+        except Exception:
+            logger.warning("Failed to read file", file=str(path))
+            continue
+
+        matches = LINK_RE.findall(text)
+        if not matches:
+            continue
+
+        src_build = Path(build_path(path)).with_suffix(path.suffix)
+        for ref_id in matches:
+            ref_path = id_map.get(ref_id)
+            if ref_path is None:
+                continue
+            dep_build = Path(build_path(ref_path)).with_suffix(ref_path.suffix)
+            rules.add(f"{src_build.as_posix()}: {dep_build.as_posix()}")
+
+    return sorted(rules)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -93,6 +174,9 @@ def main(argv: list[str] | None = None) -> None:
 
     for yml_file in src_root.rglob("*.yml"):
         print(generate_rule(yml_file, src_root=src_root, build_root=build_root))
+
+    for rule in generate_dependencies(src_root, build_root):
+        print(rule)
 
 
 if __name__ == "__main__":

--- a/dist/app/shell/py/pie/tests/test_picasso.py
+++ b/dist/app/shell/py/pie/tests/test_picasso.py
@@ -39,3 +39,19 @@ def test_main_writes_log_file(tmp_path):
     picasso.main(["--src", str(src), "--build", str(build), "--log", str(log)])
 
     assert log.exists()
+
+
+def test_generate_dependencies(tmp_path):
+    src = tmp_path / "src"
+    build = tmp_path / "build"
+    src.mkdir()
+
+    quick = src / "quickstart.md"
+    quick.write_text("---\nid: quickstart\n---\nbody")
+
+    index = src / "index.md"
+    index.write_text('{{"quickstart"|link}}')
+
+    deps = picasso.generate_dependencies(src, build)
+
+    assert deps == ["build/index.md: build/quickstart.md"]


### PR DESCRIPTION
## Summary
- extend `picasso` to track Jinja link references
- output Makefile dependency rules based on those links
- test link dependency detection

## Testing
- `pytest dist/app/shell/py/pie/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688c40abc7ac83218c62f38aacec0a53