### PR TITLE
feat: handle circular dependencies in picasso

### DIFF
--- a/dist/docs/picasso.md
+++ b/dist/docs/picasso.md
@@ -41,3 +41,7 @@ The command also inspects Markdown files for cross-document links and any
 `include-filter` Python blocks.  Dependencies discovered this way are emitted as
 additional Makefile rules so that updates to referenced files trigger a rebuild
 of the including document.
+
+If these dependencies form a cycle, `picasso` logs a warning and drops the
+minimum number of rules required to break the loop. The build continues with the
+remaining rules.


### PR DESCRIPTION
## Summary
- detect and break circular dependencies when generating picasso Makefile rules
- log warnings instead of failing the build when cycles are found
- document cycle handling and test for it

## Testing
- `pytest dist/app/shell/py/pie/tests/test_picasso.py`


------
https://chatgpt.com/codex/tasks/task_e_68924485a09483219bfa9bd808887bc6