### PR TITLE
refactor: extract shared index helpers

### DIFF
--- a/app/shell/py/pie/pie/gen_markdown_index.py
+++ b/app/shell/py/pie/pie/gen_markdown_index.py
@@ -4,70 +4,20 @@
 from __future__ import annotations
 
 import argparse
-import warnings
 from pathlib import Path
 from typing import Iterator
 
-import yaml
-
-
-def extract_metadata(filepath: Path) -> dict | None:
-    """Return parsed YAML metadata for *filepath* or ``None`` if invalid."""
-    try:
-        with filepath.open("r", encoding="utf-8") as f:
-            return yaml.safe_load(f) or {}
-    except Exception as e:  # pragma: no cover - warning path
-        warnings.warn(f"Invalid YAML: {filepath} ({e})")
-        return None
-
-
-def getopt_link(meta: dict) -> bool:
-    """Return whether the item should be linked."""
-    section = meta.get("gen-markdown-index") or {}
-    return section.get("link", True)
-
-
-def getopt_show(meta: dict) -> bool:
-    """Return whether the item should be shown."""
-    section = meta.get("gen-markdown-index") or {}
-    return section.get("show", True)
-
-
-def visit(directory: Path) -> Iterator[tuple[str, str, Path, bool, bool]]:
-    """Yield metadata tuples for entries in *directory*."""
-    for path in directory.iterdir():
-        try:
-            if path.is_dir():
-                index_file = path / "index.yml"
-                if index_file.is_file():
-                    meta = extract_metadata(index_file)
-                    if meta:
-                        yield (
-                            meta["id"],
-                            meta["title"],
-                            path,
-                            getopt_link(meta),
-                            getopt_show(meta),
-                        )
-            elif path.is_file() and path.suffix == ".yml" and path.name != "index.yml":
-                meta = extract_metadata(path)
-                if meta:
-                    yield (
-                        meta["id"],
-                        meta["title"],
-                        path,
-                        getopt_link(meta),
-                        getopt_show(meta),
-                    )
-        except Exception as e:  # pragma: no cover - warning path
-            warnings.warn(f"Failed to process {path}")
-            raise
+from pie.index_tree import walk, getopt_link, getopt_show
 
 
 def generate(directory: Path, level: int = 0) -> Iterator[str]:
     """Yield Markdown list items for *directory* recursively."""
-    for entry in sorted(visit(directory), key=lambda x: x[1].lower()):
-        entry_id, title, path, link, show = entry
+    entries = sorted(walk(directory), key=lambda x: x[0]["title"].lower())
+    for meta, path in entries:
+        entry_id = meta["id"]
+        title = meta["title"]
+        link = getopt_link(meta)
+        show = getopt_show(meta)
         if show:
             if link:
                 yield "  " * level + f'- {{{{"{entry_id}"|linktitle}}}}'

--- a/app/shell/py/pie/pie/indextree_json.py
+++ b/app/shell/py/pie/pie/indextree_json.py
@@ -1,100 +1,45 @@
 #!/usr/bin/env python3
 
 import json
-import os
-import warnings
 from pathlib import Path
 
-import yaml
+from pie.index_tree import walk, getopt_link, getopt_show
 from pie.load_metadata import load_metadata_pair
 
 
-def getopt_link(meta):
-    if meta.get("gen-markdown-index"):
-        return meta.get("gen-markdown-index").get("link", True)
-    return True
-
-
-def getopt_show(meta):
-    if meta.get("gen-markdown-index"):
-        return meta.get("gen-markdown-index").get("show", True)
-    return True
-
-
-def visit(directory):
-    for filename in os.listdir(directory):
-        try:
-            p = os.path.join(directory, filename)
-            if os.path.isdir(p):
-                if os.path.isfile(os.path.join(p, "index.yml")):
-                    meta = load_metadata_pair(Path(os.path.join(p, "index.yml")))
-                    yield (
-                        meta["id"],
-                        meta["title"],
-                        meta.get("url"),
-                        p,
-                        getopt_link(meta),
-                        getopt_show(meta),
-                    )
-            elif os.path.isfile(p) and p.endswith(".yml") and filename != "index.yml":
-                meta = load_metadata_pair(Path(p))
-                yield (
-                    meta["id"],
-                    meta["title"],
-                    meta.get("url"),
-                    p,
-                    getopt_link(meta),
-                    getopt_show(meta),
-                )
-        except Exception as e:
-            warnings.warn(f"Failed to process {p}")
-            raise
-
-
-def process_dir(directory):
-    """
-    Recursively process a directory tree to print structured link entries.
-
-    Args:
-        directory (str): Path to the current directory.
-    """
-    for entry in sorted(list(visit(directory)), key=lambda x: x[1].lower()):
-        entry_id = entry[0]
-        entry_title = entry[1]
-        entry_url = entry[2]
-        entry_path = entry[3]
-        entry_link = entry[4]
-        entry_show = entry[5]
-        if os.path.isdir(entry_path):
+def process_dir(directory: Path):
+    """Recursively process *directory* to yield structured entries."""
+    entries = sorted(
+        walk(directory, loader=load_metadata_pair),
+        key=lambda x: x[0]["title"].lower(),
+    )
+    for meta, path in entries:
+        entry_id = meta["id"]
+        entry_title = meta["title"]
+        entry_url = meta.get("url")
+        entry_link = getopt_link(meta)
+        entry_show = getopt_show(meta)
+        if path.is_dir():
+            children = list(process_dir(path))
             if entry_show:
-                if entry_link:
-                    yield {
-                        "id": entry_id,
-                        "label": entry_title,
-                        "url": entry_url,
-                        "children": list(process_dir(entry_path)),
-                    }
-                else:
-                    yield {
-                        "id": entry_id,
-                        "label": entry_title,
-                        "children": list(process_dir(entry_path)),
-                    }
+                node = {"id": entry_id, "label": entry_title, "children": children}
+                if entry_link and entry_url:
+                    node["url"] = entry_url
+                yield node
             else:
-                process_dir(entry_path)
-                yield from process_dir(entry_path)
+                yield from children
         else:
             if entry_show:
-                if entry_link:
-                    yield {"id": entry_id, "label": entry_title, "url": entry_url}
-                else:
-                    yield {"id": entry_id, "label": entry_title}
+                node = {"id": entry_id, "label": entry_title}
+                if entry_link and entry_url:
+                    node["url"] = entry_url
+                yield node
 
 
 def main():
     import sys
 
-    root_dir = sys.argv[1] if len(sys.argv) > 1 else "."
+    root_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
     data = list(process_dir(root_dir))
     print(json.dumps(data, indent=2))
 


### PR DESCRIPTION
## Summary
- create shared index_tree module with metadata walkers and link/show helpers
- reuse index_tree utilities in gen-markdown-index and indextree-json

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894873343708321a9bad5d5753749a6