### PR TITLE
Remove unused Jinja globals

### DIFF
--- a/app/shell/py/pie/pie/render_jinja_template.py
+++ b/app/shell/py/pie/pie/render_jinja_template.py
@@ -280,54 +280,6 @@ def process_directory(root_dir: str) -> None:
                 logger.warning("No front matter or title", file=full_path)
 
 
-def get_origins(name):
-    """Yield origin references for the given entry ``name``."""
-
-    j = _get_metadata(name)
-    if j is None or "origins" not in j:
-        logger.error("Missing origins", id=name)
-        raise SystemExit(1)
-    for i in j["origins"]:
-        meta = _get_metadata(str(i))
-        yield meta if meta is not None else i
-
-
-def get_insertions(name):
-    """Yield insertion references for ``name``."""
-
-    j = _get_metadata(name)
-    if j is None or "insertions" not in j:
-        logger.error("Missing insertions", id=name)
-        raise SystemExit(1)
-    for i in j["insertions"]:
-        meta = _get_metadata(str(i))
-        yield meta if meta is not None else i
-
-
-def get_actions(name):
-    """Yield actions associated with ``name`` from ``index_json``."""
-
-    j = _get_metadata(name)
-    if j is None or "actions" not in j:
-        logger.error("Missing actions", id=name)
-        raise SystemExit(1)
-    yield from j["actions"]
-
-
-def get_translations(name):
-    """Yield key/value translation pairs for ``name``."""
-
-    j = _get_metadata(name)
-    if j is None or "translations" not in j:
-        logger.error("Missing translations", id=name)
-        raise SystemExit(1)
-    if isinstance(j["translations"], dict):
-        yield from j["translations"].items()
-    else:
-        logger.error("Invalid translations format", id=name)
-        raise SystemExit(1)
-
-
 def get_desc(name):
     """Return the metadata entry for ``name`` from Redis."""
 
@@ -389,10 +341,6 @@ def create_env():
     env.filters["linkicon"] = linkicon
     env.filters["linkshort"] = linkshort
     env.filters["get_desc"] = get_desc
-    env.globals["get_origins"] = get_origins
-    env.globals["get_insertions"] = get_insertions
-    env.globals["get_actions"] = get_actions
-    env.globals["get_translations"] = get_translations
     env.globals["render_jinja"] = render_jinja
     env.globals["to_alpha_index"] = to_alpha_index
     env.globals["read_json"] = read_json

--- a/app/shell/py/pie/tests/test_render_template_misc.py
+++ b/app/shell/py/pie/tests/test_render_template_misc.py
@@ -1,0 +1,40 @@
+import pytest
+from pie import render_jinja_template as render_template
+
+
+def test_get_desc_returns_metadata(monkeypatch):
+    monkeypatch.setattr(render_template, "_get_metadata", lambda name: {"id": name})
+    assert render_template.get_desc("entry") == {"id": "entry"}
+
+
+def test_get_desc_missing_raises(monkeypatch):
+    monkeypatch.setattr(render_template, "_get_metadata", lambda name: None)
+    with pytest.raises(SystemExit):
+        render_template.get_desc("entry")
+
+
+def test_to_alpha_index_maps():
+    assert [render_template.to_alpha_index(i) for i in range(4)] == list("abcd")
+
+
+def test_read_yaml_yields_toc(tmp_path):
+    yml = tmp_path / "t.yml"
+    yml.write_text("toc:\n - 1\n - 2\n", encoding="utf-8")
+    assert list(render_template.read_yaml(yml)) == [1, 2]
+
+
+def test_extract_front_matter(tmp_path):
+    md = tmp_path / "f.md"
+    md.write_text("---\ntitle: Hi\n---\nbody\n", encoding="utf-8")
+    assert render_template.extract_front_matter(md) == {"title": "Hi"}
+
+
+def test_extract_front_matter_missing(tmp_path):
+    md = tmp_path / "f.md"
+    md.write_text("no front matter", encoding="utf-8")
+    assert render_template.extract_front_matter(md) is None
+
+
+def test_render_jinja_renders_snippet():
+    render_template.index_json = {"name": "world"}
+    assert render_template.render_jinja("Hello {{ name }}") == "Hello world"

--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -7,10 +7,6 @@ for details on the structure of this metadata.
 
 ## Available Globals
 
-- `get_origins(name)` – yield origin strings for the given key.
-- `get_insertions(name)` – yield insertion strings for the key.
-- `get_actions(name)` – yield action descriptions.
-- `get_translations(name)` – iterate over translation pairs.
 - `render_jinja(snippet)` – render a snippet of text using the same environment.
 - `to_alpha_index(i)` – convert `0`–`3` to `a`–`d`.
 - `read_json(path)` – read and parse a JSON file.


### PR DESCRIPTION
## Summary
- drop unused `get_origins`, `get_insertions`, `get_actions` and `get_translations` helpers from Jinja environment
- document remaining global helpers
- add coverage for `render_jinja_template` utilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893b3cda2ec83219c96478d9668b46b