### PR TITLE
docs: update makefile documentation

### DIFF
--- a/app/indextree/dep.mk
+++ b/app/indextree/dep.mk
@@ -1,5 +1,6 @@
 # Build rules for the IndexTree React interface.
 # Included by src/dep.mk so build.mk knows how to generate assets.
+# See docs/guides/dep-mk.md for details on dependency makefiles.
 
 # Ensure built JS is available under build/static/
 all: build/static/indextree.js

--- a/app/quiz/dep.mk
+++ b/app/quiz/dep.mk
@@ -1,6 +1,7 @@
 # Build rules for the React quiz interface.
 # Included by the main `dep.mk` so that `build.mk` knows how to
 # generate and copy quiz assets.
+# See docs/guides/dep-mk.md for details on dependency makefiles.
 #
 # The `all` target ensures that the compiled JavaScript bundle and any
 # accompanying JSON files are present under `build/quiz/`.

--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -1,16 +1,16 @@
 # Makefile for building and managing Press
-# This file executes inside the shell container. See dist/docs/guides/redo-mk.md
+# This file executes inside the shell container. See docs/guides/redo-mk.md
 # for how to run these targets from the host.
 
 # Override MAKEFLAGS (so your settings can’t be clobbered by the environment)
-# docker-make passes these flags to the container; see dist/docs/guides/docker-make.md
+# docker-make passes these flags to the container; see docs/guides/docker-make.md
 override MAKEFLAGS += --warn-undefined-variables  \
                       --no-builtin-rules        \
                       -j16                      \
                       --no-print-directory      \
 
 # Export it so sub-makes see the same flags
-# docker-make handles running this file inside Docker; see dist/docs/guides/docker-make.md
+# docker-make handles running this file inside Docker; see docs/guides/docker-make.md
 export MAKEFLAGS
 
 # Verbosity control
@@ -38,7 +38,7 @@ CFG_DIR   := cfg
 
 # Define the Pandoc command used inside the container
 #       -T: Don't allocate pseudo-tty. Makes parallel builds work.
-# For container setup details, see dist/docs/guides/docker-make.md.
+# For container setup details, see docs/guides/docker-make.md.
 PANDOC_CMD := pandoc
 PANDOC_TEMPLATE := $(SRC_DIR)/pandoc-template.html
 
@@ -108,7 +108,7 @@ $(BUILD_DIR)/.minify:
 	$(Q)touch $@
 
 .PHONY: test
-# Triggered by the test target in redo.mk; see dist/docs/guides/redo-mk.md.
+# Triggered by the test target in redo.mk; see docs/guides/redo-mk.md.
 test: $(BUILD_DIR)/.minify | $(LOG_DIR)
 	$(call status,Run link check)
 	$(Q)$(CHECKLINKS_CMD) http://nginx-dev
@@ -131,7 +131,7 @@ $(BUILD_DIR)/%.css: %.css | $(BUILD_DIR)
 	$(Q)cp $< $@
 
 # Include and preprocess Markdown files up to three levels deep
-# See dist/docs/guides/preprocess.md for preprocessing details
+# See docs/guides/preprocess.md for preprocessing details
 $(BUILD_DIR)/%.md: %.md | $(BUILD_DIR)
 	$(call status,Preprocess $<)
 	$(Q)preprocess $<
@@ -142,7 +142,7 @@ $(BUILD_DIR)/%.html: $(BUILD_DIR)/%.md $(PANDOC_TEMPLATE) | $(BUILD_DIR)
 	$(Q)$(PANDOC_CMD) $(PANDOC_OPTS) -o $@ $<
 
 # Generate PDF from processed Markdown using Pandoc
-# include-filter usage is documented in dist/docs/guides/include-filter.md
+# include-filter usage is documented in docs/guides/include-filter.md
 $(BUILD_DIR)/%.pdf: %.md | $(BUILD_DIR)
 	$(call status,Generate PDF $@)
 	$(Q)include-filter $(BUILD_DIR) $< $(BUILD_DIR)/$*.1.md
@@ -159,7 +159,8 @@ clean:
 	$(call status,Remove build artifacts)
 	$(Q)-rm -rf $(BUILD_DIR)
 
-# Optionally include user dependencies; see dist/docs/guides/redo-mk.md.
+# Optionally include user dependencies; see docs/guides/redo-mk.md and
+# docs/guides/dep-mk.md.
 -include /app/mk/dep.mk
 
 $(BUILD_DIR)/picasso.mk: $(YAMLS) | $(BUILD_DIR)

--- a/redo.mk
+++ b/redo.mk
@@ -9,7 +9,8 @@ override MAKEFLAGS += --warn-undefined-variables  \
 export MAKEFLAGS
 
 # Containers started when running `up`/`upd`.
-# See docs/guides/redo-mk.md for details on targets and variables.
+# See docs/guides/redo-mk.md for details on targets and variables and
+# docs/guides/dep-mk.md for dependency file conventions.
 SERVICES := nginx-dev dragonfly
 
 SRC_DIR   := src

--- a/src/dep.mk
+++ b/src/dep.mk
@@ -1,2 +1,5 @@
+## Aggregate dependency rules for Press. Included by build.mk so
+## module-specific makefiles can provide asset targets.
+## See docs/guides/dep-mk.md for details on dependency makefiles.
 include app/quiz/dep.mk
 include app/indextree/dep.mk


### PR DESCRIPTION
## Summary
- link Makefile help comments to dep-mk docs
- document aggregated dependency Makefiles
- update build Makefile to point to current doc paths and mention dep.mk usage

## Testing
- `make -f redo.mk help`
- `make -f redo.mk test` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894f43868f48321bd33ee9b0cb6a222