### PR TITLE
Limit update-index metadata loading to 10 threads

### DIFF
--- a/app/shell/py/pie/pie/update_index.py
+++ b/app/shell/py/pie/pie/update_index.py
@@ -152,7 +152,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 paths.append(p)
 
         index: dict[str, dict[str, Any]] = {}
-        with ThreadPoolExecutor() as executor:
+        num_workers = min(10, max(2, os.cpu_count() or 1))
+        with ThreadPoolExecutor(max_workers=num_workers) as executor:
             for metadata in executor.map(load_metadata_pair, paths):
                 if metadata:
                     index[metadata["id"]] = metadata


### PR DESCRIPTION
## Summary
- cap metadata loading in `update_index` to at most 10 concurrent threads for predictable parallelism

## Testing
- `pytest app/shell/py/pie/tests`


------
https://chatgpt.com/codex/tasks/task_e_6893c8746e188321b2543f4f564a1198