### PR TITLE
Fix checklinks exit code and document script

### DIFF
--- a/app/shell/bin/checklinks
+++ b/app/shell/bin/checklinks
@@ -1,9 +1,35 @@
-#!/bin/bash -x
-wget \
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <url>" >&2
+    exit 1
+fi
+
+log=$(mktemp)
+trap 'rm -f "$log"' EXIT
+
+pattern='broken link!!!|ERROR [45][0-9]{2}'
+
+if ! wget \
     --spider \
     --recursive \
     --no-verbose \
     --level=3 \
     --no-directories \
     --hsts-file=/dev/null \
-    "$1"
+    "$1" 2>&1 | tee "$log"; then
+    if grep -qE "$pattern" "$log"; then
+        echo "Broken links detected" >&2
+    else
+        echo "Link check failed" >&2
+    fi
+    exit 1
+fi
+
+if grep -qE "$pattern" "$log"; then
+    echo "Broken links detected" >&2
+    exit 1
+fi
+
+echo "No broken links found."

--- a/docs/checklinks.md
+++ b/docs/checklinks.md
@@ -1,0 +1,11 @@
+# checklinks
+
+`checklinks` verifies that every link on a site resolves successfully. It uses `wget --spider` to crawl the provided URL and exits with a non-zero status when a broken link or HTTP error is encountered.
+
+## Usage
+
+```bash
+checklinks URL
+```
+
+The command prints `wget`'s output while it scans up to three levels deep. If any link fails to resolve, `checklinks` reports "Broken links detected" and returns `1`. When all links are valid, it prints "No broken links found." and exits with `0`.


### PR DESCRIPTION
## Summary
- make `checklinks` fail when wget detects broken links or HTTP errors
- document the `checklinks` utility and its usage

## Testing
- `make -f redo.mk test` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68928c066e74832188685249af08a18d