### PR TITLE
docs: add reference README

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,13 @@
+# Reference
+
+This section contains background material and technical specifications for the project. The documents here provide in-depth details to support the guides and source code.
+
+## Contents
+- `architecture.md` – overview of the site's architecture.
+- `jinja-filters.md` – custom Jinja filters available to templates.
+- `jinja-globals.md` – global variables exposed to templates.
+- `keyterms.md` – glossary of important terminology.
+- `link-metadata.md` – link metadata format and usage.
+- `metadata-fields.md` – description of common metadata fields.
+
+Refer back to [../guides](../guides) for step-by-step workflows and tutorials.


### PR DESCRIPTION
## Summary
- add missing README for docs/reference

## Testing
- `make -f redo.mk test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6893b379f278832183b9d04d5f14260a