### PR TITLE
Add include_deflist_entry demo

### DIFF
--- a/dist/docs/include-filter.md
+++ b/dist/docs/include-filter.md
@@ -18,8 +18,20 @@ include-filter <output-dir> <input> <output>
 Within fenced `python` blocks the following functions are available:
 
 - `include(path)` – insert another Markdown file and adjust heading levels
+- `include_deflist_entry(path)` – insert a Markdown file as a definition list
+  entry using its `title` metadata for the term
 - `mermaid(file, alt, id)` – convert a Mermaid code block into an image using
   `mmdc` and emit a Markdown image link
+
+Example:
+
+```markdown
+<dl>
+```python
+include_deflist_entry("src/dist/include-filter/a.md")
+```
+</dl>
+```
 
 Any links ending with `.md` are automatically rewritten to point at the
 corresponding `.html` file.

--- a/src/dist/include-filter/b.md
+++ b/src/dist/include-filter/b.md
@@ -1,0 +1,7 @@
+---
+title: b
+---
+b is the second letter of the English alphabet.
+
+It represents the voiced bilabial stop in English and traces its lineage back
+to the Phoenician letter *beth*.

--- a/src/dist/include-filter/index.md
+++ b/src/dist/include-filter/index.md
@@ -1,5 +1,6 @@
 <dl>
 ```python
 include_deflist_entry("src/dist/include-filter/a.md")
+include_deflist_entry("src/dist/include-filter/b.md")
 ```
 </dl>

--- a/src/index.md
+++ b/src/index.md
@@ -63,3 +63,14 @@ time.
 ```python
 include("build/static/index/dist.md")
 ```
+
+## include_deflist_entry demo
+
+This variant inserts another Markdown file as a definition list entry:
+
+<dl>
+```python
+include_deflist_entry("src/dist/include-filter/a.md")
+include_deflist_entry("src/dist/include-filter/b.md")
+```
+</dl>


### PR DESCRIPTION
## Summary
- demonstrate include_deflist_entry in docs and index page
- add second Markdown entry for demo
- include multiple paragraphs in `include-filter/b.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cead978d08321885f03423cae700a