### PR TITLE
feat: expand include_deflist_entry

### DIFF
--- a/dist/docs/include-filter.md
+++ b/dist/docs/include-filter.md
@@ -18,8 +18,11 @@ include-filter <output-dir> <input> <output>
 Within fenced `python` blocks the following functions are available:
 
 - `include(path)` – insert another Markdown file and adjust heading levels
-- `include_deflist_entry(path)` – insert a Markdown file as a definition list
-  entry using its `title` metadata for the term
+- `include_deflist_entry(*paths, glob='*', sort_fn=None)` – insert Markdown
+  files as definition list entries using their `title` metadata.  Each argument
+  may be a file or directory.  Directories are searched recursively for files
+  matching `glob` and processed in alphabetical order by default.  A custom
+  `sort_fn` can be provided to override the ordering.
 - `mermaid(file, alt, id)` – convert a Mermaid code block into an image using
   `mmdc` and emit a Markdown image link
 
@@ -28,7 +31,7 @@ Example:
 ```markdown
 <dl>
 ```python
-include_deflist_entry("src/dist/include-filter/a.md")
+include_deflist_entry("src/dist/include-filter", glob="*.md")
 ```
 </dl>
 ```

--- a/src/dist/include-filter/index.md
+++ b/src/dist/include-filter/index.md
@@ -1,6 +1,5 @@
 <dl>
 ```python
-include_deflist_entry("src/dist/include-filter/a.md")
-include_deflist_entry("src/dist/include-filter/b.md")
+include_deflist_entry("src/dist/include-filter", glob="*.md")
 ```
 </dl>

--- a/src/examples/include-filter.md
+++ b/src/examples/include-filter.md
@@ -21,8 +21,7 @@ This variant inserts another Markdown file as a definition list entry:
 
 <dl>
 ```python
-include_deflist_entry("src/dist/include-filter/a.md")
-include_deflist_entry("src/dist/include-filter/b.md")
+include_deflist_entry("src/dist/include-filter", glob="*.md")
 ```
 </dl>
 


### PR DESCRIPTION
## Summary
- allow include_deflist_entry to accept multiple files or directories
- document new arguments for include_deflist_entry
- support multiple include paths in dependency generator

## Testing
- `python -m py_compile dist/app/shell/py/pie/pie/include_filter.py dist/app/shell/py/pie/pie/picasso.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_688e84e144fc8321b604175a39ed863e