### PR TITLE
docs: add guides overview README

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,13 @@
+# Guides
+
+This directory collects step-by-step notes for working with the Press
+toolchain. Each document focuses on a specific task.
+
+Notable guides include:
+
+- `build-index.md` – generate a JSON index of document metadata.
+- `picasso.md` – create Makefile rules from YAML metadata.
+- `checklinks.md` – scan rendered HTML for broken links.
+- `webp-service.md` – convert images to WebP using the helper container.
+
+Refer to the individual files for full details and additional guides.


### PR DESCRIPTION
## Summary
- add `docs/guides/README.md` with overview of available guides

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest app/shell/py/pie/tests`

------
https://chatgpt.com/codex/tasks/task_e_6893c116c908832182e7bbe8b270c537