### PR TITLE
Warn when pubdate missing for changed src files

### DIFF
--- a/app/shell/py/pie/tests/test_update_pubdate.py
+++ b/app/shell/py/pie/tests/test_update_pubdate.py
@@ -28,7 +28,7 @@ def test_updates_yaml_from_markdown_change(tmp_path: Path, monkeypatch, capsys) 
     captured = capsys.readouterr()
     assert captured.out.strip() == expected_line
     log_text = (tmp_path / "log/update-pubdate.txt").read_text(encoding="utf-8")
-    assert log_text.strip() == expected_line
+    assert expected_line in log_text
 
 
 def test_updates_markdown_frontmatter(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -51,7 +51,7 @@ def test_updates_markdown_frontmatter(tmp_path: Path, monkeypatch, capsys) -> No
     captured = capsys.readouterr()
     assert captured.out.strip() == expected_line
     log_text = (tmp_path / "log/update-pubdate.txt").read_text(encoding="utf-8")
-    assert log_text.strip() == expected_line
+    assert expected_line in log_text
 
 
 def test_ignores_pubdate_in_body(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -68,3 +68,23 @@ def test_ignores_pubdate_in_body(tmp_path: Path, monkeypatch, capsys) -> None:
     assert "Jan 01, 2000" in md.read_text(encoding="utf-8")
     captured = capsys.readouterr()
     assert captured.out.strip() == ""
+
+
+def test_warns_when_pubdate_missing(tmp_path: Path, monkeypatch) -> None:
+    """A warning is logged when pubdate can't be updated for a src file."""
+    src = tmp_path / "src"
+    src.mkdir()
+    md = src / "doc.md"
+    md.write_text("---\ntitle: Test\n---\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(update_pubdate, "get_changed_files", lambda: [Path("src/doc.md")])
+
+    warnings: list[str] = []
+    handle = update_pubdate.logger.add(warnings.append, level="WARNING")
+    try:
+        update_pubdate.main([])
+    finally:
+        update_pubdate.logger.remove(handle)
+
+    assert any("pubdate not updated" in m for m in warnings)

--- a/docs/reference/update-pubdate.md
+++ b/docs/reference/update-pubdate.md
@@ -13,3 +13,6 @@ update-pubdate
 
 Each updated file is printed as `<path>: <old> -> <new>` and the same information
 is logged to `log/update-pubdate.txt`.
+
+If a file under `src` is modified but no `pubdate` field can be updated, a
+warning is logged.


### PR DESCRIPTION
## Summary
- use pie.logger in update-pubdate and log to file
- warn when a modified file under src lacks an updated pubdate
- document new warning and test for it

## Testing
- `pytest app/shell/py/pie/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_689504c8f450832197c54b2a4ea82730