### PR TITLE
Add optional pdoc service for pie docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ ls app/webp/output
 See [docs/guides/webp-service.md](docs/guides/webp-service.md) for more about how the
 converter works.
 
+### pdoc documentation server
+
+Use [pdoc](https://pdoc.dev) to browse API docs for the `pie` package.
+Start the service with the optional profile:
+
+```bash
+docker compose --profile pdoc up pdoc
+```
+
+Open <http://localhost:8080> to view the documentation.
+
 ## Redis Configuration
 
 The build tools connect to DragonflyDB/Redis using the `REDIS_HOST` and

--- a/app/pdoc/Dockerfile
+++ b/app/pdoc/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /pie
+
+# Install pdoc and dependencies for pie
+COPY ../shell/py/pie/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir pdoc \
+    && pip install --no-cache-dir -r /tmp/requirements.txt
+
+EXPOSE 8080
+ENTRYPOINT ["pdoc", "--http", "0.0.0.0:8080", "pie"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,3 +69,12 @@ services:
       - ./app/shell/py/pie/pie:/press/py/pie/pie
       - ./app/shell/py/pie/tests:/press/py/pie/tests
       - ./src/dep.mk:/app/mk/dep.mk
+
+  pdoc:
+    build: ./app/pdoc
+    entrypoint: ["pdoc", "--http", "0.0.0.0:8080", "pie"]
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./app/shell/py/pie:/pie
+    profiles: ["pdoc"]

--- a/docs/guides/pdoc-service.md
+++ b/docs/guides/pdoc-service.md
@@ -1,0 +1,16 @@
+# pdoc documentation service
+
+The `pdoc` service serves API documentation for the `pie` package using [pdoc](https://pdoc.dev).
+It is disabled by default so it only runs when explicitly requested.
+
+## Running the service
+
+Start the container using the `pdoc` profile:
+
+```bash
+docker compose --profile pdoc up pdoc
+```
+
+Then open <http://localhost:8080> in your browser to explore the documentation.
+
+The service mounts the local `pie` sources, so edits are reflected without rebuilding the image.


### PR DESCRIPTION
## Summary
- add pdoc docker service to browse pie Python documentation
- document optional pdoc service and usage

## Testing
- `make -f redo.mk pytest DOCKER_COMPOSE="docker-compose -f docker-compose.yml"` *(fails: ConnectionError: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_6893e00a1b6c8321bcee586ac63e92ea