### PR TITLE
Add post-build output check

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -114,6 +114,8 @@ test: $(BUILD_DIR)/.minify | $(LOG_DIR)
 	$(Q)$(CHECKLINKS_CMD) http://nginx-dev
 	$(call status,Check page titles)
 	$(Q)check-page-title -x $(CFG_DIR)/check-page-title-exclude.yml $(BUILD_DIR)
+	$(call status,Check post-build artifacts)
+	$(Q)check-post-build -c $(CFG_DIR)/check-post-build.yml
 
 # Create necessary build directories
 $(BUILD_DIR): | $(BUILD_SUBDIRS)

--- a/app/shell/py/pie/pie/__init__.py
+++ b/app/shell/py/pie/pie/__init__.py
@@ -18,6 +18,7 @@ The most commonly used modules are:
 * :mod:`detect_html_dicts` – identify dictionary-like data structures within
   HTML snippets.
 * :mod:`picasso` – bundle assets for diagrams and interactive code examples.
+* :mod:`check_post_build` – verify that expected build artifacts exist.
 
 Use ``help(pie.<module>)`` to view documentation for any of the individual
 modules.
@@ -33,4 +34,5 @@ __all__ = [
     "process_yaml",
     "detect_html_dicts",
     "picasso",
+    "check_post_build",
 ]

--- a/app/shell/py/pie/pie/check_post_build.py
+++ b/app/shell/py/pie/pie/check_post_build.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Check for required build artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import yaml
+
+from pie.utils import add_file_logger, logger
+
+DEFAULT_LOG = "log/check-post-build.txt"
+DEFAULT_CFG = "cfg/check-post-build.yml"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Return parsed command line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Verify that expected build artifacts exist.",
+    )
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="build",
+        help="Root directory containing build artifacts",
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        default=DEFAULT_CFG,
+        help="YAML file listing required paths",
+    )
+    parser.add_argument(
+        "-l",
+        "--log",
+        default=DEFAULT_LOG,
+        help="Write logs to the specified file",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Return ``0`` if all required files exist, ``1`` otherwise."""
+
+    args = parse_args(argv)
+    Path(args.log).parent.mkdir(parents=True, exist_ok=True)
+    add_file_logger(args.log)
+
+    with open(args.config, "r", encoding="utf-8") as cfg:
+        required = yaml.safe_load(cfg) or []
+
+    base = Path(args.directory)
+    missing = False
+    for rel in required:
+        target = base / rel
+        if target.is_file():
+            logger.info("Found artifact", path=str(target))
+        else:
+            logger.error("Missing artifact", path=str(target))
+            missing = True
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -27,6 +27,7 @@ setup(
             'detect-html-dicts=pie.detect_html_dicts:main',
             'indextree-json=pie.indextree_json:main',
             'gen-markdown-index=pie.gen_markdown_index:main',
+            'check-post-build=pie.check_post_build:main',
         ],
     },
 )

--- a/app/shell/py/pie/tests/test_check_post_build.py
+++ b/app/shell/py/pie/tests/test_check_post_build.py
@@ -1,0 +1,32 @@
+from pie import check_post_build
+
+
+def make_cfg(path):
+    path.write_text("- static/indextree.json\n")
+    return path
+
+
+def test_main_reports_missing(tmp_path):
+    build = tmp_path / "build"
+    build.mkdir()
+    cfg = make_cfg(tmp_path / "cfg.yml")
+    rc = check_post_build.main([str(build), "-c", str(cfg), "-l", str(tmp_path / "log.txt")])
+    assert rc == 1
+
+
+def test_main_passes_and_logs(tmp_path):
+    build = tmp_path / "build" / "static"
+    build.mkdir(parents=True)
+    (build / "indextree.json").write_text("{}", encoding="utf-8")
+    cfg = make_cfg(tmp_path / "cfg.yml")
+    log = tmp_path / "log.txt"
+    rc = check_post_build.main([str(tmp_path / "build"), "-c", str(cfg), "-l", str(log)])
+    assert rc == 0
+    assert log.exists()
+
+
+def test_parse_args_defaults():
+    args = check_post_build.parse_args([])
+    assert args.directory == "build"
+    assert args.config == "cfg/check-post-build.yml"
+    assert args.log == "log/check-post-build.txt"

--- a/cfg/check-post-build.yml
+++ b/cfg/check-post-build.yml
@@ -1,0 +1,2 @@
+# Required build artifacts
+- static/indextree.json

--- a/docs/guides/check-post-build.md
+++ b/docs/guides/check-post-build.md
@@ -1,0 +1,17 @@
+# check-post-build
+
+`check-post-build` verifies that expected build artifacts exist after a build
+completes. The list of required paths lives in `cfg/check-post-build.yml`,
+making it easy to extend in the future. Results are written to
+`log/check-post-build.txt`.
+
+## Usage
+
+```bash
+check-post-build [build-directory]
+```
+
+If no directory is provided, `build/` is assumed. Use `-c` to point to a
+different YAML config file. The command logs the outcome of each check and
+exits with a non-zero status when any required file is missing.
+


### PR DESCRIPTION
## Summary
- move post-build artifact check into the `pie` package with a YAML config and file logging
- expose a `check-post-build` console script and integrate it into the test target
- document and unit test the new checker

## Testing
- `pytest app/shell/py/pie/tests/test_check_post_build.py -q`
- `PYTHONPATH=app/shell/py/pie python -m pie.check_post_build || echo 'missing'`
- `mkdir -p build/static && touch build/static/indextree.json`
- `PYTHONPATH=app/shell/py/pie python -m pie.check_post_build && echo 'ok'`
- `cat log/check-post-build.txt`


------
https://chatgpt.com/codex/tasks/task_e_6894deaaaa448321b2c21bbcbb28b1b8