### PR TITLE
Add architecture overview

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,39 @@
+# Architecture
+
+## Overview
+Press is a static-site generator that wraps Pandoc tooling in a containerized build and runtime environment. Docker Compose services and Makefiles coordinate building Markdown content into HTML or PDF and serving the generated site.
+
+## Repository Layout
+- `src/` – markdown sources, templates, and static assets.
+- `dist/` – Dockerfiles, docker-compose templates, and build scripts used inside containers.
+- `bin/` – host-side helper scripts for container management.
+- `cfg/` – configuration files used during validation tasks.
+
+## Orchestration
+The top-level Makefile (`redo.mk`) drives all host-side automation. It launches required services and executes the inner build Makefile within the shell container:
+
+- The default goal starts `dragonfly` and invokes `/app/mk/build.mk` inside the shell container to render the site.
+- A `test` target reruns the build's own tests from the host environment.
+
+## Services
+`dist/docker-compose.yml` defines the container stack used by Press:
+
+- `nginx` and `nginx-dev` serve generated content.
+- `shell` provides the build environment and exposes tools and tests.
+- `dragonfly` supplies a Redis-compatible store used for tracking document metadata.
+- Auxiliary services `sync`, `seed`, and `webp` handle S3 uploads, database seeding, and WebP image conversion.
+
+## Build Pipeline
+The shell container executes `dist/app/shell/mk/build.mk` to transform sources into deliverables:
+
+1. Discover Markdown and YAML files and update a Redis-backed index.
+2. Convert preprocessed Markdown to HTML and PDF using Pandoc with a shared template and options for table of contents, math rendering, and cross references.
+3. Copy CSS assets and minify the resulting site.
+4. Run link checking and page title validation before marking the build complete.
+
+## Data Flow
+Source files in `src/` become processed artifacts in `build/`. The development `nginx-dev` service mounts the build directory for local preview, while production content can be synchronized or served by `nginx`.
+
+## Testing
+Python utilities that support the build live under `dist/app/shell/py/pie`. Unit tests for these helpers execute with `pytest` via the host Makefile or directly inside the shell container.
+


### PR DESCRIPTION
## Summary
- document the project's architecture, including repo layout, orchestration, services, and build pipeline

## Testing
- `python -m pytest dist/app/shell/py/pie/tests`


------
https://chatgpt.com/codex/tasks/task_e_689210834c68832190a3a2525f780d93