### PR TITLE
Consolidate metadata loader and prune indextree files

### DIFF
--- a/app/shell/py/pie/pie/load_metadata.py
+++ b/app/shell/py/pie/pie/load_metadata.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+import warnings
+
+from pie import build_index
+from pie.utils import logger
+
+
+def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
+    """Load metadata from ``path`` and a sibling Markdown/YAML file.
+
+    If both a ``.md`` and ``.yml``/``.yaml`` exist for the same base name,
+    the metadata from each file is combined. Values from YAML override those
+    from Markdown when keys conflict and a :class:`UserWarning` is emitted.
+    Returns ``None`` if neither file contains metadata.
+    """
+
+    base = path.with_suffix("")
+    md_path = base.with_suffix(".md")
+    yml_path = base.with_suffix(".yml")
+    yaml_path = base.with_suffix(".yaml")
+
+    md_data = None
+    if md_path.exists():
+        md_data = build_index.process_markdown(str(md_path))
+
+    yaml_data = None
+    yaml_file: Path | None = None
+    if yml_path.exists():
+        yaml_file = yml_path
+        yaml_data = build_index.parse_yaml_metadata(str(yml_path))
+    elif yaml_path.exists():
+        yaml_file = yaml_path
+        yaml_data = build_index.parse_yaml_metadata(str(yaml_path))
+
+    if md_data is None and yaml_data is None:
+        return None
+
+    combined: dict[str, Any] = {}
+    if md_data:
+        combined.update(md_data)
+    if yaml_data:
+        for k, v in yaml_data.items():
+            if k in combined and combined[k] != v:
+                warnings.warn(
+                    f"Conflict for '{k}', using value from {yaml_file.name}",
+                    UserWarning,
+                )
+            combined[k] = v
+
+    if "id" not in combined:
+        base = path.with_suffix("")
+        combined["id"] = base.name
+        logger.info(
+            "Generated 'id'",
+            filename=str(path.resolve().relative_to(Path.cwd())),
+            id=combined["id"],
+        )
+
+    logger.debug(combined)
+    return combined

--- a/app/shell/py/pie/pie/update_index.py
+++ b/app/shell/py/pie/pie/update_index.py
@@ -18,8 +18,8 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 
 import redis
-from pie import build_index
 from pie.utils import add_file_logger, logger
+from pie.load_metadata import load_metadata_pair
 
 
 def load_index(path: str | Path) -> Mapping[str, Mapping[str, Any]]:
@@ -50,55 +50,6 @@ def flatten_index(index: Mapping[str, Mapping[str, Any]]) -> Iterable[tuple[str,
         yield from _walk(doc_id, props)
 
 
-def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
-    """Load metadata from ``path`` and a sibling Markdown/YAML file.
-
-    If both a ``.md`` and ``.yml``/``.yaml`` exist for the same base name,
-    the metadata from each file is combined. Values from YAML override those
-    from Markdown when keys conflict and a :class:`UserWarning` is emitted.
-    Returns ``None`` if neither file contains metadata.
-    """
-
-    base = path.with_suffix("")
-    md_path = base.with_suffix(".md")
-    yml_path = base.with_suffix(".yml")
-    yaml_path = base.with_suffix(".yaml")
-
-    md_data = None
-    if md_path.exists():
-        md_data = build_index.process_markdown(str(md_path))
-
-    yaml_data = None
-    yaml_file: Path | None = None
-    if yml_path.exists():
-        yaml_file = yml_path
-        yaml_data = build_index.parse_yaml_metadata(str(yml_path))
-    elif yaml_path.exists():
-        yaml_file = yaml_path
-        yaml_data = build_index.parse_yaml_metadata(str(yaml_path))
-
-    if md_data is None and yaml_data is None:
-        return None
-
-    combined: dict[str, Any] = {}
-    if md_data:
-        combined.update(md_data)
-    if yaml_data:
-        for k, v in yaml_data.items():
-            if k in combined and combined[k] != v:
-                warnings.warn(
-                    f"Conflict for '{k}', using value from {yaml_file.name}",
-                    UserWarning,
-                )
-            combined[k] = v
-
-    if "id" not in combined:
-        base = path.with_suffix('')
-        combined["id"] = base.name
-        logger.info("Generated 'id'", filename=str(path.resolve().relative_to(Path.cwd())), id=combined["id"])
-
-    logger.debug(combined)
-    return combined
 
 
 def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:

--- a/app/shell/py/pie/tests/test_indextree_json.py
+++ b/app/shell/py/pie/tests/test_indextree_json.py
@@ -30,6 +30,8 @@ def test_scan_dir_uses_metadata(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
+    (root / "delta.md").write_text("delta\n", encoding="utf-8")
+
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:


### PR DESCRIPTION
## Summary
- centralize metadata loader into shared module
- use shared loader in update_index
- ignore non-metadata files when generating indextree json

## Testing
- `pytest tests/test_indextree_json.py tests/test_update_index.py -q`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/app/bin/gen-markdown-index')*

------
https://chatgpt.com/codex/tasks/task_e_6893df0e7c70832187135dbd4804e4ca