### PR TITLE
refactor indextree_json

### DIFF
--- a/app/shell/py/pie/pie/indextree_json.py
+++ b/app/shell/py/pie/pie/indextree_json.py
@@ -1,93 +1,95 @@
-"""Generate IndexTree JSON from a directory structure."""
+"""Generate JSON data for the React ``IndexTree`` component.
+
+This module walks a directory tree of YAML metadata files in the same
+fashion as the ``gen-markdown-index`` script and produces a nested data
+structure describing the entries.  Each item exposes an ``id`` and
+``label`` and, when links are enabled, copies the ``url`` from the
+metadata verbatim.  Directories are represented by items containing a
+``children`` list.
+"""
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Tuple
+
+import yaml
 
 from pie.utils import add_file_logger
-from pie.update_index import load_index_from_path
 
 
-def label_from(name: str) -> str:
-    """Return a human readable label for *name*."""
-    return name.replace("-", " ").title()
+def _load_meta(path: Path) -> Dict[str, Any]:
+    """Load YAML metadata from *path*."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
 
 
-def scan_dir(root: Path, base: str) -> List[Dict[str, object]]:
-    """Return IndexTree nodes for *root* using file metadata."""
+def _opt(meta: Dict[str, Any], key: str, default: bool = True) -> bool:
+    """Return a boolean option from the ``gen-markdown-index`` section."""
 
-    index, _ = load_index_from_path(root)
+    section = meta.get("gen-markdown-index") or {}
+    return bool(section.get(key, default))
 
-    base_prefix = base.rstrip("/")
 
-    root_node: Dict[str, Any] = {"children": []}
-    nodes: Dict[tuple[str, ...], Dict[str, Any]] = {(): root_node}
+def _visit(directory: Path) -> Iterable[Tuple[Dict[str, Any], Path, bool]]:
+    """Yield ``(meta, path, is_dir)`` tuples for *directory* entries."""
 
-    def get_node(path: List[str]) -> Dict[str, Any]:
-        key = tuple(path)
-        if key not in nodes:
-            parent = get_node(path[:-1])
-            name = path[-1]
-            node: Dict[str, Any] = {
-                "id": name,
-                "label": label_from(name),
-                "url": f"{base_prefix}/{'/'.join(path)}",
-            }
-            parent.setdefault("children", []).append(node)
-            nodes[key] = node
-        return nodes[key]
+    for name in os.listdir(directory):
+        p = directory / name
+        if p.is_dir():
+            index = p / "index.yml"
+            if index.is_file():
+                yield _load_meta(index), p, True
+        elif p.is_file() and p.suffix == ".yml" and p.name != "index.yml":
+            yield _load_meta(p), p, False
 
-    for metadata in index.values():
-        url = metadata.get("url")
-        if not url:
-            continue
-        parts = [p for p in url.lstrip("/").split("/") if p]
-        if not parts:
-            continue
-        if parts == ["index.html"]:
-            continue
-        if parts[-1] == "index.html":
-            segs = parts[:-1]
-            node = get_node(segs)
-            node["id"] = metadata.get("id", node["id"])
-            node["label"] = metadata.get("title", node["label"])
-            node["url"] = f"{base_prefix}{url}"
+
+def scan_dir(root: Path) -> List[Dict[str, Any]]:
+    """Return IndexTree nodes for *root* using ``gen-markdown-index`` rules."""
+
+    nodes: List[Dict[str, Any]] = []
+    for meta, path, is_dir in sorted(
+        _visit(root), key=lambda x: str(x[0].get("title", "")).casefold()
+    ):
+        show = _opt(meta, "show")
+        link = _opt(meta, "link")
+        entry_id = meta.get("id")
+        label = meta.get("title", entry_id)
+        url = meta.get("url")
+
+        if is_dir:
+            children = scan_dir(path)
+            if show:
+                node: Dict[str, Any] = {"id": entry_id, "label": label}
+                if link and url:
+                    node["url"] = url
+                if children:
+                    node["children"] = children
+                nodes.append(node)
+            else:
+                nodes.extend(children)
         else:
-            parent = get_node(parts[:-1])
-            stem = parts[-1].rsplit(".", 1)[0]
-            parent.setdefault("children", []).append(
-                {
-                    "id": metadata.get("id", stem),
-                    "label": metadata.get("title", label_from(stem)),
-                    "url": f"{base_prefix}{url}",
-                }
-            )
+            if not show:
+                continue
+            node = {"id": entry_id, "label": label}
+            if link and url:
+                node["url"] = url
+            nodes.append(node)
 
-    def sort(nodes: List[Dict[str, Any]]) -> None:
-        nodes.sort(key=lambda n: str(n["label"]).casefold())
-        for node in nodes:
-            if "children" in node:
-                sort(node["children"])
-
-    children = root_node["children"]
-    sort(children)
-    return children
+    return nodes
 
 
 def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
+
     parser = argparse.ArgumentParser(
-        description="Generate IndexTree JSON from a directory",
+        description="Generate IndexTree JSON from YAML metadata",
     )
     parser.add_argument("root", help="Root directory to scan")
-    parser.add_argument(
-        "--base-url",
-        default="/",
-        help="URL prefix for generated entries",
-    )
     parser.add_argument(
         "-o",
         "--outfile",
@@ -103,10 +105,11 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Iterable[str] | None = None) -> None:
     """Entry point for the ``indextree-json`` console script."""
+
     args = parse_args(argv)
     if args.log:
         add_file_logger(args.log, level="DEBUG")
-    tree = scan_dir(Path(args.root), args.base_url.rstrip('/') + '/')
+    tree = scan_dir(Path(args.root))
     data = json.dumps(tree, indent=2, ensure_ascii=False)
     if args.outfile:
         Path(args.outfile).write_text(data + "\n", encoding="utf-8")
@@ -116,3 +119,4 @@ def main(argv: Iterable[str] | None = None) -> None:
 
 if __name__ == "__main__":  # pragma: no cover
     main()
+

--- a/app/shell/py/pie/tests/test_indextree_json.py
+++ b/app/shell/py/pie/tests/test_indextree_json.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import os
 
 from pie.indextree_json import scan_dir
 
@@ -7,37 +6,21 @@ from pie.indextree_json import scan_dir
 def test_scan_dir_uses_metadata(tmp_path: Path) -> None:
     root = tmp_path / "src"
     (root / "alpha").mkdir(parents=True)
-
     (root / "alpha" / "index.yml").write_text(
-        "title: Alpha Section\nname: Alpha Section\nid: alpha-sec\n", encoding="utf-8"
+        "id: alpha-sec\ntitle: Alpha Section\nurl: /alpha/index.html\n",
+        encoding="utf-8",
     )
-
-    (root / "alpha" / "beta.md").write_text(
-        "---\n"
-        "title: Beta Doc\n"
-        "id: beta-doc\n"
-        "---\n"
-        "beta\n",
+    (root / "alpha" / "beta.yml").write_text(
+        "id: beta-doc\ntitle: Beta Doc\nurl: /alpha/beta.html\n",
+        encoding="utf-8",
+    )
+    (root / "gamma.yml").write_text(
+        "id: gamma-doc\ntitle: Gamma Doc\nurl: /gamma.html\n"
+        "gen-markdown-index:\n  link: false\n",
         encoding="utf-8",
     )
 
-    (root / "gamma.md").write_text(
-        "---\n"
-        "title: Gamma Doc\n"
-        "id: gamma-doc\n"
-        "---\n"
-        "gamma\n",
-        encoding="utf-8",
-    )
-
-    (root / "delta.md").write_text("delta\n", encoding="utf-8")
-
-    cwd = os.getcwd()
-    os.chdir(tmp_path)
-    try:
-        tree = scan_dir(Path("src"), "/")
-    finally:
-        os.chdir(cwd)
+    tree = scan_dir(root)
     assert tree == [
         {
             "id": "alpha-sec",
@@ -51,7 +34,7 @@ def test_scan_dir_uses_metadata(tmp_path: Path) -> None:
                 }
             ],
         },
-        {"id": "gamma-doc", "label": "Gamma Doc", "url": "/gamma.html"},
+        {"id": "gamma-doc", "label": "Gamma Doc"},
     ]
 
 
@@ -60,31 +43,18 @@ def test_scan_dir_sorts_by_title(tmp_path: Path) -> None:
     root.mkdir()
 
     # File names intentionally do not match title order
-    (root / "b.md").write_text(
-        "---\n"
-        "title: A Doc\n"
-        "id: a-doc\n"
-        "---\n"
-        "b\n",
+    (root / "b.yml").write_text(
+        "id: a-doc\ntitle: A Doc\nurl: /custom/b.html\n",
         encoding="utf-8",
     )
-    (root / "a.md").write_text(
-        "---\n"
-        "title: Z Doc\n"
-        "id: z-doc\n"
-        "---\n"
-        "a\n",
+    (root / "a.yml").write_text(
+        "id: z-doc\ntitle: Z Doc\nurl: /custom/a.html\n",
         encoding="utf-8",
     )
 
-    cwd = os.getcwd()
-    os.chdir(tmp_path)
-    try:
-        tree = scan_dir(Path("src"), "/")
-    finally:
-        os.chdir(cwd)
+    tree = scan_dir(root)
     assert tree == [
-        {"id": "a-doc", "label": "A Doc", "url": "/b.html"},
-        {"id": "z-doc", "label": "Z Doc", "url": "/a.html"},
+        {"id": "a-doc", "label": "A Doc", "url": "/custom/b.html"},
+        {"id": "z-doc", "label": "Z Doc", "url": "/custom/a.html"},
     ]
 

--- a/docs/guides/react-index-tree.md
+++ b/docs/guides/react-index-tree.md
@@ -9,9 +9,11 @@ styled using [Material UI](https://mui.com/), so make sure
 your project.
 
 The `indextree-json` console script can generate the required JSON by
-scanning a directory and producing nodes for each file and subdirectory.
-Metadata from Markdown frontmatter or companion YAML files is used for
-each entry, mirroring the behaviour of `update-index`:
+scanning a directory of YAML metadata files and producing nodes for each
+file and subdirectory. Entries honour the same `gen-markdown-index`
+options (`show` and `link`) used by the Markdown index generator. When
+linking is enabled, the `url` property is copied from the metadata
+without modification:
 
 ```bash
 indextree-json docs > doc-tree.json


### PR DESCRIPTION
## Summary
- copy `url` property from YAML metadata when building IndexTree JSON
- document that `indextree-json` uses metadata URLs verbatim
- update tests to supply explicit `url` fields

## Testing
- `pytest app/shell/py/pie/tests/test_indextree_json.py -q`
- `pytest app/shell/py/pie/tests/test_gen_markdown_index.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68940fb4fb5083218db7ce4ca5be7536