### PR TITLE
Use MUI TreeView for index tree

### DIFF
--- a/app/indextree/package-lock.json
+++ b/app/indextree/package-lock.json
@@ -10,8 +10,9 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@mui/icons-material": "^7.1.0",
-        "@mui/material": "^7.1.0",
+        "@mui/icons-material": "^7.3.1",
+        "@mui/lab": "^7.0.0-beta.0",
+        "@mui/material": "^7.3.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1202,6 +1203,50 @@
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/lab": {
+      "version": "7.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-7.0.0-beta.16.tgz",
+      "integrity": "sha512-YiyDU84F6ujjaa5xuItuXa40KN1aPC+8PBkP2OAOJGO2MMvdEicuvkEfVSnikH6uLHtKOwGzOeqEqrfaYxcOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.2",
+        "@mui/system": "^7.3.1",
+        "@mui/types": "^7.4.5",
+        "@mui/utils": "^7.3.1",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^7.3.1",
+        "@mui/material-pigment-css": "^7.3.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
         "@types/react": {
           "optional": true
         }

--- a/app/indextree/package.json
+++ b/app/indextree/package.json
@@ -12,8 +12,9 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@mui/icons-material": "^7.1.0",
-    "@mui/material": "^7.1.0",
+    "@mui/icons-material": "^7.3.1",
+    "@mui/lab": "^7.0.0-beta.0",
+    "@mui/material": "^7.3.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/app/shell/py/pie/pie/indextree_json.py
+++ b/app/shell/py/pie/pie/indextree_json.py
@@ -11,8 +11,8 @@ from pie.utils import add_file_logger
 from pie.update_index import load_index_from_path
 
 
-def title_from(name: str) -> str:
-    """Return a human readable title for *name*."""
+def label_from(name: str) -> str:
+    """Return a human readable label for *name*."""
     return name.replace("-", " ").title()
 
 
@@ -33,7 +33,7 @@ def scan_dir(root: Path, base: str) -> List[Dict[str, object]]:
             name = path[-1]
             node: Dict[str, Any] = {
                 "id": name,
-                "title": title_from(name),
+                "label": label_from(name),
                 "url": f"{base_prefix}/{'/'.join(path)}",
             }
             parent.setdefault("children", []).append(node)
@@ -53,7 +53,7 @@ def scan_dir(root: Path, base: str) -> List[Dict[str, object]]:
             segs = parts[:-1]
             node = get_node(segs)
             node["id"] = metadata.get("id", node["id"])
-            node["title"] = metadata.get("title", node["title"])
+            node["label"] = metadata.get("title", node["label"])
             node["url"] = f"{base_prefix}{url}"
         else:
             parent = get_node(parts[:-1])
@@ -61,13 +61,13 @@ def scan_dir(root: Path, base: str) -> List[Dict[str, object]]:
             parent.setdefault("children", []).append(
                 {
                     "id": metadata.get("id", stem),
-                    "title": metadata.get("title", title_from(stem)),
+                    "label": metadata.get("title", label_from(stem)),
                     "url": f"{base_prefix}{url}",
                 }
             )
 
     def sort(nodes: List[Dict[str, Any]]) -> None:
-        nodes.sort(key=lambda n: str(n["title"]).casefold())
+        nodes.sort(key=lambda n: str(n["label"]).casefold())
         for node in nodes:
             if "children" in node:
                 sort(node["children"])

--- a/app/shell/py/pie/tests/test_indextree_json.py
+++ b/app/shell/py/pie/tests/test_indextree_json.py
@@ -41,17 +41,17 @@ def test_scan_dir_uses_metadata(tmp_path: Path) -> None:
     assert tree == [
         {
             "id": "alpha-sec",
-            "title": "Alpha Section",
+            "label": "Alpha Section",
             "url": "/alpha/index.html",
             "children": [
                 {
                     "id": "beta-doc",
-                    "title": "Beta Doc",
+                    "label": "Beta Doc",
                     "url": "/alpha/beta.html",
                 }
             ],
         },
-        {"id": "gamma-doc", "title": "Gamma Doc", "url": "/gamma.html"},
+        {"id": "gamma-doc", "label": "Gamma Doc", "url": "/gamma.html"},
     ]
 
 
@@ -84,7 +84,7 @@ def test_scan_dir_sorts_by_title(tmp_path: Path) -> None:
     finally:
         os.chdir(cwd)
     assert tree == [
-        {"id": "a-doc", "title": "A Doc", "url": "/b.html"},
-        {"id": "z-doc", "title": "Z Doc", "url": "/a.html"},
+        {"id": "a-doc", "label": "A Doc", "url": "/b.html"},
+        {"id": "z-doc", "label": "Z Doc", "url": "/a.html"},
     ]
 

--- a/docs/guides/react-index-tree.md
+++ b/docs/guides/react-index-tree.md
@@ -3,9 +3,10 @@
 Render a collapsible navigation tree for metadata processed by
 `gen-markdown-index`. The `IndexTree` component loads a JSON
 representation of the directory structure, displays it as an expandable
-list, and provides a text box to filter entries by title. The demo is
+list, and provides a text box to filter entries by label. The demo is
 styled using [Material UI](https://mui.com/), so make sure
-`@mui/material` and `@mui/icons-material` are available in your project.
+`@mui/material`, `@mui/lab`, and `@mui/icons-material` are available in
+your project.
 
 The `indextree-json` console script can generate the required JSON by
 scanning a directory and producing nodes for each file and subdirectory.
@@ -35,16 +36,16 @@ The expected JSON file contains an array of nodes:
 [
   {
     "id": "alpha",
-    "title": "Alpha",
+    "label": "Alpha",
     "url": "/alpha/index.html",
     "children": [
-      { "id": "beta", "title": "Beta", "url": "/alpha/beta.html" }
+      { "id": "beta", "label": "Beta", "url": "/alpha/beta.html" }
     ]
   }
 ]
 ```
 
 Nodes are expandable when they contain a `children` array. Typing in the
-filter box hides entries whose titles do not include the query while
+filter box hides entries whose labels do not include the query while
 automatically expanding the paths to matching descendants so results are
 always visible.


### PR DESCRIPTION
## Summary
- migrate IndexTree React demo to Material UI's TreeView/TreeItem and auto-expand matches
- generate `label` fields from indextree-json for TreeView compatibility
- document new dependencies and data shape for TreeView

## Testing
- `npm run lint`
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/app/bin/gen-markdown-index')*

------
https://chatgpt.com/codex/tasks/task_e_6893f4bd908c832187c3c87a374fc730