### PR TITLE
feat: add html coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,4 +180,5 @@ cython_debug/
 dist/app/webp/input
 dist/app/webp/output
 logs
+log/
 .update-index

--- a/docs/guides/redo-mk.md
+++ b/docs/guides/redo-mk.md
@@ -32,7 +32,7 @@ This repository actually uses three Makefiles that work together:
 | `docker` | Builds and pushes the Nginx image after running `test`. |
 | `test` | Restarts `nginx-dev` and runs tests defined in `/app/mk/build.mk`. |
 | `pytest` | Runs unit tests for the `pie` package inside the shell container. |
-| `cov` | Generates a coverage report for the `pie` package inside the shell container. |
+| `cov` | Generates an HTML coverage report for the `pie` package inside the shell container (output in `log/cov`). |
 | `up` / `upd` | Starts development containers (`SERVICES`). `upd` runs detached. |
 | `down` | Stops and removes the compose stack. |
 | `clean` | Removes everything under `build/`. |

--- a/docs/guides/tests.md
+++ b/docs/guides/tests.md
@@ -10,11 +10,11 @@ r pytest
 This command invokes `pytest` within the container so the tests run in the same
 environment used for development and CI.
 
-To check test coverage for the `pie` package, run:
+To check test coverage for the `pie` package and generate an HTML report, run:
 
 ```bash
 r cov
 ```
 
-The `cov` target runs `pytest --cov=pie` inside the container and prints a
-coverage report.
+The `cov` target runs `pytest --cov=pie --cov-report=html:/data/log/cov --cov-report=term-missing` inside the container. The
+HTML report is written to `log/cov` in the project root (mounted as `/data/log/cov` inside the container).

--- a/redo.mk
+++ b/redo.mk
@@ -155,7 +155,8 @@ pytest:
 .PHONY: cov
 cov:
 	$(call status,Run coverage)
-	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell --cov=pie --cov-report=term-missing /press/py/pie/tests
+	$(Q)mkdir -p log/cov
+	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell --cov=pie --cov-report=term-missing --cov-report=html:/data/log/cov /press/py/pie/tests
 .PHONY: t
 t: ## Restart nginx-dev and run tests, ansi colors
 	$(call status,Run tests with colors)


### PR DESCRIPTION
## Summary
- generate HTML coverage report saved to `log/cov`
- document coverage output path
- ignore coverage logs

## Testing
- `docker-compose -f docker-compose.yml run --entrypoint pytest --rm shell /press/py/pie/tests` *(fails: Error while fetching server API version)*
- `PYTHONPATH=app/shell/py/pie pytest app/shell/py/pie/tests --cov=pie --cov-report=term-missing --cov-report=html:log/cov`

------
https://chatgpt.com/codex/tasks/task_e_6893bfa8c88c8321bab90ea988aa2b9f