### PR TITLE
Add check-page-title console script

### DIFF
--- a/app/shell/py/pie/pie/__init__.py
+++ b/app/shell/py/pie/pie/__init__.py
@@ -18,6 +18,7 @@ The most commonly used modules are:
 * :mod:`detect_html_dicts` – identify dictionary-like data structures within
   HTML snippets.
 * :mod:`picasso` – bundle assets for diagrams and interactive code examples.
+* :mod:`check_page_title` – ensure HTML files contain non-empty ``<h1>`` tags.
 
 Use ``help(pie.<module>)`` to view documentation for any of the individual
 modules.
@@ -33,4 +34,5 @@ __all__ = [
     "process_yaml",
     "detect_html_dicts",
     "picasso",
+    "check_page_title",
 ]

--- a/app/shell/py/pie/pie/check_page_title.py
+++ b/app/shell/py/pie/pie/check_page_title.py
@@ -1,11 +1,21 @@
-#!/usr/bin/env python3
-"""Check that HTML files contain non-empty <h1> tags."""
+"""Check that HTML files contain non-empty ``<h1>`` tags.
+
+This module provides a ``check-page-title`` console script that scans a
+directory tree for HTML files and verifies that each file contains a first
+level heading.  It mirrors the behaviour of the legacy
+``app/shell/bin/check-page-title`` script.
+"""
+
+from __future__ import annotations
+
+import argparse
 import os
 import sys
 from pathlib import Path
+
 from bs4 import BeautifulSoup
-import argparse
 import yaml
+
 
 # Detect whether we should emit ANSI colour codes. We only use colours when
 # stdout is a TTY and the TERM environment variable is not set to "dumb".
@@ -17,6 +27,7 @@ RESET = "\x1b[0m" if USE_COLOR else ""
 
 
 def check_file(path: Path) -> bool:
+    """Return ``True`` if ``path`` contains a non-empty ``<h1>`` tag."""
     with open(path, "r", encoding="utf-8") as f:
         soup = BeautifulSoup(f, "html.parser")
     h1 = soup.find("h1")
@@ -50,6 +61,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Entry point used by the ``check-page-title`` console script."""
     args = parse_args(argv)
     directory = Path(args.directory).resolve()
     html_files = list(directory.rglob("*.html"))
@@ -80,3 +92,4 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main(sys.argv[1:]))
+

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -27,6 +27,7 @@ setup(
             'detect-html-dicts=pie.detect_html_dicts:main',
             'indextree-json=pie.indextree_json:main',
             'gen-markdown-index=pie.gen_markdown_index:main',
+            'check-page-title=pie.check_page_title:main',
         ],
     },
 )

--- a/app/shell/py/pie/tests/test_check_page_title.py
+++ b/app/shell/py/pie/tests/test_check_page_title.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pie import check_page_title
+
+
+def test_main_pass(tmp_path: Path) -> None:
+    html = tmp_path / "index.html"
+    html.write_text("<html><h1>Title</h1></html>", encoding="utf-8")
+    assert check_page_title.main([str(tmp_path)]) == 0
+
+
+def test_main_fail(tmp_path: Path, capsys) -> None:
+    html = tmp_path / "index.html"
+    html.write_text("<html></html>", encoding="utf-8")
+    assert check_page_title.main([str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert "Missing or empty <h1>" in captured.out
+
+
+def test_main_exclude(tmp_path: Path) -> None:
+    html = tmp_path / "index.html"
+    html.write_text("<html></html>", encoding="utf-8")
+    exclude = tmp_path / "exclude.yml"
+    exclude.write_text("- index.html\n", encoding="utf-8")
+    assert check_page_title.main([str(tmp_path), "-x", str(exclude)]) == 0
+


### PR DESCRIPTION
## Summary
- move HTML page title checker into pie package
- expose new check-page-title console script
- cover page title checker with unit tests

## Testing
- `cd app/shell/py/pie && pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894e5161fc4832185276c3cae232983