### PR TITLE
Update picasso dependency tracking

### DIFF
--- a/dist/app/shell/py/pie/tests/test_picasso.py
+++ b/dist/app/shell/py/pie/tests/test_picasso.py
@@ -55,3 +55,19 @@ def test_generate_dependencies(tmp_path):
     deps = picasso.generate_dependencies(src, build)
 
     assert deps == ["build/index.md: build/quickstart.md"]
+
+
+def test_dependencies_from_include_filter(tmp_path):
+    src = tmp_path / "src"
+    build = tmp_path / "build"
+    src.mkdir()
+
+    inc = src / "inc.md"
+    inc.write_text("body")
+
+    main = src / "index.md"
+    main.write_text("```python\ninclude('src/inc.md')\n```\n")
+
+    deps = picasso.generate_dependencies(src, build)
+
+    assert deps == ["build/index.md: build/inc.md"]

--- a/dist/docs/picasso.md
+++ b/dist/docs/picasso.md
@@ -36,3 +36,8 @@ build/index.html: build/index.md build/index.yml
 
 Each `.yml` file produces similar targets for preprocessing the metadata and
 rendering the final HTML.
+
+The command also inspects Markdown files for cross-document links and any
+`include-filter` Python blocks.  Dependencies discovered this way are emitted as
+additional Makefile rules so that updates to referenced files trigger a rebuild
+of the including document.


### PR DESCRIPTION
## Summary
- update `picasso` docstring
- detect `include-filter` blocks in `picasso` dependency generator
- document new behaviour in `picasso` docs
- test dependency generation for `include()` calls

## Testing
- `pytest dist/app/shell/py/pie/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdd561e648321a2a3372d3e523ff7