### PR TITLE
update-index: use batch redis writes

### DIFF
--- a/docs/guides/update-index.md
+++ b/docs/guides/update-index.md
@@ -16,4 +16,4 @@ update-index index.json [--host HOST] [--port PORT] [-l LOGFILE]
 `update-index` also reads the `REDIS_HOST` and `REDIS_PORT` environment
 variables when `--host` or `--port` are not specified.
 
-When a directory is given, `update-index` scans recursively for `.md`, `.yml`, and `.yaml` files, processing each Markdown/YAML pair only once. The command expects an index produced by [`build-index`](build-index.md). Each entry is written to the configured Redis instance using separate keys.
+When a directory is given, `update-index` scans recursively for `.md`, `.yml`, and `.yaml` files, processing each Markdown/YAML pair only once. The command expects an index produced by [`build-index`](build-index.md). Entries are written to the configured Redis instance using pipelined batch writes, with each value stored under its own key.


### PR DESCRIPTION
## Summary
- use pipelined Redis writes in `update-index`
- document new batched Redis behavior

## Testing
- `pytest app/shell/py/pie/tests/test_update_index.py`
- `pytest app/shell/py/pie/tests`


------
https://chatgpt.com/codex/tasks/task_e_6893ccba8834832183f52465b2c9bb4b