### PR TITLE
Rename process_yaml helper

### DIFF
--- a/dist/app/shell/py/pie/pie/build_index.py
+++ b/dist/app/shell/py/pie/pie/build_index.py
@@ -90,7 +90,7 @@ def process_markdown(filepath: str) -> Optional[Dict[str, Any]]:
     return metadata
 
 
-def process_yaml(filepath: str) -> Optional[Dict[str, Any]]:
+def parse_yaml_metadata(filepath: str) -> Optional[Dict[str, Any]]:
     """
     Load and validate metadata from a YAML file.
 
@@ -190,7 +190,7 @@ def build_index(source_dir: str, file_pattern: str = "**/*.md") -> Dict[str, Any
         if ext_lower == ".md":
             metadata = process_markdown(filepath)
         elif ext_lower in (".yml", ".yaml"):
-            metadata = process_yaml(filepath)
+            metadata = parse_yaml_metadata(filepath)
         else:
             # Skip files that are neither Markdown nor YAML
             continue

--- a/dist/app/shell/py/pie/pie/process_yaml.py
+++ b/dist/app/shell/py/pie/pie/process_yaml.py
@@ -34,7 +34,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         add_file_logger(args.log, level="DEBUG")
 
     try:
-        metadata = build_index.process_yaml(args.input)
+        metadata = build_index.parse_yaml_metadata(args.input)
     except Exception as exc:  # pragma: no cover - pass through message
         logger.error("Failed to process YAML", filename=args.input)
         raise SystemExit(1) from exc

--- a/dist/app/shell/py/pie/pie/update_index.py
+++ b/dist/app/shell/py/pie/pie/update_index.py
@@ -70,10 +70,10 @@ def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
     yaml_file: Path | None = None
     if yml_path.exists():
         yaml_file = yml_path
-        yaml_data = build_index.process_yaml(str(yml_path))
+        yaml_data = build_index.parse_yaml_metadata(str(yml_path))
     elif yaml_path.exists():
         yaml_file = yaml_path
-        yaml_data = build_index.process_yaml(str(yaml_path))
+        yaml_data = build_index.parse_yaml_metadata(str(yaml_path))
 
     if md_data is None and yaml_data is None:
         return None

--- a/dist/app/shell/py/pie/tests/test_build_index.py
+++ b/dist/app/shell/py/pie/tests/test_build_index.py
@@ -40,13 +40,13 @@ def test_process_markdown_parses_frontmatter(tmp_path):
     assert data == {"title": "T", "url": "/doc.html"}
 
 
-def test_process_yaml_generates_fields(tmp_path):
+def test_parse_yaml_metadata_generates_fields(tmp_path):
     yml = tmp_path / "src" / "item.yml"
     yml.parent.mkdir(parents=True)
     yml.write_text('{"name": "Foo"}')
     os.chdir(tmp_path)
     try:
-        data = build_index.process_yaml("src/item.yml")
+        data = build_index.parse_yaml_metadata("src/item.yml")
     finally:
         os.chdir("/tmp")
     assert data["name"] == "Foo"

--- a/dist/docs/link-metadata.md
+++ b/dist/docs/link-metadata.md
@@ -42,7 +42,7 @@ link:
 
 ## How IDs Are Generated
 
-During indexing, `process_yaml` from `pie.build_index` loads the file and assigns an `id` if it is absent:
+During indexing, `parse_yaml_metadata` from `pie.build_index` loads the file and assigns an `id` if it is absent:
 
 ```
 base, _ = os.path.splitext(filepath)

--- a/dist/docs/metadata-fields.md
+++ b/dist/docs/metadata-fields.md
@@ -28,7 +28,7 @@ During indexing, `build_index.py` fills in several fields when they are missing:
 | `url`      | Derived from the source path (e.g. `src/foo.md` → `/foo.html`) |
 
 The `citation` value is used as the anchor text when other pages link to this document using Jinja filters such as `linktitle`.
-The helper that assigns these defaults lives in `process_yaml` within `pie.build_index`.
+The helper that assigns these defaults lives in `parse_yaml_metadata` within `pie.build_index`.
 
 `link.tracking` defaults to `true`, meaning links open in the same tab. `link.class` defaults to `internal-link`.
 


### PR DESCRIPTION
## Summary
- rename `process_yaml` to `parse_yaml_metadata`
- update references and docs

## Testing
- `pip install -r dist/app/shell/py/pie/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921bf36f5c8321bd997fada9e7d0ae