### PR TITLE
Add show flag to gen-markdown-index-2

### DIFF
--- a/app/shell/bin/gen-markdown-index-2
+++ b/app/shell/bin/gen-markdown-index-2
@@ -33,6 +33,12 @@ def getopt_link(meta):
     return True
 
 
+def getopt_show(meta):
+    if meta.get("gen-markdown-index-2"):
+        return meta.get("gen-markdown-index-2").get("show", True)
+    return True
+
+
 def visit(directory):
     for filename in os.listdir(directory):
         try:
@@ -40,10 +46,22 @@ def visit(directory):
             if os.path.isdir(p):
                 if os.path.isfile(os.path.join(p, "index.yml")):
                     meta = extract_metadata(os.path.join(p, "index.yml"))
-                    yield (meta["id"], meta["title"], p, getopt_link(meta))
+                    yield (
+                        meta["id"],
+                        meta["title"],
+                        p,
+                        getopt_link(meta),
+                        getopt_show(meta),
+                    )
             elif os.path.isfile(p) and p.endswith(".yml") and filename != "index.yml":
                 meta = extract_metadata(p)
-                yield (meta["id"], meta["title"], p, getopt_link(meta))
+                yield (
+                    meta["id"],
+                    meta["title"],
+                    p,
+                    getopt_link(meta),
+                    getopt_show(meta),
+                )
         except Exception as e:
             warnings.warn(f"Failed to process {p}")
             raise
@@ -60,16 +78,21 @@ def process_dir(directory):
     for entry in sorted(list(visit(directory)), key=lambda x: x[1].lower()):
         entry_id = entry[0]
         entry_title = entry[1]
-        entry_link = entry[3]
-        if entry_link:
-            print("  " * level + f"- {{{{\"{entry_id}\"|linktitle}}}}")
-        else:
-            print("  " * level + f"- {{{{'{entry_title}'|title}}}}")
         entry_path = entry[2]
+        entry_link = entry[3]
+        entry_show = entry[4]
+        if entry_show:
+            if entry_link:
+                print("  " * level + f"- {{{{\"{entry_id}\"|linktitle}}}}")
+            else:
+                print("  " * level + f"- {{{{'{entry_title}'|title}}}}")
         if os.path.isdir(entry_path):
-            level += 1
-            process_dir(entry_path)
-            level -= 1
+            if entry_show:
+                level += 1
+                process_dir(entry_path)
+                level -= 1
+            else:
+                process_dir(entry_path)
 
 
 if __name__ == "__main__":

--- a/app/shell/py/pie/tests/test_gen_markdown_index_2.py
+++ b/app/shell/py/pie/tests/test_gen_markdown_index_2.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import subprocess
+
+SCRIPT = Path(__file__).resolve().parents[3] / "bin" / "gen-markdown-index-2"
+
+
+def test_show_property(tmp_path):
+    (tmp_path / "alpha.yml").write_text("id: alpha\ntitle: Alpha\n")
+    (tmp_path / "beta.yml").write_text(
+        "id: beta\ntitle: Beta\n" "gen-markdown-index-2:\n  show: false\n"
+    )
+    hidden = tmp_path / "hidden"
+    hidden.mkdir()
+    (hidden / "index.yml").write_text(
+        "id: hidden\ntitle: Hidden\n" "gen-markdown-index-2:\n  show: false\n"
+    )
+    (hidden / "child.yml").write_text("id: child\ntitle: Child\n")
+
+    result = subprocess.run(
+        [str(SCRIPT), str(tmp_path)], capture_output=True, text=True, check=True
+    )
+    assert result.stdout.strip().splitlines() == [
+        '- {{"alpha"|linktitle}}',
+        '- {{"child"|linktitle}}',
+    ]
+

--- a/docs/guides/gen-markdown-index.md
+++ b/docs/guides/gen-markdown-index.md
@@ -17,3 +17,10 @@ Example output:
 ```jinja
 - {{ {"citation": "Example", "url": "/ex", "link": {"tracking": false}} | linktitle }}
 ```
+
+## gen-markdown-index-2
+
+`gen-markdown-index-2` walks a directory tree of YAML metadata files and prints a
+Markdown list. To exclude an item from the output, set
+`gen-markdown-index-2.show` to `false` in its metadata. When a directory is
+hidden this way, its children are still processed at the same indentation level.

--- a/src/gen-markdown-index/index.yml
+++ b/src/gen-markdown-index/index.yml
@@ -3,3 +3,4 @@ name: gen-markdown-index
 id: dist_gen_markdown_index
 gen-markdown-index-2:
   link: false
+  show: false


### PR DESCRIPTION
## Summary
- hide entries in gen-markdown-index-2 when `gen-markdown-index-2.show` is false
- document new flag and sample metadata
- add unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893c0ac1e548321ae0750fb2fedc723