### PR TITLE
feat: include metadata in indextree-json

### DIFF
--- a/app/shell/py/pie/pie/indextree_json.py
+++ b/app/shell/py/pie/pie/indextree_json.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import warnings
 from pathlib import Path
-from typing import Iterable, List, Dict
+from typing import Any, Dict, Iterable, List
 
-from pie.utils import add_file_logger
+from pie import build_index
+from pie.utils import add_file_logger, logger
 
 
 def title_from(name: str) -> str:
@@ -15,31 +17,105 @@ def title_from(name: str) -> str:
     return name.replace("-", " ").title()
 
 
+def load_metadata_pair(path: Path) -> Dict[str, Any] | None:
+    """Load metadata from ``path`` and a sibling Markdown/YAML file."""
+
+    base = path.with_suffix("")
+    md_path = base.with_suffix(".md")
+    yml_path = base.with_suffix(".yml")
+    yaml_path = base.with_suffix(".yaml")
+
+    md_data = None
+    if md_path.exists():
+        md_data = build_index.process_markdown(str(md_path))
+
+    yaml_data = None
+    yaml_file: Path | None = None
+    if yml_path.exists():
+        yaml_file = yml_path
+        yaml_data = build_index.parse_yaml_metadata(str(yml_path))
+    elif yaml_path.exists():
+        yaml_file = yaml_path
+        yaml_data = build_index.parse_yaml_metadata(str(yaml_path))
+
+    if md_data is None and yaml_data is None:
+        return None
+
+    combined: Dict[str, Any] = {}
+    if md_data:
+        combined.update(md_data)
+    if yaml_data:
+        for k, v in yaml_data.items():
+            if k in combined and combined[k] != v:
+                warnings.warn(
+                    f"Conflict for '{k}', using value from {yaml_file.name}",
+                    UserWarning,
+                )
+            combined[k] = v
+
+    if "id" not in combined:
+        base = path.with_suffix("")
+        combined["id"] = base.name
+        logger.info(
+            "Generated 'id'",
+            filename=str(path.resolve().relative_to(Path.cwd())),
+            id=combined["id"],
+        )
+
+    logger.debug(combined)
+    return combined
+
+
 def scan_dir(root: Path, base: str) -> List[Dict[str, object]]:
-    """Return IndexTree nodes for *root*."""
+    """Return IndexTree nodes for *root* using file metadata."""
+
     nodes: List[Dict[str, object]] = []
     for child in sorted(root.iterdir(), key=lambda p: p.name):
         if child.name.startswith('.'):
             continue
+
         if child.is_dir():
-            url = f"{base}{child.name}"
-            node: Dict[str, object] = {
-                "id": child.name,
-                "title": title_from(child.name),
+            metadata = None
+            for ext in (".md", ".yml", ".yaml"):
+                index_file = child / f"index{ext}"
+                if index_file.exists():
+                    try:
+                        metadata = load_metadata_pair(index_file)
+                    except Exception:  # pragma: no cover - fall back
+                        metadata = None
+                    break
+
+            node_id = metadata.get("id") if metadata else child.name
+            title = metadata.get("title") if metadata else title_from(child.name)
+            url = metadata.get("url") if metadata else f"{base}{child.name}"
+
+            node: Dict[str, Any] = {
+                "id": node_id,
+                "title": title,
                 "url": url,
             }
-            children = scan_dir(child, f"{url}/")
+            children = scan_dir(child, f"{base}{child.name}/")
             if children:
                 node["children"] = children
             nodes.append(node)
         elif child.is_file():
+            if child.name in {"index.md", "index.yml", "index.yaml"}:
+                continue
+
             stem = child.stem
-            url = f"{base}{stem}"
-            nodes.append({
-                "id": stem,
-                "title": title_from(stem),
-                "url": url,
-            })
+            metadata = None
+            if child.suffix.lower() in {".md", ".yml", ".yaml"}:
+                try:
+                    metadata = load_metadata_pair(child)
+                except Exception:  # pragma: no cover - fall back
+                    metadata = None
+
+            node_id = metadata.get("id") if metadata else stem
+            title = metadata.get("title") if metadata else title_from(stem)
+            url = metadata.get("url") if metadata else f"{base}{stem}"
+
+            nodes.append({"id": node_id, "title": title, "url": url})
+
     return nodes
 
 

--- a/docs/guides/react-index-tree.md
+++ b/docs/guides/react-index-tree.md
@@ -8,7 +8,9 @@ styled using [Material UI](https://mui.com/), so make sure
 `@mui/material` and `@mui/icons-material` are available in your project.
 
 The `indextree-json` console script can generate the required JSON by
-scanning a directory and producing nodes for each file and subdirectory:
+scanning a directory and producing nodes for each file and subdirectory.
+Metadata from Markdown frontmatter or companion YAML files is used for
+each entry, mirroring the behaviour of `update-index`:
 
 ```bash
 indextree-json docs > doc-tree.json
@@ -34,9 +36,9 @@ The expected JSON file contains an array of nodes:
   {
     "id": "alpha",
     "title": "Alpha",
-    "url": "/alpha",
+    "url": "/alpha/index.html",
     "children": [
-      { "id": "beta", "title": "Beta", "url": "/alpha/beta" }
+      { "id": "beta", "title": "Beta", "url": "/alpha/beta.html" }
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- use Markdown/YAML metadata when generating IndexTree JSON
- document metadata-aware tree generation
- test metadata handling in indextree-json

## Testing
- `pytest app/shell/py/pie/tests/test_indextree_json.py`
- `pytest` *(fails: FileNotFoundError: No such file or directory: '/app/bin/gen-markdown-index-2')*


------
https://chatgpt.com/codex/tasks/task_e_6893d7e70f4c8321af7489fb4168c6b2