### PR TITLE
docs: add docstrings to tests

### DIFF
--- a/app/shell/py/pie/tests/test_build_index.py
+++ b/app/shell/py/pie/tests/test_build_index.py
@@ -7,6 +7,7 @@ from pie import build_index
 
 
 def test_get_url_from_src_md(tmp_path):
+    """'src/foo.md' -> '/foo.html'."""
     path = tmp_path / "src" / "foo.md"
     path.parent.mkdir(parents=True)
     path.write_text("")
@@ -18,6 +19,7 @@ def test_get_url_from_src_md(tmp_path):
 
 
 def test_get_url_invalid_raises(tmp_path):
+    """Unknown path raises an error."""
     bad = tmp_path / "foo.md"
     bad.write_text("")
     os.chdir(tmp_path)
@@ -29,6 +31,7 @@ def test_get_url_invalid_raises(tmp_path):
 
 
 def test_process_markdown_parses_frontmatter(tmp_path):
+    """Frontmatter {'title': 'T'} -> {'title': 'T', 'url': '/doc.html'}."""
     md = tmp_path / "src" / "doc.md"
     md.parent.mkdir(parents=True)
     md.write_text("---\n{\"title\": \"T\"}\n---\nbody")
@@ -41,6 +44,7 @@ def test_process_markdown_parses_frontmatter(tmp_path):
 
 
 def test_parse_yaml_metadata_generates_fields(tmp_path):
+    """YAML {'name': 'Foo'} -> metadata with url/id/citation."""
     yml = tmp_path / "src" / "item.yml"
     yml.parent.mkdir(parents=True)
     yml.write_text('{"name": "Foo"}')
@@ -56,12 +60,14 @@ def test_parse_yaml_metadata_generates_fields(tmp_path):
 
 
 def test_validate_and_insert_duplicate(tmp_path):
+    """Duplicate id triggers KeyError."""
     index = {"a": {"id": "a"}}
     with pytest.raises(KeyError):
         build_index.validate_and_insert_metadata({"id": "a"}, "file", index)
 
 
 def test_build_index_handles_multiple_extensions(tmp_path):
+    """'.md' and '.yml' -> index with both entries."""
     src = tmp_path / "src"
     src.mkdir()
     md = src / "doc.md"
@@ -79,6 +85,7 @@ def test_build_index_handles_multiple_extensions(tmp_path):
 
 
 def test_main_writes_log_file(tmp_path):
+    """CLI writes index.json and build.log."""
     src = tmp_path / "src"
     src.mkdir()
     md = src / "doc.md"

--- a/app/shell/py/pie/tests/test_check_page_title.py
+++ b/app/shell/py/pie/tests/test_check_page_title.py
@@ -6,12 +6,14 @@ from pie import check_page_title
 
 
 def test_main_pass(tmp_path: Path) -> None:
+    """'<h1>Title</h1>' -> exit code 0."""
     html = tmp_path / "index.html"
     html.write_text("<html><h1>Title</h1></html>", encoding="utf-8")
     assert check_page_title.main([str(tmp_path)]) == 0
 
 
 def test_main_fail(tmp_path: Path, capsys) -> None:
+    """Missing <h1> -> exit code 1 with message."""
     html = tmp_path / "index.html"
     html.write_text("<html></html>", encoding="utf-8")
     assert check_page_title.main([str(tmp_path)]) == 1
@@ -20,6 +22,7 @@ def test_main_fail(tmp_path: Path, capsys) -> None:
 
 
 def test_main_exclude(tmp_path: Path) -> None:
+    """exclude.yml skips failing file."""
     html = tmp_path / "index.html"
     html.write_text("<html></html>", encoding="utf-8")
     exclude = tmp_path / "exclude.yml"

--- a/app/shell/py/pie/tests/test_check_post_build.py
+++ b/app/shell/py/pie/tests/test_check_post_build.py
@@ -7,6 +7,7 @@ def make_cfg(path):
 
 
 def test_main_reports_missing(tmp_path):
+    """Missing file -> exit code 1."""
     build = tmp_path / "build"
     build.mkdir()
     cfg = make_cfg(tmp_path / "cfg.yml")
@@ -15,6 +16,7 @@ def test_main_reports_missing(tmp_path):
 
 
 def test_main_passes_and_logs(tmp_path):
+    """Existing file -> exit 0 and write log."""
     build = tmp_path / "build" / "static"
     build.mkdir(parents=True)
     (build / "indextree.json").write_text("{}", encoding="utf-8")
@@ -26,6 +28,7 @@ def test_main_passes_and_logs(tmp_path):
 
 
 def test_parse_args_defaults():
+    """parse_args returns default paths."""
     args = check_post_build.parse_args([])
     assert args.directory == "build"
     assert args.config == "cfg/check-post-build.yml"

--- a/app/shell/py/pie/tests/test_detect_html_dicts.py
+++ b/app/shell/py/pie/tests/test_detect_html_dicts.py
@@ -4,12 +4,14 @@ from pie import detect_html_dicts
 
 
 def test_contains_python_dict_identifies_and_ignores():
+    """"{'a': 1}" -> True; "no dict here" -> False."""
     assert detect_html_dicts.contains_python_dict("{'a': 1}")
     assert not detect_html_dicts.contains_python_dict("no dict here")
     assert not detect_html_dicts.contains_python_dict("{0}")
 
 
 def test_main_detects_dict_in_html(tmp_path):
+    """HTML with dict -> exit 1."""
     html = tmp_path / "page.html"
     html.write_text("<p>{'a': 1}</p>", encoding="utf-8")
     rc = detect_html_dicts.main([str(html)])
@@ -17,6 +19,7 @@ def test_main_detects_dict_in_html(tmp_path):
 
 
 def test_main_writes_log_file(tmp_path):
+    """Clean HTML -> exit 0 and create log."""
     html = tmp_path / "clean.html"
     html.write_text("<p>No dict</p>", encoding="utf-8")
     log = tmp_path / "det.log"
@@ -26,6 +29,7 @@ def test_main_writes_log_file(tmp_path):
 
 
 def test_parse_args_parses_options():
+    """parse_args returns file and log paths."""
     args = detect_html_dicts.parse_args(["file.html", "--log", "log.txt"])
     assert args.html_file == "file.html"
     assert args.log == "log.txt"

--- a/app/shell/py/pie/tests/test_gen_markdown_index.py
+++ b/app/shell/py/pie/tests/test_gen_markdown_index.py
@@ -2,6 +2,7 @@ from pie.gen_markdown_index import generate
 
 
 def test_show_property(tmp_path):
+    """Nodes with 'show: false' are skipped."""
     (tmp_path / "alpha.yml").write_text("id: alpha\ntitle: Alpha\n")
     (tmp_path / "beta.yml").write_text(
         "id: beta\ntitle: Beta\n" "gen-markdown-index:\n  show: false\n",

--- a/app/shell/py/pie/tests/test_include_filter.py
+++ b/app/shell/py/pie/tests/test_include_filter.py
@@ -10,6 +10,7 @@ from pie import include_filter
 
 
 def test_parse_metadata_returns_dict():
+    """Front matter -> metadata dict."""
     include_filter.outfile = io.StringIO()
     f = io.StringIO("---\n{\"title\": \"Foo\"}\n---\nBody")
     data = include_filter.parse_metadata_or_print_first_line(f)
@@ -18,6 +19,7 @@ def test_parse_metadata_returns_dict():
 
 
 def test_parse_metadata_prints_line():
+    """No front matter -> first line output."""
     out = io.StringIO()
     include_filter.outfile = out
     f = io.StringIO("First line\nSecond")
@@ -27,12 +29,14 @@ def test_parse_metadata_prints_line():
 
 
 def test_md_to_html_links():
+    """'.md' links -> '.html' links."""
     line = "See [Doc](dist/docs/guides/file.md) and [X](x.md)"
     converted = include_filter.md_to_html_links(line)
     assert converted == "See [Doc](dist/docs/guides/file.html) and [X](x.html)"
 
 
 def test_new_filestem_skips_existing(tmp_path):
+    """Find next available stem like diagram2."""
     (tmp_path / "diagram0.svg").write_text("")
     (tmp_path / "diagram1.mmd").write_text("")
     stem = include_filter.new_filestem(str(tmp_path / "diagram"))
@@ -40,6 +44,7 @@ def test_new_filestem_skips_existing(tmp_path):
 
 
 def test_include_writes_output(tmp_path):
+    """include() writes processed markdown."""
     md = tmp_path / "doc.md"
     md.write_text("---\n{\"title\": \"Title\"}\n---\n# H1\nText\n")
     include_filter.outfile = io.StringIO()
@@ -50,6 +55,7 @@ def test_include_writes_output(tmp_path):
 
 
 def test_mermaid_creates_files(tmp_path):
+    """Mermaid block -> .mmd and .png files."""
     include_filter.figcount = 0
     include_filter.outdir = str(tmp_path)
     include_filter.outfile = io.StringIO()
@@ -68,6 +74,7 @@ def test_mermaid_creates_files(tmp_path):
 
 
 def test_main_writes_log_file(tmp_path):
+    """CLI writes output and log."""
     outdir = tmp_path / "out"
     outdir.mkdir()
     infile = tmp_path / "doc.md"
@@ -88,6 +95,7 @@ def test_main_writes_log_file(tmp_path):
 
 
 def test_yield_lines_reads_until_fence():
+    """yield_lines stops before ``` fence."""
     f = io.StringIO("one\ntwo\n```\nthree\n")
     lines = list(include_filter.yield_lines(f))
     assert lines == ["one\n", "two\n"]
@@ -95,6 +103,7 @@ def test_yield_lines_reads_until_fence():
 
 
 def test_parse_args_parses_all_options():
+    """parse_args reads outdir, infile, outfile, log."""
     args = include_filter.parse_args([
         "out", "in.md", "out.md", "--log", "log.txt"
     ])
@@ -105,6 +114,7 @@ def test_parse_args_parses_all_options():
 
 
 def test_include_deflist_entry_handles_files_and_dirs(tmp_path):
+    """Files + directory -> combined <dt>/<dd> output."""
     f1 = tmp_path / "a.md"
     f1.write_text("---\n{\"title\": \"A\"}\n---\nA body\n")
     sub = tmp_path / "sub"
@@ -118,6 +128,7 @@ def test_include_deflist_entry_handles_files_and_dirs(tmp_path):
 
 
 def test_include_deflist_entry_sort_fn(tmp_path):
+    """Custom sort_fn orders entries descending."""
     f1 = tmp_path / "a.md"
     f1.write_text("---\n{\"title\": \"A\"}\n---\nA\n")
     f2 = tmp_path / "b.md"
@@ -133,6 +144,7 @@ def test_include_deflist_entry_sort_fn(tmp_path):
 
 
 def test_main_executes_lines_individually_and_tracks_headings(tmp_path):
+    """Main runs each line; heading_level increments."""
     outdir = tmp_path / "out"
     outdir.mkdir()
     infile = tmp_path / "doc.md"
@@ -145,6 +157,7 @@ def test_main_executes_lines_individually_and_tracks_headings(tmp_path):
 
 
 def test_script_entry_point(tmp_path, monkeypatch):
+    """Running module executes main."""
     outdir = tmp_path / "out"
     outdir.mkdir()
     infile = tmp_path / "doc.md"

--- a/app/shell/py/pie/tests/test_indextree_json.py
+++ b/app/shell/py/pie/tests/test_indextree_json.py
@@ -10,6 +10,7 @@ def write_yaml(path: Path, data: dict) -> None:
 
 
 def test_process_dir_builds_tree(tmp_path):
+    """YAML files -> hierarchical tree."""
     src = tmp_path / "src"
     alpha = src / "alpha"
     alpha.mkdir(parents=True)
@@ -37,6 +38,7 @@ def test_process_dir_builds_tree(tmp_path):
 
 
 def test_process_dir_honours_show_and_link(tmp_path):
+    """show:False hides nodes; link:False omits URL."""
     src = tmp_path / "src"
     alpha = src / "alpha"
     delta = src / "delta"

--- a/app/shell/py/pie/tests/test_link_tracking_html.py
+++ b/app/shell/py/pie/tests/test_link_tracking_html.py
@@ -31,7 +31,7 @@ def _collect_tracking_disabled_urls(src_root: Path) -> list[str]:
 
 
 def test_tracking_false_links_have_attributes():
-    """Ensure disabled-tracking links in HTML have the expected attributes."""
+    """Links with ``tracking: false`` -> rel/target attrs."""
 
     build_dir = Path("/data/build")
     if not build_dir.is_dir():

--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -7,6 +7,7 @@ from pie import picasso
 
 
 def test_generate_rule_basic():
+    """generate_rule('src/foo/bar.yml') -> build/foo/bar.{yml,html} rule."""
     rule = picasso.generate_rule(Path("src/foo/bar.yml")).strip()
     expected = (
         "build/foo/bar.yml: src/foo/bar.yml\n"
@@ -21,6 +22,7 @@ def test_generate_rule_basic():
 
 
 def test_main_prints_rules(tmp_path, capsys):
+    """CLI prints rule for doc.yml."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()
@@ -33,6 +35,7 @@ def test_main_prints_rules(tmp_path, capsys):
 
 
 def test_main_writes_log_file(tmp_path):
+    """--log writes picasso.log."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()
@@ -45,6 +48,7 @@ def test_main_writes_log_file(tmp_path):
 
 
 def test_generate_dependencies(tmp_path):
+    """link to 'quickstart' -> build/index.md: build/quickstart.md."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()
@@ -61,6 +65,7 @@ def test_generate_dependencies(tmp_path):
 
 
 def test_dependencies_from_include_filter(tmp_path):
+    """include('src/inc.md') -> build/index.md: build/inc.md."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()
@@ -77,6 +82,7 @@ def test_dependencies_from_include_filter(tmp_path):
 
 
 def test_circular_dependencies_are_removed(tmp_path):
+    """Circular links a<->b -> only a:b and warning."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()
@@ -98,6 +104,7 @@ def test_circular_dependencies_are_removed(tmp_path):
 
 
 def test_collect_ids_invalid_yaml(tmp_path):
+    """Malformed YAML still yields id in set."""
     src = tmp_path / "src"
     src.mkdir()
     (src / "bad.yml").write_text(":\n- [")
@@ -108,16 +115,19 @@ def test_collect_ids_invalid_yaml(tmp_path):
 
 
 def test_has_path_seen_returns_false():
+    """_has_path({}, 'a','b',{'a'}) -> False."""
     assert picasso._has_path({}, "a", "b", {"a"}) is False
 
 
 def test_remove_circular_dependencies_no_colon():
+    """'_remove_circular_dependencies({'phony','a: b'})' preserves phony."""
     rules = {"phony", "a: b"}
     result = picasso._remove_circular_dependencies(rules)
     assert result == ["a: b", "phony"]
 
 
 def test_generate_dependencies_skips_other_extensions(tmp_path):
+    """note.txt in src -> no dependencies."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()
@@ -129,6 +139,7 @@ def test_generate_dependencies_skips_other_extensions(tmp_path):
 
 
 def test_generate_dependencies_logs_read_error(tmp_path, monkeypatch):
+    """Read failure -> empty deps."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()
@@ -150,6 +161,7 @@ def test_generate_dependencies_logs_read_error(tmp_path, monkeypatch):
 
 
 def test_generate_dependencies_ignores_missing_id(tmp_path):
+    """link to missing id -> no deps."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()
@@ -163,6 +175,7 @@ def test_generate_dependencies_ignores_missing_id(tmp_path):
 
 
 def test_generate_dependencies_handles_syntax_error(tmp_path):
+    """Bad include syntax -> no deps."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()
@@ -176,6 +189,7 @@ def test_generate_dependencies_handles_syntax_error(tmp_path):
 
 
 def test_include_deflist_entry_with_glob_and_directory(tmp_path):
+    """include_deflist_entry('defs', glob='*.md') -> deps for each file."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()
@@ -197,6 +211,7 @@ def test_include_deflist_entry_with_glob_and_directory(tmp_path):
 
 
 def test_include_with_absolute_directory(tmp_path):
+    """include('/abs/path') -> dependency uses absolute path."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()
@@ -215,6 +230,7 @@ def test_include_with_absolute_directory(tmp_path):
 
 
 def test_main_errors_on_missing_directory(tmp_path):
+    """Missing src dir -> SystemExit 1."""
     build = tmp_path / "build"
     with pytest.raises(SystemExit) as exc:
         picasso.main(["--src", str(tmp_path / "missing"), "--build", str(build)])
@@ -222,6 +238,7 @@ def test_main_errors_on_missing_directory(tmp_path):
 
 
 def test_main_prints_dependencies(tmp_path, capsys):
+    """main prints build/index.md: build/quickstart.md."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()
@@ -237,6 +254,7 @@ def test_main_prints_dependencies(tmp_path, capsys):
 
 
 def test_run_as_module_executes_main(tmp_path, monkeypatch, capsys):
+    """runpy.run_path executes picasso.main."""
     src = tmp_path / "src"
     build = tmp_path / "build"
     src.mkdir()

--- a/app/shell/py/pie/tests/test_process_yaml.py
+++ b/app/shell/py/pie/tests/test_process_yaml.py
@@ -4,6 +4,7 @@ from pie import process_yaml
 
 
 def test_main_generates_metadata(tmp_path):
+    """item.yml -> metadata with url/citation/id."""
     src = tmp_path / "src"
     src.mkdir()
     inp = src / "item.yml"
@@ -23,6 +24,7 @@ def test_main_generates_metadata(tmp_path):
 
 
 def test_main_writes_log_file(tmp_path):
+    """CLI writes processed YAML and log."""
     src = tmp_path / "src"
     src.mkdir()
     inp = src / "doc.yml"

--- a/app/shell/py/pie/tests/test_render_study_json.py
+++ b/app/shell/py/pie/tests/test_render_study_json.py
@@ -5,6 +5,7 @@ from pie import render_study_json
 
 
 def test_render_study_basic():
+    """Template question -> rendered with index data."""
     index = {"item": {"name": "Foo"}}
     questions = [
         {"q": "Name {{item['name']}}", "c": ["A", "B"], "a": [0, "Because {{item['name']}}"]}
@@ -14,6 +15,7 @@ def test_render_study_basic():
 
 
 def test_main_outputs_stdout(tmp_path, capsys):
+    """CLI prints rendered study JSON."""
     index_file = tmp_path / "index.json"
     study_file = tmp_path / "study.json"
     index = {"val": {"name": "Bar"}}
@@ -27,6 +29,7 @@ def test_main_outputs_stdout(tmp_path, capsys):
 
 
 def test_main_writes_file(tmp_path):
+    """'-o out.json' writes output file."""
     index_file = tmp_path / "index.json"
     study_file = tmp_path / "study.json"
     out_file = tmp_path / "out.json"
@@ -39,6 +42,7 @@ def test_main_writes_file(tmp_path):
 
 
 def test_main_writes_log_file(tmp_path):
+    """'--log study.log' creates log file."""
     index_file = tmp_path / "index.json"
     study_file = tmp_path / "study.json"
     log_file = tmp_path / "study.log"

--- a/app/shell/py/pie/tests/test_render_template.py
+++ b/app/shell/py/pie/tests/test_render_template.py
@@ -10,36 +10,42 @@ def test_default_class():
 
 
 def test_override_class():
+    """link.class overrides default."""
     desc = {"citation": "foo", "url": "/f", "link": {"class": "external"}}
     html = render_template.render_link(desc, style="title")
     assert 'class="external"' in html
 
 
 def test_tracking_false_adds_attributes():
+    """tracking False -> rel/target attrs."""
     desc = {"link": {"tracking": False}}
     opts = render_template.get_tracking_options(desc)
     assert opts == 'rel="noopener noreferrer" target="_blank"'
 
 
 def test_tracking_true_returns_empty():
+    """tracking True -> no extra attrs."""
     desc = {"link": {"tracking": True}}
     opts = render_template.get_tracking_options(desc)
     assert opts == ""
 
 
 def test_no_link_returns_empty():
+    """No link section -> empty options."""
     desc = {"citation": "foo"}
     opts = render_template.get_tracking_options(desc)
     assert opts == ""
 
 
 def test_missing_tracking_interpreted_as_false():
+    """Absent tracking treated as False."""
     desc = {"link": {}}
     opts = render_template.get_tracking_options(desc)
     assert opts == 'rel="noopener noreferrer" target="_blank"'
 
 
 def test_linktitle_uses_redis(monkeypatch):
+    """Redis provides citation and url."""
     fake = fakeredis.FakeRedis(decode_responses=True)
     fake.set("item.citation", "Item")
     fake.set("item.url", "/i")
@@ -52,6 +58,7 @@ def test_linktitle_uses_redis(monkeypatch):
 
 
 def test_linktitle_missing_raises(monkeypatch):
+    """Unknown key -> SystemExit."""
     fake = fakeredis.FakeRedis(decode_responses=True)
     monkeypatch.setattr(render_template, "redis_conn", fake)
     render_template.index_json = {}
@@ -61,12 +68,14 @@ def test_linktitle_missing_raises(monkeypatch):
 
 
 def test_linktitle_skips_small_words():
+    """Title style capitalizes but skips small words."""
     desc = {"citation": "movement in a circle", "url": "/c"}
     html = render_template.render_link(desc, style="title")
     assert ">Movement in a Circle<" in html
 
 
 def test_link_uses_redis_tracking_and_ignores_icon(monkeypatch):
+    """Redis data with tracking adds attrs, icon skipped."""
     fake = fakeredis.FakeRedis(decode_responses=True)
     fake.set("entry.citation", "link text")
     fake.set("entry.url", "/link")
@@ -83,6 +92,7 @@ def test_link_uses_redis_tracking_and_ignores_icon(monkeypatch):
 
 
 def test_linkcap_includes_icon_and_capitalizes(monkeypatch):
+    """style='cap' prepends icon and capitalizes first word."""
     fake = fakeredis.FakeRedis(decode_responses=True)
     fake.set("entry.citation", "foo bar")
     fake.set("entry.url", "/link")
@@ -98,6 +108,7 @@ def test_linkcap_includes_icon_and_capitalizes(monkeypatch):
 
 
 def test_linkicon_includes_icon_without_capitalization(monkeypatch):
+    """Default style shows icon; citation unchanged."""
     fake = fakeredis.FakeRedis(decode_responses=True)
     fake.set("entry.citation", "foo bar")
     fake.set("entry.url", "/link")
@@ -113,6 +124,7 @@ def test_linkicon_includes_icon_without_capitalization(monkeypatch):
 
 
 def test_link_icon_title_capitalizes_each_word_and_includes_icon(monkeypatch):
+    """style='title' capitalizes all words and shows icon."""
     fake = fakeredis.FakeRedis(decode_responses=True)
     fake.set("entry.citation", "foo bar")
     fake.set("entry.url", "/link")
@@ -127,6 +139,7 @@ def test_link_icon_title_capitalizes_each_word_and_includes_icon(monkeypatch):
 
 
 def test_linkshort_uses_short_citation_and_ignores_icon(monkeypatch):
+    """citation='short' uses short text without icon."""
     fake = fakeredis.FakeRedis(decode_responses=True)
     fake.set("entry.citation.short", "Short")
     fake.set("entry.url", "/link")
@@ -142,12 +155,14 @@ def test_linkshort_uses_short_citation_and_ignores_icon(monkeypatch):
 
 
 def test_render_link_with_anchor():
+    """anchor='bar' -> href endswith '#bar'."""
     desc = {"citation": "foo", "url": "/f"}
     html = render_template.render_link(desc, anchor="bar")
     assert '<a href="/f#bar"' in html
 
 
 def test_wrapper_accepts_anchor(monkeypatch):
+    """link() adds anchor to href."""
     fake = fakeredis.FakeRedis(decode_responses=True)
     fake.set("entry.citation", "Foo")
     fake.set("entry.url", "/link")

--- a/app/shell/py/pie/tests/test_render_template_misc.py
+++ b/app/shell/py/pie/tests/test_render_template_misc.py
@@ -3,38 +3,45 @@ from pie import render_jinja_template as render_template
 
 
 def test_get_desc_returns_metadata(monkeypatch):
+    """Existing entry -> metadata dict."""
     monkeypatch.setattr(render_template, "_get_metadata", lambda name: {"id": name})
     assert render_template.get_desc("entry") == {"id": "entry"}
 
 
 def test_get_desc_missing_raises(monkeypatch):
+    """Missing entry -> SystemExit."""
     monkeypatch.setattr(render_template, "_get_metadata", lambda name: None)
     with pytest.raises(SystemExit):
         render_template.get_desc("entry")
 
 
 def test_to_alpha_index_maps():
+    """Indices 0..3 -> 'a'..'d'."""
     assert [render_template.to_alpha_index(i) for i in range(4)] == list("abcd")
 
 
 def test_read_yaml_yields_toc(tmp_path):
+    """YAML toc list -> yielded items."""
     yml = tmp_path / "t.yml"
     yml.write_text("toc:\n - 1\n - 2\n", encoding="utf-8")
     assert list(render_template.read_yaml(yml)) == [1, 2]
 
 
 def test_extract_front_matter(tmp_path):
+    """Front matter returns dict."""
     md = tmp_path / "f.md"
     md.write_text("---\ntitle: Hi\n---\nbody\n", encoding="utf-8")
     assert render_template.extract_front_matter(md) == {"title": "Hi"}
 
 
 def test_extract_front_matter_missing(tmp_path):
+    """Missing front matter -> None."""
     md = tmp_path / "f.md"
     md.write_text("no front matter", encoding="utf-8")
     assert render_template.extract_front_matter(md) is None
 
 
 def test_render_jinja_renders_snippet():
+    """Template uses variables from index_json."""
     render_template.index_json = {"name": "world"}
     assert render_template.render_jinja("Hello {{ name }}") == "Hello world"

--- a/app/shell/py/pie/tests/test_update_index.py
+++ b/app/shell/py/pie/tests/test_update_index.py
@@ -7,6 +7,7 @@ from pie import update_index
 
 
 def test_main_inserts_keys(tmp_path, monkeypatch):
+    """JSON index -> Redis keys like quickstart.title."""
     index_data = {
         "quickstart": {
             "title": "Quickstart",
@@ -32,6 +33,7 @@ def test_main_inserts_keys(tmp_path, monkeypatch):
 
 
 def test_main_handles_arrays(tmp_path, monkeypatch):
+    """Lists become indexed Redis keys."""
     index_data = {
         "quickstart": {
             "tags": ["foo", "bar"],
@@ -56,6 +58,7 @@ def test_main_handles_arrays(tmp_path, monkeypatch):
 
 
 def test_main_directory_processes_yamls(tmp_path, monkeypatch):
+    """Directory of yml -> Redis entries for each."""
     src = tmp_path / "src"
     src.mkdir()
     (src / "a.yml").write_text('{"name": "Foo"}')
@@ -77,6 +80,7 @@ def test_main_directory_processes_yamls(tmp_path, monkeypatch):
 
 
 def test_main_single_yaml_file(tmp_path, monkeypatch):
+    """Single YAML file populates Redis."""
     src = tmp_path / "src"
     src.mkdir()
     yml = src / "item.yml"
@@ -96,6 +100,7 @@ def test_main_single_yaml_file(tmp_path, monkeypatch):
 
 
 def test_main_combines_md_and_yaml(tmp_path, monkeypatch):
+    """Markdown + YAML -> merged metadata."""
     src = tmp_path / "src"
     src.mkdir()
     md = src / "doc.md"
@@ -119,6 +124,7 @@ def test_main_combines_md_and_yaml(tmp_path, monkeypatch):
 
 
 def test_directory_pair_processed_once(tmp_path, monkeypatch):
+    """Processing a directory handles md/yml pair once."""
     src = tmp_path / "src"
     src.mkdir()
     (src / "doc.md").write_text("---\n{\"title\": \"Md\"}\n---\n")
@@ -139,6 +145,7 @@ def test_directory_pair_processed_once(tmp_path, monkeypatch):
 
 
 def test_main_inserts_path(tmp_path, monkeypatch):
+    """Stores source paths as JSON array."""
     src = tmp_path / "src"
     src.mkdir()
     md = src / "doc.md"
@@ -159,6 +166,7 @@ def test_main_inserts_path(tmp_path, monkeypatch):
 
 
 def test_main_missing_id_generates(tmp_path, monkeypatch):
+    """Missing id -> generated from filename."""
     src = tmp_path / "src"
     src.mkdir()
     md = src / "doc.md"
@@ -177,6 +185,7 @@ def test_main_missing_id_generates(tmp_path, monkeypatch):
 
 
 def test_directory_processed_in_parallel(tmp_path, monkeypatch):
+    """Concurrent processing still populates Redis."""
     src = tmp_path / "src"
     src.mkdir()
     (src / "a.yml").write_text('{"name": "A"}')
@@ -205,6 +214,7 @@ def test_directory_processed_in_parallel(tmp_path, monkeypatch):
 
 
 def test_logs_execution_time_and_count(tmp_path, monkeypatch):
+    """Logging shows file count and elapsed time."""
     src = tmp_path / "src"
     src.mkdir()
     (src / "a.yml").write_text('{"name": "A"}')


### PR DESCRIPTION
## Summary
- add concise docstrings to test cases with example inputs and outputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894e8580b7083219417235994cf83bb