### PR TITLE
refactor shell helper scripts for clarity

### DIFF
--- a/app/shell/bin/checklinks
+++ b/app/shell/bin/checklinks
@@ -1,20 +1,50 @@
 #!/usr/bin/env bash
+
+# checklinks
+# Crawl a site and report broken links.
+
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
+LOG_DIR="log"
+LOG_FILE="${LOG_DIR}/checklinks.txt"
+PATTERN='broken link!!!|ERROR [45][0-9]{2}'
+
+usage() {
     echo "Usage: $0 <url>" >&2
-    exit 1
-fi
+}
 
-log=$(mktemp)
-trap 'rm -f "$log"' EXIT
+run_wget() {
+    local url="$1"
+    mkdir -p "$LOG_DIR"
+    wget --spider \
+        --recursive \
+        --no-directories \
+        --level=3 \
+        --hsts-file=/dev/null \
+        "$url" 2>&1 | tee "$LOG_FILE"
+    return "${PIPESTATUS[0]}"
+}
 
-pattern='broken link!!!|ERROR [45][0-9]{2}'
+main() {
+    if [[ $# -ne 1 ]]; then
+        usage
+        exit 1
+    fi
 
-wget --spider \
-    --recursive \
-    --no-directories \
-    --level=3 \
-    --hsts-file=/dev/null \
-    "$1" 2>&1 | tee log/checklinks.txt
-exit ${PIPESTATUS[0]}
+    local status=0
+    run_wget "$1" || status=$?
+
+    if grep -Eq "$PATTERN" "$LOG_FILE"; then
+        status=1
+    fi
+
+    if (( status != 0 )); then
+        echo "Broken links detected" >&2
+    else
+        echo "No broken links found."
+    fi
+
+    return "$status"
+}
+
+main "$@"

--- a/app/shell/bin/preprocess
+++ b/app/shell/bin/preprocess
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-set -euo pipefail
-VERBOSE=0
-if [ $VERBOSE -eq 1 ]; then set -x; fi
 
-# process_file <input_markdown>
-#   - mirrors: build/%.md: %.md
-#   - runs include-filter 3× (3 levels of include expansion)
-#   - then runs link, then emojify
+# preprocess
+# Expand includes, render links, and substitute emoji in Markdown files.
+
+set -euo pipefail
+
+VERBOSE="${VERBOSE:-0}"
+(( VERBOSE )) && set -x
+
 process_file() {
     local input="$1"
     # strip leading src/ if present, then prefix with build/
@@ -24,19 +25,26 @@ process_file() {
     # Render links using metadata from Redis
     render-jinja-template "$output" > "$output.$$"
     mv "$output.$$" "$output"
-    if [ $VERBOSE -eq 1 ]; then cat "$output"; fi
+    (( VERBOSE )) && cat "$output"
 
     # run emojify, write to a temp file and atomically move
     emojify < "$output" > "$output.tmp"
     mv "$output.tmp" "$output"
 }
 
-# main
-if [[ $# -lt 1 ]]; then
-    echo "Usage: $0 <markdown-file> [more-markdown-files...]"
-    exit 1
-fi
+usage() {
+    echo "Usage: $0 <markdown-file>..." >&2
+}
 
-for md in "$@"; do
-    process_file "$md"
-done
+main() {
+    if [[ $# -lt 1 ]]; then
+        usage
+        exit 1
+    fi
+
+    for md in "$@"; do
+        process_file "$md"
+    done
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- streamline `checklinks` with functions, logging, and explicit status messages
- modernize `preprocess` with a main entry point, usage helper, and env-based verbosity

## Testing
- `shellcheck app/shell/bin/checklinks app/shell/bin/preprocess`


------
https://chatgpt.com/codex/tasks/task_e_6894e9d05e2883218558d176fef11e08