### PR TITLE
docs: demonstrate anchor with linktitle

### DIFF
--- a/docs/jinja-filters.md
+++ b/docs/jinja-filters.md
@@ -44,6 +44,19 @@ Older filters such as `linktitle`, `linkcap`, `linkicon`, `link_icon_title`,
 and `linkshort` remain available for backward compatibility but are now thin
 wrappers around `link`.  They will be removed in a future release.
 
+Example:
+
+```jinja
+{{ {"citation": "deltoid tuberosity", "url": "/humerus.html"}
+   | linktitle(anchor="deltoid_tuberosity") }}
+```
+
+renders as:
+
+```html
+<a href="/humerus.html#deltoid_tuberosity" class="internal-link">Deltoid Tuberosity</a>
+```
+
 ## `get_desc`
 
 Looks up a description object from the build index. If the name is not present,

--- a/src/examples/link-filters.md
+++ b/src/examples/link-filters.md
@@ -11,7 +11,7 @@ Press provides custom Jinja filters for formatting links. Each filter accepts a 
 {{"quickstart"|linktitle}}
 
 ## linktitle with anchor
-{{ {"citation": "deltoid tuberosity", "url": "/humerus.html"} | linktitle(anchor="deltoid_tuberosity") }}
+{{ {"citation": "home", "url": "/"} | linktitle(anchor="#example") }}
 
 ## linkcap
 {{"quickstart"|linkcap}}

--- a/src/examples/link-filters.md
+++ b/src/examples/link-filters.md
@@ -10,6 +10,9 @@ Press provides custom Jinja filters for formatting links. Each filter accepts a 
 ## linktitle
 {{"quickstart"|linktitle}}
 
+## linktitle with anchor
+{{ {"citation": "deltoid tuberosity", "url": "/humerus.html"} | linktitle(anchor="deltoid_tuberosity") }}
+
 ## linkcap
 {{"quickstart"|linkcap}}
 


### PR DESCRIPTION
## Summary
- show how to use the `anchor` argument with the legacy `linktitle` Jinja filter
- add example of `linktitle` with an anchor fragment

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689383e1c80483219e81a9626dd5f856