### PR TITLE
Sort IndexTree output by title

### DIFF
--- a/app/shell/py/pie/pie/indextree_json.py
+++ b/app/shell/py/pie/pie/indextree_json.py
@@ -70,6 +70,7 @@ def scan_dir(root: Path, base: str) -> List[Dict[str, object]]:
 
             nodes.append({"id": node_id, "title": title, "url": url})
 
+    nodes.sort(key=lambda n: str(n["title"]).casefold())
     return nodes
 
 

--- a/app/shell/py/pie/tests/test_indextree_json.py
+++ b/app/shell/py/pie/tests/test_indextree_json.py
@@ -54,3 +54,37 @@ def test_scan_dir_uses_metadata(tmp_path: Path) -> None:
         {"id": "gamma-doc", "title": "Gamma Doc", "url": "/gamma.html"},
     ]
 
+
+def test_scan_dir_sorts_by_title(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+
+    # File names intentionally do not match title order
+    (root / "b.md").write_text(
+        "---\n"
+        "title: A Doc\n"
+        "id: a-doc\n"
+        "---\n"
+        "b\n",
+        encoding="utf-8",
+    )
+    (root / "a.md").write_text(
+        "---\n"
+        "title: Z Doc\n"
+        "id: z-doc\n"
+        "---\n"
+        "a\n",
+        encoding="utf-8",
+    )
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        tree = scan_dir(Path("src"), "/")
+    finally:
+        os.chdir(cwd)
+    assert tree == [
+        {"id": "a-doc", "title": "A Doc", "url": "/b.html"},
+        {"id": "z-doc", "title": "Z Doc", "url": "/a.html"},
+    ]
+


### PR DESCRIPTION
## Summary
- ensure `indextree-json` sorts nodes by title so users see lists in alphabetical order
- add regression test covering title-based sorting

## Testing
- `pre-commit run --files app/shell/py/pie/pie/indextree_json.py app/shell/py/pie/tests/test_indextree_json.py` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `pytest app/shell/py/pie/tests/test_indextree_json.py`

------
https://chatgpt.com/codex/tasks/task_e_6893e10c1ea483219d8d418efa490530