### PR TITLE
docs: add cross references

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ If you don’t provide these, Pandoc (or your build tooling) will generate them 
 - `id`: A unique identifier for cross-document linking (e.g., when using Jinja templates).
 - `citation`: Default anchor text for cross-document links. Jinja filters such as `linktitle` use this value.
 
-See [docs/metadata-fields.md](docs/metadata-fields.md) for a complete list of supported fields and defaults.
+See [docs/metadata-fields.md](docs/metadata-fields.md) for a complete list of supported fields and defaults. For describing
+external URLs in YAML, refer to [docs/link-metadata.md](docs/link-metadata.md).
 
 ### Examples
 - **Sidecar metadata**  
@@ -166,3 +167,6 @@ build. Use `--src DIR` to search a different directory for `.yml` files and
 - [make](docs/make.md)
 - [WebP Service](docs/webp-service.md)
 - [check-page-title](docs/check-page-title.md)
+- [Architecture](docs/architecture.md)
+- [Link Metadata](docs/link-metadata.md)
+- [checklinks](docs/checklinks.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,10 +26,10 @@ The top-level Makefile (`redo.mk`) drives all host-side automation. It launches 
 ## Build Pipeline
 The shell container executes `app/shell/mk/build.mk` to transform sources into deliverables:
 
-1. Discover Markdown and YAML files and update a Redis-backed index.
+1. Discover Markdown and YAML files and update a Redis-backed index. See [build-index](build-index.md) and [update-index](update-index.md) for details on this step.
 2. Convert preprocessed Markdown to HTML and PDF using Pandoc with a shared template and options for table of contents, math rendering, and cross references.
 3. Copy CSS assets and minify the resulting site.
-4. Run link checking and page title validation before marking the build complete.
+4. Run link checking and page title validation before marking the build complete. See [checklinks](checklinks.md) and [check-page-title](check-page-title.md).
 
 ## Data Flow
 Source files in `src/` become processed artifacts in `build/`. The development `nginx-dev` service mounts the build directory for local preview, while production content can be synchronized or served by `nginx`.

--- a/docs/checklinks.md
+++ b/docs/checklinks.md
@@ -9,3 +9,6 @@ checklinks URL
 ```
 
 The command prints `wget`'s output while it scans up to three levels deep. If any link fails to resolve, `checklinks` reports "Broken links detected" and returns `1`. When all links are valid, it prints "No broken links found." and exits with `0`.
+
+This check runs as part of the build pipeline described in [Architecture](architecture.md). For validating page titles, see
+[check-page-title](check-page-title.md).

--- a/docs/link-metadata.md
+++ b/docs/link-metadata.md
@@ -50,3 +50,5 @@ metadata["id"] = base.split(os.sep)[-1]
 ```
 
 Thus `src/links/press_io_home.yml` results in the `id` `press_io_home`.
+
+After defining link metadata, run [checklinks](checklinks.md) to ensure each target resolves correctly.


### PR DESCRIPTION
## Summary
- link to metadata and link metadata docs from the README
- connect build pipeline to component docs in architecture overview
- reference check-page-title and architecture from checklinks; cross-link link metadata to checklinks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6893a73fa2d08321a4b32f6371f24136