### PR TITLE
feat: add flexible link rendering filter

### DIFF
--- a/dist/app/shell/py/pie/pie/gen_markdown_index.py
+++ b/dist/app/shell/py/pie/pie/gen_markdown_index.py
@@ -24,7 +24,9 @@ def generate_lines(index: Mapping[str, Mapping[str, str]]) -> List[str]:
         link = item.get("link")
         if isinstance(link, dict) and "tracking" in link:
             desc["link"] = {"tracking": link["tracking"]}
-        snippet = "{{ " + json.dumps(desc, ensure_ascii=False) + " | linktitle }}"
+        snippet = (
+            "{{ " + json.dumps(desc, ensure_ascii=False) + " | link(style='title') }}"
+        )
         lines.append(f"- {snippet}")
     return lines
 

--- a/dist/app/shell/py/pie/tests/test_gen_markdown_index.py
+++ b/dist/app/shell/py/pie/tests/test_gen_markdown_index.py
@@ -24,11 +24,13 @@ def test_generate_lines_sorted_and_icon():
         "url": "/b",
     }
     expected_lines = [
-        "- {{ " + json.dumps(expected_a, ensure_ascii=False) + " | linktitle }}",
-        "- {{ " + json.dumps(expected_b, ensure_ascii=False) + " | linktitle }}",
+        "- {{ "
+        + json.dumps(expected_a, ensure_ascii=False)
+        + " | link(style='title') }}",
+        "- {{ " + json.dumps(expected_b, ensure_ascii=False) + " | link(style='title') }}",
     ]
-    # - {{ {"citation": "Alpha", "url": "/a", "icon": "*", "link": {"tracking": false}} | linktitle }}
-    # - {{ {"citation": "Beta", "url": "/b"} | linktitle }}
+    # - {{ {"citation": "Alpha", "url": "/a", "icon": "*", "link": {"tracking": false}} | link(style='title') }}
+    # - {{ {"citation": "Beta", "url": "/b"} | link(style='title') }}
     assert lines == expected_lines
 
 
@@ -46,8 +48,10 @@ def test_main_outputs_lines(tmp_path, capsys):
     gen_markdown_index.main([str(path)])
     out = capsys.readouterr().out.strip()
     desc = {"citation": "Foo", "url": "/foo", "link": {"tracking": False}}
-    expected = "- {{ " + json.dumps(desc, ensure_ascii=False) + " | linktitle }}"
-    # - {{ {"citation": "Foo", "url": "/foo", "link": {"tracking": false}} | linktitle }}
+    expected = (
+        "- {{ " + json.dumps(desc, ensure_ascii=False) + " | link(style='title') }}"
+    )
+    # - {{ {"citation": "Foo", "url": "/foo", "link": {"tracking": false}} | link(style='title') }}
     assert out == expected
 
 

--- a/dist/app/shell/py/pie/tests/test_render_template.py
+++ b/dist/app/shell/py/pie/tests/test_render_template.py
@@ -5,13 +5,13 @@ from pie import render_jinja_template as render_template
 
 def test_default_class():
     desc = {"citation": "foo", "url": "/f"}
-    html = render_template.linktitle(desc)
+    html = render_template.render_link(desc, style="title")
     assert 'class="internal-link"' in html
 
 
 def test_override_class():
     desc = {"citation": "foo", "url": "/f", "link": {"class": "external"}}
-    html = render_template.linktitle(desc)
+    html = render_template.render_link(desc, style="title")
     assert 'class="external"' in html
 
 
@@ -46,7 +46,7 @@ def test_linktitle_uses_redis(monkeypatch):
     monkeypatch.setattr(render_template, "redis_conn", fake)
     render_template.index_json = {}
 
-    html = render_template.linktitle("item")
+    html = render_template.render_link("item", style="title")
     assert '<a href="/i"' in html
     assert ">Item<" in html
 
@@ -57,12 +57,12 @@ def test_linktitle_missing_raises(monkeypatch):
     render_template.index_json = {}
 
     with pytest.raises(SystemExit):
-        render_template.linktitle("foo")
+        render_template.render_link("foo", style="title")
 
 
 def test_linktitle_skips_small_words():
     desc = {"citation": "movement in a circle", "url": "/c"}
-    html = render_template.linktitle(desc)
+    html = render_template.render_link(desc, style="title")
     assert ">Movement in a Circle<" in html
 
 
@@ -75,7 +75,7 @@ def test_link_uses_redis_tracking_and_ignores_icon(monkeypatch):
     monkeypatch.setattr(render_template, "redis_conn", fake)
     render_template.index_json = {}
 
-    html = render_template.link("entry")
+    html = render_template.render_link("entry", use_icon=False)
     assert '<a href="/link"' in html
     assert 'link text' in html
     assert 'ICON' not in html
@@ -91,7 +91,7 @@ def test_linkcap_includes_icon_and_capitalizes(monkeypatch):
     monkeypatch.setattr(render_template, "redis_conn", fake)
     render_template.index_json = {}
 
-    html = render_template.linkcap("entry")
+    html = render_template.render_link("entry", style="cap")
     assert 'ICON Foo bar' in html
     assert 'Foo Bar' not in html
     assert 'rel="noopener noreferrer" target="_blank"' in html
@@ -106,7 +106,7 @@ def test_linkicon_includes_icon_without_capitalization(monkeypatch):
     monkeypatch.setattr(render_template, "redis_conn", fake)
     render_template.index_json = {}
 
-    html = render_template.linkicon("entry")
+    html = render_template.render_link("entry")
     assert 'ICON foo bar' in html
     assert 'Foo bar' not in html
     assert 'rel="noopener noreferrer" target="_blank"' in html
@@ -121,7 +121,7 @@ def test_link_icon_title_capitalizes_each_word_and_includes_icon(monkeypatch):
     monkeypatch.setattr(render_template, "redis_conn", fake)
     render_template.index_json = {}
 
-    html = render_template.link_icon_title("entry")
+    html = render_template.render_link("entry", style="title")
     assert 'ICON Foo Bar' in html
     assert 'rel="noopener noreferrer" target="_blank"' in html
 
@@ -135,7 +135,7 @@ def test_linkshort_uses_short_citation_and_ignores_icon(monkeypatch):
     monkeypatch.setattr(render_template, "redis_conn", fake)
     render_template.index_json = {}
 
-    html = render_template.linkshort("entry")
+    html = render_template.render_link("entry", citation="short", use_icon=False)
     assert '>Short<' in html
     assert 'ICON' not in html
     assert 'rel="noopener noreferrer" target="_blank"' in html

--- a/dist/docs/jinja-filters.md
+++ b/dist/docs/jinja-filters.md
@@ -7,17 +7,24 @@ text, along with a `url` field. Optional keys like `icon`,
 `link.tracking`, and `link.class` customize the output.  For an overview of
 these metadata fields, see [Metadata Fields](metadata-fields.md).
 
-## `linktitle`
+## `link`
 
-`linktitle` capitalizes the first character of each word in the
-`citation` field, except for short words like `in`, `a`, `an`, and `of`.
-It returns an HTML `<a>` element using the supplied `url` and optional
-`icon`, `link.class`, or `link.tracking` fields.
+The `link` filter formats a metadata dictionary into an HTML anchor.  It
+accepts a few optional parameters to control the output:
+
+- `style` – controls capitalization of the citation text.  Use `"plain"`
+  (default) to leave text unchanged, `"title"` for title‑case, or `"cap"` to
+  capitalise only the first character.
+- `use_icon` – when `True` (default) any `icon` field in the metadata is
+  prefixed to the link text.  Set to `False` to suppress icons.
+- `citation` – selects which citation field to render.  The default `"citation"`
+  uses the main citation value; pass `"short"` to use `citation.short`.
 
 Example:
 
 ```jinja
-{{ {"citation": "deltoid tuberosity", "url": "/humerus.html#deltoid_tuberosity"} | linktitle }}
+{{ {"citation": "deltoid tuberosity", "url": "/humerus.html#deltoid_tuberosity"}
+   | link(style="title") }}
 ```
 
 renders as:
@@ -26,52 +33,15 @@ renders as:
 <a href="/humerus.html#deltoid_tuberosity" class="internal-link">Deltoid Tuberosity</a>
 ```
 
-You can also use it inside YAML fragments that feed into Jinja templates:
-
-```yaml
-toc:
-  - "{{\"deltoid_tuberosity\"|linktitle}}"
-```
-
-This filter lives in `pie.render_jinja_template` and is also exposed by the
-`render-jinja-template` command.
-
-When you pass a string instead of a dictionary, the filters fetch the
-corresponding metadata from Redis. The lookup now retries a few times before
+When you pass a string instead of a dictionary, the filter fetches the
+corresponding metadata from Redis. The lookup retries a few times before
 aborting so templates are more resilient when entries are added concurrently.
 
-## `linkcap`
+### Legacy filters
 
-`linkcap` capitalizes only the first character of the `citation` text. It uses
-the same metadata fields as `linktitle` and returns an anchor element.
-
-```jinja
-{{ {"citation": "deltoid tuberosity", "url": "/humerus.html#deltoid_tuberosity"} | linkcap }}
-```
-
-renders as:
-
-```html
-<a href="/humerus.html#deltoid_tuberosity" class="internal-link">Deltoid tuberosity</a>
-```
-
-## `linkicon`
-
-`linkicon` leaves the `citation` text unchanged but allows emoji or other icons
-to appear before it. Provide the optional `icon` field in the metadata to prefix
-the link text.
-
-## `link_icon_title`
-
-This filter combines the behavior of `linkicon` with word capitalization. It is
-primarily used when the metadata includes both an `icon` and a `citation`
-value.
-
-## `link`
-
-`link` renders the `citation` field as-is without altering capitalization.
-It is useful when no formatting is desired but you still want an anchor
-element with the correct `url` and optional link attributes.
+Older filters such as `linktitle`, `linkcap`, `linkicon`, `link_icon_title`,
+and `linkshort` remain available for backward compatibility but are now thin
+wrappers around `link`.  They will be removed in a future release.
 
 ## `get_desc`
 


### PR DESCRIPTION
## Summary
- introduce `render_link` helper with style, icon, and citation options
- register new helper as `link` filter and keep legacy filter aliases
- document and test updated parameterised filter

## Testing
- `pytest dist/app/shell/py/pie/tests/test_render_template.py dist/app/shell/py/pie/tests/test_gen_markdown_index.py`

------
https://chatgpt.com/codex/tasks/task_e_6892210b1aa483219c3503b0d8c3faf0