### PR TITLE
Add coverage make target

### DIFF
--- a/app/shell/Dockerfile
+++ b/app/shell/Dockerfile
@@ -18,8 +18,6 @@ RUN apt update -qq \
         locales \
         make \
         minify \
-        python3-jinja2 \
-        python3-pytest \
         linkchecker
 
 # Install curl to install nodejs

--- a/app/shell/py/pie/requirements.txt
+++ b/app/shell/py/pie/requirements.txt
@@ -4,3 +4,6 @@ redis
 fakeredis
 flatten-dict
 beautifulsoup4
+jinja2
+pytest
+pytest-cov

--- a/docs/guides/redo-mk.md
+++ b/docs/guides/redo-mk.md
@@ -31,6 +31,8 @@ This repository actually uses three Makefiles that work together:
 | `all`  | Builds the site by invoking `/app/mk/build.mk` inside the shell container. |
 | `docker` | Builds and pushes the Nginx image after running `test`. |
 | `test` | Restarts `nginx-dev` and runs tests defined in `/app/mk/build.mk`. |
+| `pytest` | Runs unit tests for the `pie` package inside the shell container. |
+| `cov` | Generates a coverage report for the `pie` package inside the shell container. |
 | `up` / `upd` | Starts development containers (`SERVICES`). `upd` runs detached. |
 | `down` | Stops and removes the compose stack. |
 | `clean` | Removes everything under `build/`. |

--- a/docs/guides/tests.md
+++ b/docs/guides/tests.md
@@ -9,3 +9,12 @@ r pytest
 
 This command invokes `pytest` within the container so the tests run in the same
 environment used for development and CI.
+
+To check test coverage for the `pie` package, run:
+
+```bash
+r cov
+```
+
+The `cov` target runs `pytest --cov=pie` inside the container and prints a
+coverage report.

--- a/redo.mk
+++ b/redo.mk
@@ -152,6 +152,10 @@ pytest:
 	$(call status,Run pytest)
 	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell /press/py/pie/tests
 
+.PHONY: cov
+cov:
+	$(call status,Run coverage)
+	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell --cov=pie --cov-report=term-missing /press/py/pie/tests
 .PHONY: t
 t: ## Restart nginx-dev and run tests, ansi colors
 	$(call status,Run tests with colors)


### PR DESCRIPTION
## Summary
- add `cov` rule to run pytest coverage for pie in container
- document `cov` in testing guide and redo.mk guide

## Testing
- `make -f redo.mk cov` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893b41dd90483219e08cbec8491cfff