### PR TITLE
Add profiling rule for update-index

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -100,6 +100,14 @@ $(BUILD_DIR)/.update-index: $(MARKDOWNS) $(YAMLS)
 	$(Q)for i in $(?); do update-index --host $(REDIS_HOST) --port $(REDIS_PORT) $$i; done
 	$(Q)touch $@
 
+# Generate a cProfile report for update-index
+$(LOG_DIR)/update-index.prof: $(MARKDOWNS) $(YAMLS) | $(LOG_DIR)
+	$(call status,Profile update-index)
+	$(Q)python -m cProfile -o $@ -m pie.update_index $(SRC_DIR)
+
+.PHONY: profile-update-index
+profile-update-index: $(LOG_DIR)/update-index.prof
+
 # Target to minify HTML and CSS files
 # Modifies file timestamps. The preserve option doesn't seem to work.
 $(BUILD_DIR)/.minify:
@@ -147,9 +155,9 @@ $(BUILD_DIR)/%.pdf: %.md | $(BUILD_DIR)
 	$(Q)include-filter $(BUILD_DIR) $(BUILD_DIR)/$*.1.md $(BUILD_DIR)/$*.2.md
 	$(Q)include-filter $(BUILD_DIR) $(BUILD_DIR)/$*.2.md $(BUILD_DIR)/$*.3.md
 	$(Q)$(PANDOC_CMD) \
-$(PANDOC_OPTS_PDF) \
-        -o $@ \
-        $(BUILD_DIR)/$*.3.md
+	$(PANDOC_OPTS_PDF) \
+	-o $@ \
+	$(BUILD_DIR)/$*.3.md
 
 # Clean the build directory by removing all build artifacts
 .PHONY: clean

--- a/docs/guides/redo-mk.md
+++ b/docs/guides/redo-mk.md
@@ -33,6 +33,7 @@ This repository actually uses three Makefiles that work together:
 | `test` | Restarts `nginx-dev` and runs tests defined in `/app/mk/build.mk`. |
 | `pytest` | Runs unit tests for the `pie` package inside the shell container. |
 | `cov` | Generates an HTML coverage report for the `pie` package inside the shell container (output in `log/cov`). |
+| `profile-update-index` | Generates a cProfile report for the `update-index` command. |
 | `up` / `upd` | Starts development containers (`SERVICES`). `upd` runs detached. |
 | `down` | Stops and removes the compose stack. |
 | `clean` | Removes everything under `build/`. |

--- a/redo.mk
+++ b/redo.mk
@@ -69,6 +69,11 @@ test: ## Restart nginx-dev and run tests
 	$(call status,Run tests)
 	$(Q)$(MAKE_CMD) -f /app/mk/build.mk VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
 
+.PHONY: profile-update-index
+profile-update-index: ## Generate cProfile stats for update-index
+	$(call status,Profile update-index)
+	$(Q)$(MAKE_CMD) -f /app/mk/build.mk VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) profile-update-index
+
 # Target to bring up the development Nginx container
 .PHONY: up
 up: ## Start development containers defined in SERVICES
@@ -159,7 +164,7 @@ cov:
 	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell --cov=pie --cov-report=term-missing --cov-report=html:/data/log/cov /press/py/pie/tests
 .PHONY: t
 t: ## Restart nginx-dev and run tests, ansi colors
-	$(call status,Run tests with colors)
+		$(call status,Run tests with colors)
 	$(Q)$(DOCKER_COMPOSE) run --entrypoint make --rm shell -f /app/mk/build.mk VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
 	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell /press/py/pie/tests
 


### PR DESCRIPTION
## Summary
- add cProfile-based profiling rule for `update-index`
- expose profiling rule via top-level `redo.mk`
- document `profile-update-index` target in redo-mk guide
- fix Makefile recipes to use tab indentation

## Testing
- `make -n -f app/shell/mk/build.mk profile-update-index`
- `make -f redo.mk test` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893cf7ef4a48321bb8dffd7f2e7563c