### PR TITLE
Add tests for detect_html_dicts

### DIFF
--- a/app/shell/py/pie/tests/test_detect_html_dicts.py
+++ b/app/shell/py/pie/tests/test_detect_html_dicts.py
@@ -1,0 +1,31 @@
+import pytest
+
+from pie import detect_html_dicts
+
+
+def test_contains_python_dict_identifies_and_ignores():
+    assert detect_html_dicts.contains_python_dict("{'a': 1}")
+    assert not detect_html_dicts.contains_python_dict("no dict here")
+    assert not detect_html_dicts.contains_python_dict("{0}")
+
+
+def test_main_detects_dict_in_html(tmp_path):
+    html = tmp_path / "page.html"
+    html.write_text("<p>{'a': 1}</p>", encoding="utf-8")
+    rc = detect_html_dicts.main([str(html)])
+    assert rc == 1
+
+
+def test_main_writes_log_file(tmp_path):
+    html = tmp_path / "clean.html"
+    html.write_text("<p>No dict</p>", encoding="utf-8")
+    log = tmp_path / "det.log"
+    rc = detect_html_dicts.main([str(html), "--log", str(log)])
+    assert rc == 0
+    assert log.exists()
+
+
+def test_parse_args_parses_options():
+    args = detect_html_dicts.parse_args(["file.html", "--log", "log.txt"])
+    assert args.html_file == "file.html"
+    assert args.log == "log.txt"


### PR DESCRIPTION
## Summary
- add tests verifying dictionary detection in HTML and log file creation
- add coverage for CLI argument parsing

## Testing
- `pip install beautifulsoup4 loguru`
- `pytest app/shell/py/pie/tests/test_detect_html_dicts.py`


------
https://chatgpt.com/codex/tasks/task_e_6893c2187abc83218f11d5bdc9c63081