### PR TITLE
Update linktitle word capitalization

### DIFF
--- a/dist/app/shell/py/pie/pie/render_jinja_template.py
+++ b/dist/app/shell/py/pie/pie/render_jinja_template.py
@@ -172,7 +172,7 @@ def linktitle(desc):
 
     def cap_match(m):
         word = m.group(1)
-        if word in ("of",):
+        if word.lower() in {"of", "in", "a", "an"}:
             return word
         return word[0].upper() + word[1:]
 

--- a/dist/app/shell/py/pie/tests/test_render_template.py
+++ b/dist/app/shell/py/pie/tests/test_render_template.py
@@ -58,3 +58,10 @@ def test_linktitle_missing_raises(monkeypatch):
 
     with pytest.raises(SystemExit):
         render_template.linktitle("foo")
+
+
+def test_linktitle_skips_small_words():
+    desc = {"citation": "movement in a circle", "url": "/c"}
+    html = render_template.linktitle(desc)
+    assert ">Movement in a Circle<" in html
+

--- a/dist/docs/jinja-filters.md
+++ b/dist/docs/jinja-filters.md
@@ -9,9 +9,10 @@ these metadata fields, see [Metadata Fields](metadata-fields.md).
 
 ## `linktitle`
 
-`linktitle` capitalizes the first character of **each** word in the
-`citation` field. It returns an HTML `<a>` element using the supplied
-`url` and optional `icon`, `link.class`, or `link.tracking` fields.
+`linktitle` capitalizes the first character of each word in the
+`citation` field, except for short words like `in`, `a`, `an`, and `of`.
+It returns an HTML `<a>` element using the supplied `url` and optional
+`icon`, `link.class`, or `link.tracking` fields.
 
 Example:
 


### PR DESCRIPTION
## Summary
- avoid capitalizing common small words in `linktitle`
- clarify documentation for `linktitle`
- test that `linktitle` skips certain words when title-casing

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest dist/app/shell/py/pie -q`

------
https://chatgpt.com/codex/tasks/task_e_688d14e70fb08321958d9b0a6f8feb28