### PR TITLE
Add retry to _load_desc lookups

### DIFF
--- a/dist/app/shell/py/pie/pie/render_jinja_template.py
+++ b/dist/app/shell/py/pie/pie/render_jinja_template.py
@@ -12,6 +12,7 @@ import os
 import re
 import sys
 import argparse
+import time
 
 import redis
 from flatten_dict import unflatten
@@ -104,7 +105,12 @@ def _load_desc(desc):
     """Return a metadata dict for ``desc`` using Redis lookups when needed."""
 
     if isinstance(desc, str):
-        data = _get_metadata(desc)
+        data = None
+        for _ in range(3):
+            data = _get_metadata(desc)
+            if data is not None:
+                break
+            time.sleep(0.5)
         if data is None:
             logger.error("Missing metadata", id=desc)
             raise SystemExit(1)

--- a/dist/docs/jinja-filters.md
+++ b/dist/docs/jinja-filters.md
@@ -35,6 +35,10 @@ toc:
 This filter lives in `pie.render_jinja_template` and is also exposed by the
 `render-jinja-template` command.
 
+When you pass a string instead of a dictionary, the filters fetch the
+corresponding metadata from Redis. The lookup now retries a few times before
+aborting so templates are more resilient when entries are added concurrently.
+
 ## `linkcap`
 
 `linkcap` capitalizes only the first character of the `citation` text. It uses


### PR DESCRIPTION
## Summary
- make `_load_desc` more robust by retrying metadata lookups
- document the retry behaviour in the Jinja filters docs

## Testing
- `pytest dist/app/shell/py/pie/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0991fa408321988a2abaa43fa781