### PR TITLE
Ensure IndexTree uses site font

### DIFF
--- a/app/indextree/src/index.css
+++ b/app/indextree/src/index.css
@@ -1,7 +1,7 @@
 /* Ensure the IndexTree demo uses the site's base styling */
 #indextree-root,
 #indextree-root * {
-  font-family: var(--font-base);
+  font-family: var(--font-base, "minion-pro", serif);
   color: var(--color-text);
 }
 


### PR DESCRIPTION
## Summary
- Align IndexTree demo font with site styles by falling back to "minion-pro" when `--font-base` isn't defined.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894e666c79c8321adc22e115411fd7b