### PR TITLE
chore: align indextree styling with site

### DIFF
--- a/app/indextree/src/index.css
+++ b/app/indextree/src/index.css
@@ -1,68 +1,7 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+/* Ensure the IndexTree demo uses the site's base styling */
+#indextree-root,
+#indextree-root * {
+  font-family: var(--font-base);
+  color: var(--color-text);
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}

--- a/src/style.css
+++ b/src/style.css
@@ -235,50 +235,17 @@ a {
   padding: 2px;
 }
 
-.internal-link {
-    /*
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4em;
-  padding: 0.2em 0.4em;
-  background-color: #f5f0fa;
-  border: 1px solid #d5c4e6;
-  border-radius: 1em;
-  text-decoration: none;
-  transition: all 0.2s ease-in-out;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
-  margin: 3px;
-  */
-}
-
-/*
-.internal-link:hover {
-  background-color: #e9def6;
-  border-color: #bca2da;
-  color: #3f1d6b;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-}
-*/
-
 .emoji {
   font-size: 1.1em;
   line-height: 1;
 }
-
-.question {
-    font-weight: 600;
-    margin-bottom: 5px;
-}
-
 ol + details.answer {
-    margin-top: 15px;
+  margin-top: 15px;
 }
-
 
 .quiz-container {
   max-width: 600px;
   margin: 2rem auto;
-  font-family: sans-serif;
 }
 
 .question-block {


### PR DESCRIPTION
## Summary
- streamline `src/style.css` by removing unused blocks and consolidating quiz styles
- ensure IndexTree demo inherits site fonts and colors

## Testing
- `npm --prefix app/indextree run lint`
- `npm --prefix app/indextree run build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6893ea7ed854832186124722ac548b45