### PR TITLE
feat: support anchor fragments in link filter

### DIFF
--- a/app/shell/py/pie/pie/render_jinja_template.py
+++ b/app/shell/py/pie/pie/render_jinja_template.py
@@ -150,7 +150,14 @@ def get_link_class(desc):
     return "internal-link"
 
 
-def render_link(desc, *, style: str = "plain", use_icon: bool = True, citation: str = "citation"):
+def render_link(
+    desc,
+    *,
+    style: str = "plain",
+    use_icon: bool = True,
+    citation: str = "citation",
+    anchor: str | None = None,
+):
     """Return a formatted HTML anchor for ``desc``.
 
     ``desc`` may be either a metadata dictionary or a string id which will be
@@ -187,6 +194,8 @@ def render_link(desc, *, style: str = "plain", use_icon: bool = True, citation: 
         citation_text = citation_text[0].upper() + citation_text[1:]
 
     url = desc["url"]
+    if anchor:
+        url += anchor if anchor.startswith("#") else f"#{anchor}"
     icon = desc.get("icon") if use_icon else None
     a_attribs = get_tracking_options(desc)
 
@@ -195,28 +204,28 @@ def render_link(desc, *, style: str = "plain", use_icon: bool = True, citation: 
     return f"""<a href="{url}" class="{get_link_class(desc)}" {a_attribs}>{citation_text}</a>"""
 
 
-def linktitle(desc):
-    return render_link(desc, style="title")
+def linktitle(desc, anchor: str | None = None):
+    return render_link(desc, style="title", anchor=anchor)
 
 
-def link_icon_title(desc):
-    return render_link(desc, style="title", use_icon=True)
+def link_icon_title(desc, anchor: str | None = None):
+    return render_link(desc, style="title", use_icon=True, anchor=anchor)
 
 
-def linkcap(desc):
-    return render_link(desc, style="cap")
+def linkcap(desc, anchor: str | None = None):
+    return render_link(desc, style="cap", anchor=anchor)
 
 
-def linkicon(desc):
-    return render_link(desc, use_icon=True)
+def linkicon(desc, anchor: str | None = None):
+    return render_link(desc, use_icon=True, anchor=anchor)
 
 
-def link(desc):
-    return render_link(desc, use_icon=False)
+def link(desc, anchor: str | None = None):
+    return render_link(desc, use_icon=False, anchor=anchor)
 
 
-def linkshort(desc):
-    return render_link(desc, use_icon=False, citation="short")
+def linkshort(desc, anchor: str | None = None):
+    return render_link(desc, use_icon=False, citation="short", anchor=anchor)
 
 
 def extract_front_matter(file_path: str) -> dict | None:

--- a/app/shell/py/pie/tests/test_render_template.py
+++ b/app/shell/py/pie/tests/test_render_template.py
@@ -140,3 +140,20 @@ def test_linkshort_uses_short_citation_and_ignores_icon(monkeypatch):
     assert 'ICON' not in html
     assert 'rel="noopener noreferrer" target="_blank"' in html
 
+
+def test_render_link_with_anchor():
+    desc = {"citation": "foo", "url": "/f"}
+    html = render_template.render_link(desc, anchor="bar")
+    assert '<a href="/f#bar"' in html
+
+
+def test_wrapper_accepts_anchor(monkeypatch):
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    fake.set("entry.citation", "Foo")
+    fake.set("entry.url", "/link")
+    monkeypatch.setattr(render_template, "redis_conn", fake)
+    render_template.index_json = {}
+
+    html = render_template.link("entry", anchor="top")
+    assert '<a href="/link#top"' in html
+

--- a/docs/jinja-filters.md
+++ b/docs/jinja-filters.md
@@ -17,14 +17,15 @@ accepts a few optional parameters to control the output:
   capitalise only the first character.
 - `use_icon` – when `True` (default) any `icon` field in the metadata is
   prefixed to the link text.  Set to `False` to suppress icons.
+- `anchor` – appends a fragment identifier (`#anchor`) to the URL when provided.
 - `citation` – selects which citation field to render.  The default `"citation"`
   uses the main citation value; pass `"short"` to use `citation.short`.
 
 Example:
 
 ```jinja
-{{ {"citation": "deltoid tuberosity", "url": "/humerus.html#deltoid_tuberosity"}
-   | link(style="title") }}
+{{ {"citation": "deltoid tuberosity", "url": "/humerus.html"}
+   | link(style="title", anchor="deltoid_tuberosity") }}
 ```
 
 renders as:


### PR DESCRIPTION
## Summary
- allow passing an anchor fragment to the `link` Jinja filter and wrapper helpers
- document anchor usage for link filters
- test that anchors propagate through link wrappers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893814a0c988321a342370b3dd2c5e1