### PR TITLE
feat: build index for md and yaml in single pass

### DIFF
--- a/dist/app/shell/py/pie/tests/test_build_index.py
+++ b/dist/app/shell/py/pie/tests/test_build_index.py
@@ -61,11 +61,30 @@ def test_validate_and_insert_duplicate(tmp_path):
         build_index.validate_and_insert_metadata({"id": "a"}, "file", index)
 
 
+def test_build_index_handles_multiple_extensions(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    md = src / "doc.md"
+    md.write_text("---\n{\"title\": \"T\", \"id\": \"doc\"}\n---\n")
+    yml = src / "item.yml"
+    yml.write_text('{"name": "Foo"}')
+
+    os.chdir(tmp_path)
+    try:
+        index = build_index.build_index("src")
+    finally:
+        os.chdir("/tmp")
+
+    assert set(index) == {"doc", "item"}
+
+
 def test_main_writes_log_file(tmp_path):
     src = tmp_path / "src"
     src.mkdir()
     md = src / "doc.md"
-    md.write_text("---\n{\"title\": \"T\"}\n---\n")
+    md.write_text("---\n{\"title\": \"T\", \"id\": \"doc\"}\n---\n")
+    yml = src / "item.yml"
+    yml.write_text('{"name": "Foo"}')
     out = tmp_path / "index.json"
     log = tmp_path / "build.log"
 
@@ -76,4 +95,6 @@ def test_main_writes_log_file(tmp_path):
         os.chdir("/tmp")
 
     assert out.exists()
+    data = json.loads(out.read_text())
+    assert set(data) == {"doc", "item"}
     assert log.exists()


### PR DESCRIPTION
## Summary
- Allow `build_index` to traverse once for `.md`, `.yml`, and `.yaml` files
- Update CLI to call `build_index` only once with merged results
- Expand unit tests to cover multiple extensions in a single pass

## Testing
- `pytest dist/app/shell/py/pie/tests/test_build_index.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892214d58248321a615e715bbc30386