### PR TITLE
docs: replace docker-compose with docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Press is a static-site generator built on Pandoc and Docker. It uses
-`docker-compose` together with `redo.mk` to orchestrate services for building
+`docker compose` together with `redo.mk` to orchestrate services for building
 and serving content. The project includes helpers for rendering Markdown to HTML
 or PDF, converting images to WebP, and customizing Jinja templates. It's meant
 for building documentation or other small websites that can be served from a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Press is a static-site generator that wraps Pandoc tooling in a containerized bu
 
 ## Repository Layout
 - `src/` – markdown sources, templates, and static assets.
-- `dist/` – Dockerfiles, docker-compose templates, and build scripts used inside containers.
+- `app/` – Dockerfiles, Docker Compose templates, and build scripts used inside containers.
 - `bin/` – host-side helper scripts for container management.
 - `cfg/` – configuration files used during validation tasks.
 
@@ -24,7 +24,7 @@ The top-level Makefile (`redo.mk`) drives all host-side automation. It launches 
 - Auxiliary services `sync`, `seed`, and `webp` handle S3 uploads, database seeding, and WebP image conversion.
 
 ## Build Pipeline
-The shell container executes `dist/app/shell/mk/build.mk` to transform sources into deliverables:
+The shell container executes `app/shell/mk/build.mk` to transform sources into deliverables:
 
 1. Discover Markdown and YAML files and update a Redis-backed index.
 2. Convert preprocessed Markdown to HTML and PDF using Pandoc with a shared template and options for table of contents, math rendering, and cross references.
@@ -35,5 +35,5 @@ The shell container executes `dist/app/shell/mk/build.mk` to transform sources i
 Source files in `src/` become processed artifacts in `build/`. The development `nginx-dev` service mounts the build directory for local preview, while production content can be synchronized or served by `nginx`.
 
 ## Testing
-Python utilities that support the build live under `dist/app/shell/py/pie`. Unit tests for these helpers execute with `pytest` via the host Makefile or directly inside the shell container.
+Python utilities that support the build live under `app/shell/py/pie`. Unit tests for these helpers execute with `pytest` via the host Makefile or directly inside the shell container.
 

--- a/docs/dep-mk.md
+++ b/docs/dep-mk.md
@@ -1,7 +1,7 @@
 # dep.mk Custom Dependencies
 
 `dep.mk` is an optional Makefile that extends the build process with project specific rules.
-It is included at the end of `dist/app/shell/mk/build.mk` if present.
+It is included at the end of `app/shell/mk/build.mk` if present.
 
 ## How It Works
 
@@ -11,7 +11,7 @@ It is included at the end of `dist/app/shell/mk/build.mk` if present.
 -include /app/mk/dep.mk
 ```
 
-During `docker-compose` runs, the repository's `dep.mk` is mounted into the
+During `docker compose` runs, the repository's `dep.mk` is mounted into the
 shell container at `/app/mk/dep.mk`:
 
 ```yaml
@@ -29,10 +29,10 @@ The provided `dep.mk` simply pulls in rules for building the React quiz
 interface:
 
 ```make
-include dist/app/quiz/dep.mk
+include app/quiz/dep.mk
 ```
 
-`dist/app/quiz/dep.mk` compiles the quiz bundle with Vite and copies JSON quizzes into
+`app/quiz/dep.mk` compiles the quiz bundle with Vite and copies JSON quizzes into
 `build/quiz/`. See `docs/quiz-workflow.md` for the full workflow.
 
 ## Customization

--- a/docs/include-filter.md
+++ b/docs/include-filter.md
@@ -31,7 +31,7 @@ Example:
 ```markdown
 <dl>
 ```python
-include_deflist_entry("src/dist/include-filter", glob="*.md")
+include_deflist_entry("src/include-filter", glob="*.md")
 ```
 </dl>
 ```
@@ -39,5 +39,5 @@ include_deflist_entry("src/dist/include-filter", glob="*.md")
 Any links ending with `.md` are automatically rewritten to point at the
 corresponding `.html` file.
 
-Typical usage in `dist/app/shell/mk/build.mk` chains the command multiple times to
+Typical usage in `app/shell/mk/build.mk` chains the command multiple times to
 resolve nested includes before passing the final Markdown to Pandoc.

--- a/docs/jinja-globals.md
+++ b/docs/jinja-globals.md
@@ -16,6 +16,6 @@ for details on the structure of this metadata.
 - `read_json(path)` – read and parse a JSON file.
 - `read_yaml(path)` – read YAML and yield the sequence stored under `toc`.
 
-These helpers live in `dist/app/shell/py/pie/pie/render_jinja_template.py` and are
+These helpers live in `app/shell/py/pie/pie/render_jinja_template.py` and are
 registered with the Jinja environment by `create_env()`.
 

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -1,6 +1,6 @@
 # Nginx Dockerfile
 
-The `dist/app/nginx/Dockerfile` builds a minimal image for serving the static site.
+The `app/nginx/Dockerfile` builds a minimal image for serving the static site.
 It starts from `nginx:alpine-slim` and copies the generated `build/` directory
 into Nginx's default web root. Both the `nginx` and `nginx-dev` services in
 `docker-compose.yml` use this image.
@@ -15,7 +15,7 @@ COPY ./build /usr/share/nginx/html
 To test the container directly:
 
 ```bash
-docker build -f dist/app/nginx/Dockerfile -t press-nginx .
+docker build -f app/nginx/Dockerfile -t press-nginx .
 docker run -p 80:80 press-nginx
 ```
 

--- a/docs/picasso.md
+++ b/docs/picasso.md
@@ -2,7 +2,7 @@
 
 `picasso` scans the `src/` directory for YAML metadata files and emits Makefile
 rules that convert them to HTML using Pandoc. The generated rules are written to
-`build/picasso.mk` and included by `dist/app/shell/mk/build.mk` during the build.
+`build/picasso.mk` and included by `app/shell/mk/build.mk` during the build.
 Refer to [Metadata Fields](metadata-fields.md) for the supported metadata keys.
 
 ## Usage

--- a/docs/preprocess.md
+++ b/docs/preprocess.md
@@ -22,7 +22,7 @@ Each input file is processed in place:
 
 ### Makefile Integration
 
-`dist/app/shell/mk/build.mk` invokes `preprocess` when building `.md` targets:
+`app/shell/mk/build.mk` invokes `preprocess` when building `.md` targets:
 
 ```make
 build/%.md: %.md | build

--- a/docs/quiz-workflow.md
+++ b/docs/quiz-workflow.md
@@ -33,17 +33,17 @@ Example from `src/quiz/demo.json`:
 ## 2. Rendering JSON
 
 During the build the React quiz interface is compiled with Vite.  The
-`dist/app/quiz/dep.mk` makefile also copies the JSON files so they are
+`app/quiz/dep.mk` makefile also copies the JSON files so they are
 served from `/quiz/`:
 
 ```make
 all: build/quiz/quiz.js build/quiz/demo.json
 
-build/quiz/quiz.js: dist/app/build/static/js/quiz.js | build/quiz
-cp $< $@
+build/quiz/quiz.js: app/build/static/js/quiz.js | build/quiz
+    cp $< $@
 
-dist/app/build/static/js/quiz.js: $(wildcard dist/app/quiz/src/*) dist/app/quiz/.init
-    cd dist/app/quiz; npm run build
+app/build/static/js/quiz.js: $(wildcard app/quiz/src/*) app/quiz/.init
+    cd app/quiz; npm run build
 
 build/quiz/demo.json: src/quiz/demo.json
 mkdir -p $(dir $@)
@@ -54,7 +54,7 @@ The resulting assets live under `build/quiz/` and are served directly by the sit
 
 ## 3. Interactive Quiz Component
 
-For dynamic quizzes, the React component `dist/app/quiz/src/Quiz.jsx` fetches a JSON file and handles user interaction:
+For dynamic quizzes, the React component `app/quiz/src/Quiz.jsx` fetches a JSON file and handles user interaction:
 
 ```jsx
 const Quiz = ({ src = "/study/key_terms.json" }) => {
@@ -86,11 +86,11 @@ A page can embed the quiz with:
 
 ## 4. Styling
 
-Both the site CSS (`src/style.css`) and the React bundle’s stylesheet (`dist/app/quiz/src/index.css`) define classes like `.quiz-container`, `.question`, `.choice`, and `.answer` to style quizzes consistently.
+Both the site CSS (`src/style.css`) and the React bundle’s stylesheet (`app/quiz/src/index.css`) define classes like `.quiz-container`, `.question`, `.choice`, and `.answer` to style quizzes consistently.
 
 ## Summary
 
 1. Quizzes are defined as JSON under `src/quiz/`.
-2. `dist/app/quiz/dep.mk` compiles the React app and copies quizzes to `build/quiz/`.
+2. `app/quiz/dep.mk` compiles the React app and copies quizzes to `build/quiz/`.
 3. The React `Quiz` component fetches the built JSON for an interactive version and is included via `quiz.js`.
 

--- a/docs/redo-mk.md
+++ b/docs/redo-mk.md
@@ -20,7 +20,7 @@ This repository actually uses three Makefiles that work together:
 - **`BUILD_DIR`** – Directory for generated output (default: `build`).
 - **`SERVICES`** – Containers started by `up`/`upd` (default: `nginx-dev sync webp`).
 - **`MAKE_CMD`** – Helper command to run the lower-level makefile inside the `shell` service.
-- **`COMPOSE_FILE`** – Compose file used by commands. Defaults to `docker-compose.yml` in the project root, falling back to `dist/docker-compose.yml` if missing.
+- **`COMPOSE_FILE`** – Compose file used by commands. Defaults to `docker-compose.yml` in the project root.
 - **`DOCKER_COMPOSE`** – Shortcut for `docker compose -f $(COMPOSE_FILE)`.
 - **`VERBOSE`** – Set to `1` to print each command executed by `make` in addition to status messages.
 
@@ -35,7 +35,7 @@ This repository actually uses three Makefiles that work together:
 | `down` | Stops and removes the compose stack. |
 | `clean` | Removes everything under `build/`. |
 | `prune` | Runs `docker system prune -f` to clean unused Docker resources. |
-| `setup` | Prepares `dist/app/webp` directories and builds all services. |
+| `setup` | Prepares `app/webp` directories and builds all services. |
 | `seed` | Runs the `seed` container to populate initial data. |
 | `sync` | Runs the `sync` container to upload site files to S3. |
 | `webp` | Runs the image conversion service. |

--- a/docs/webp-service.md
+++ b/docs/webp-service.md
@@ -2,12 +2,12 @@
 
 The `webp` service converts PNG and JPEG files to WebP format using
 [ImageMagick](https://imagemagick.org). The container lives under
-`dist/app/webp` and runs `/app/bin/service` in a loop.
+`app/webp` and runs `/app/bin/service` in a loop.
 
 ## Directories
 
-- `dist/app/webp/input` – place `.png` or `.jpg` files here for processing.
-- `dist/app/webp/output` – converted `.webp` files are written here.
+- `app/webp/input` – place `.png` or `.jpg` files here for processing.
+- `app/webp/output` – converted `.webp` files are written here.
 - `log/webp.txt` – log of conversions when the service runs.
 
 ## Running the service
@@ -18,19 +18,19 @@ Use `redo.mk` to start the container:
 r webp
 ```
 
-The service watches `dist/app/webp/input` and converts anything it finds.
+The service watches `app/webp/input` and converts anything it finds.
 Once finished, the original file is removed and the WebP version
-appears under `dist/app/webp/output`.
+appears under `app/webp/output`.
 
 ### Example
 
 ```bash
-cp foo.png dist/app/webp/input
+cp foo.png app/webp/input
 r webp
-ls dist/app/webp/output
+ls app/webp/output
 ```
 
-This will produce `foo.webp` inside `dist/app/webp/output`.
+This will produce `foo.webp` inside `app/webp/output`.
 
 The `setup` target creates the input and output directories if they do
 not already exist.


### PR DESCRIPTION
## Summary
- replace `docker-compose` command references with `docker compose`
- update documentation paths from removed `dist/` directory to current `app/` layout

## Testing
- `make -f redo.mk test` *(fails: `docker: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68928424a5888321bde5cae78d8d44f6