### PR TITLE
Rename docker make scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,6 @@ build. Use `--src DIR` to search a different directory for `.yml` files and
 - [gen-markdown-index](docs/gen-markdown-index.md)
 - [process-yaml](docs/process-yaml.md)
 - [Nginx Dockerfile](docs/nginx.md)
-- [docker-make](docs/docker-make.md)
+- [make](docs/make.md)
 - [WebP Service](docs/webp-service.md)
 - [check-page-title](docs/check-page-title.md)

--- a/bin/make
+++ b/bin/make
@@ -8,10 +8,10 @@
 #   to the underlying `make` command.
 #
 # Usage:
-#   docker-make [MAKE_TARGETS]
+#   make [MAKE_TARGETS]
 #
 # Example:
-#   docker-make all
+#   make all
 #
 # Run "make" in the container with the current user's UID so that
 # generated files are owned by the invoking user. The container is

--- a/bin/remake
+++ b/bin/remake
@@ -2,19 +2,19 @@
 #
 # Description:
 #   Remove the specified build directories and then invoke
-#   `docker-make` with the same arguments. This is useful when
+#   `make` with the same arguments. This is useful when
 #   you want to force a clean rebuild of one or more targets.
 #
 # Usage:
-#   docker-remake [TARGETS...]
+#   remake [TARGETS...]
 #
 # Example:
-#   docker-remake build webp
+#   remake build webp
 #
 # Each argument is recursively deleted with `rm -rf` before
-# delegating to `docker-make` so the build artifacts are
-# regenerated from scratch.
+# delegating to `make` so the build artifacts are regenerated
+# from scratch.
 
 bin=$(dirname "$0")
 rm -rf "$@"
-$bin/docker-make "$@"
+$bin/make "$@"

--- a/docs/make.md
+++ b/docs/make.md
@@ -1,13 +1,13 @@
-# docker-make
+# make
 
-`docker-make` runs `make` inside the Docker Compose `shell` service. It ensures
+The `make` script runs `make` inside the Docker Compose `shell` service. It ensures
 that the build environment matches the containerized setup and that generated
 files are owned by your user.
 
 ## Usage
 
 ```bash
-docker-make [MAKE_TARGETS]
+make [MAKE_TARGETS]
 ```
 
 All arguments are forwarded to `make` running in the container.
@@ -15,7 +15,7 @@ All arguments are forwarded to `make` running in the container.
 ### Example
 
 ```bash
-docker-make all
+make all
 ```
 
 The script uses your current UID when starting the container and removes the
@@ -23,8 +23,8 @@ container after `make` completes.
 
 ### Cleaning Build Artifacts
 
-Use `docker-remake` to delete targets before rebuilding:
+Use `remake` to delete targets before rebuilding:
 
 ```bash
-docker-remake build webp
+remake build webp
 ```


### PR DESCRIPTION
## Summary
- rename `docker-make` to `make`
- rename `docker-remake` to `remake`
- update docs and README accordingly

## Testing
- `./bin/make help` *(fails: docker command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892703622048321a147f9a12d7ed4c6