### PR TITLE
Store source file paths in update-index entries

### DIFF
--- a/app/shell/py/pie/pie/load_metadata.py
+++ b/app/shell/py/pie/pie/load_metadata.py
@@ -50,6 +50,12 @@ def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
                 )
             combined[k] = v
 
+    files: list[Path] = []
+    if yaml_file:
+        files.append(yaml_file)
+    if md_path.exists():
+        files.append(md_path)
+
     if "id" not in combined:
         base = path.with_suffix("")
         combined["id"] = base.name
@@ -58,6 +64,9 @@ def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
             filename=str(path.resolve().relative_to(Path.cwd())),
             id=combined["id"],
         )
+
+    if files:
+        combined["path"] = [str(p.resolve().relative_to(Path.cwd())) for p in files]
 
     logger.debug(combined)
     return combined

--- a/app/shell/py/pie/pie/update_index.py
+++ b/app/shell/py/pie/pie/update_index.py
@@ -40,8 +40,11 @@ def flatten_index(index: Mapping[str, Mapping[str, Any]]) -> Iterable[tuple[str,
             for k, v in obj.items():
                 yield from _walk(f"{prefix}.{k}", v)
         elif isinstance(obj, list):
-            for i, item in enumerate(obj):
-                yield from _walk(f"{prefix}.{i}", item)
+            if prefix.endswith(".path"):
+                yield prefix, json.dumps(obj, ensure_ascii=False)
+            else:
+                for i, item in enumerate(obj):
+                    yield from _walk(f"{prefix}.{i}", item)
         else:
             val = obj if isinstance(obj, str) else json.dumps(obj, ensure_ascii=False)
             yield prefix, val

--- a/docs/guides/update-index.md
+++ b/docs/guides/update-index.md
@@ -1,6 +1,6 @@
 # update-index
 
-Load a JSON index and insert each value into DragonflyDB or Redis. Keys use a dot-separated format of `<id>.<property>` with nested objects and arrays flattened. Complex values are stored as JSON strings.
+Load a JSON index and insert each value into DragonflyDB or Redis. Keys use a dot-separated format of `<id>.<property>` with nested objects and arrays flattened. Complex values are stored as JSON strings. When processing metadata files, the paths to the source files are recorded under `<id>.path` as a JSON array; this `path` array is stored unflattened.
 
 ## Usage
 
@@ -16,4 +16,4 @@ update-index index.json [--host HOST] [--port PORT] [-l LOGFILE]
 `update-index` also reads the `REDIS_HOST` and `REDIS_PORT` environment
 variables when `--host` or `--port` are not specified.
 
-When a directory is given, `update-index` scans recursively for `.md`, `.yml`, and `.yaml` files, processing each Markdown/YAML pair only once. The command expects an index produced by [`build-index`](build-index.md). Entries are written to the configured Redis instance using pipelined batch writes, with each value stored under its own key.
+When a directory is given, `update-index` scans recursively for `.md`, `.yml`, and `.yaml` files, processing each Markdown/YAML pair only once. The command expects an index produced by [`build-index`](build-index.md). Entries are written to the configured Redis instance using pipelined batch writes, with each value stored under its own key, including `id.path` entries pointing to the original files.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -26,7 +26,7 @@ The top-level Makefile (`redo.mk`) drives all host-side automation. It launches 
 ## Build Pipeline
 The shell container executes `app/shell/mk/build.mk` to transform sources into deliverables:
 
-1. Discover Markdown and YAML files and update a Redis-backed index. See [build-index](../guides/build-index.md) and [update-index](../guides/update-index.md) for details on this step.
+1. Discover Markdown and YAML files and update a Redis-backed index. See [build-index](../guides/build-index.md) and [update-index](../guides/update-index.md) for details on this step. Each document's source paths are stored under `<id>.path`.
 2. Convert preprocessed Markdown to HTML and PDF using Pandoc with a shared template and options for table of contents, math rendering, and cross references.
 3. Copy CSS assets and minify the resulting site.
 4. Run link checking and page title validation before marking the build complete. See [checklinks](../guides/checklinks.md) and [check-page-title](../guides/check-page-title.md).


### PR DESCRIPTION
## Summary
- track Markdown/YAML source paths when building metadata
- emit `<id>.path` entries to Redis for each document
- document new `path` field and how it is handled

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893ef4e54708321a27e1d7679720635