### PR TITLE
indextree: auto-expand filtered paths

### DIFF
--- a/app/indextree/src/IndexTree.jsx
+++ b/app/indextree/src/IndexTree.jsx
@@ -38,12 +38,18 @@ function filterTree(nodes, query) {
 /**
  * Render a single tree node with optional children.
  *
- * @param {{ node: TreeNodeData }} props
+ * @param {{ node: TreeNodeData, forceOpen: boolean }} props
  * @returns {JSX.Element}
  */
-function TreeNode({ node }) {
+function TreeNode({ node, forceOpen }) {
   const [open, setOpen] = useState(false);
   const hasChildren = Boolean(node.children && node.children.length);
+
+  useEffect(() => {
+    if (forceOpen) {
+      setOpen(true);
+    }
+  }, [forceOpen]);
 
   return (
     <>
@@ -61,7 +67,7 @@ function TreeNode({ node }) {
         <Collapse in={open} timeout="auto" unmountOnExit>
           <List component="div" disablePadding sx={{ pl: 4 }}>
             {node.children.map((child) => (
-              <TreeNode key={child.id} node={child} />
+              <TreeNode key={child.id} node={child} forceOpen={forceOpen} />
             ))}
           </List>
         </Collapse>
@@ -103,7 +109,7 @@ export default function IndexTree({ src }) {
       />
       <List sx={{ p: 0 }}>
         {filtered.map((node) => (
-          <TreeNode key={node.id} node={node} />
+          <TreeNode key={node.id} node={node} forceOpen={Boolean(query)} />
         ))}
       </List>
     </div>

--- a/docs/guides/react-index-tree.md
+++ b/docs/guides/react-index-tree.md
@@ -44,4 +44,5 @@ The expected JSON file contains an array of nodes:
 
 Nodes are expandable when they contain a `children` array. Typing in the
 filter box hides entries whose titles do not include the query while
-keeping matching descendants visible.
+automatically expanding the paths to matching descendants so results are
+always visible.


### PR DESCRIPTION
## Summary
- expand ancestors for matching items so filtered results are always visible
- document the auto-expansion behavior in IndexTree guide
- clarify TreeNode prop types

## Testing
- `npm --prefix app/indextree run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893da2cc3b08321875eb700f2bc878a