### PR TITLE
refactor logging setup helpers

### DIFF
--- a/app/shell/py/pie/pie/build_index.py
+++ b/app/shell/py/pie/pie/build_index.py
@@ -11,7 +11,7 @@ import os
 from typing import Any, Dict, Optional
 
 import yaml
-from pie.utils import add_file_logger, logger
+from pie.utils import logger, add_log_argument, setup_file_logger
 
 
 def get_url(filename: str) -> Optional[str]:
@@ -222,11 +222,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--output",
         help="Path to write the JSON index (defaults to stdout)",
     )
-    parser.add_argument(
-        "-l",
-        "--log",
-        help="Write logs to the specified file",
-    )
+    add_log_argument(parser)
     return parser.parse_args(argv)
 
 
@@ -234,8 +230,7 @@ def main(argv: list[str] | None = None) -> None:
     """Build the index and write JSON output."""
     args = parse_args(argv)
 
-    if args.log:
-        add_file_logger(args.log, level="DEBUG")
+    setup_file_logger(args.log)
 
     index = build_index(args.source_dir)
 

--- a/app/shell/py/pie/pie/check_post_build.py
+++ b/app/shell/py/pie/pie/check_post_build.py
@@ -7,7 +7,7 @@ import argparse
 from pathlib import Path
 import yaml
 
-from pie.utils import add_file_logger, logger
+from pie.utils import logger, add_log_argument, setup_file_logger
 
 DEFAULT_LOG = "log/check-post-build.txt"
 DEFAULT_CFG = "cfg/check-post-build.yml"
@@ -31,12 +31,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_CFG,
         help="YAML file listing required paths",
     )
-    parser.add_argument(
-        "-l",
-        "--log",
-        default=DEFAULT_LOG,
-        help="Write logs to the specified file",
-    )
+    add_log_argument(parser, default=DEFAULT_LOG)
     return parser.parse_args(argv)
 
 
@@ -45,7 +40,7 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parse_args(argv)
     Path(args.log).parent.mkdir(parents=True, exist_ok=True)
-    add_file_logger(args.log)
+    setup_file_logger(args.log)
 
     with open(args.config, "r", encoding="utf-8") as cfg:
         required = yaml.safe_load(cfg) or []

--- a/app/shell/py/pie/pie/detect_html_dicts.py
+++ b/app/shell/py/pie/pie/detect_html_dicts.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import re
 from bs4 import BeautifulSoup
-from pie.utils import add_file_logger, logger
+from pie.utils import logger, add_log_argument, setup_file_logger
 
 def contains_python_dict(text: str) -> bool:
     """Return ``True`` if *text* looks like a Python dictionary literal."""
@@ -20,11 +20,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Check for Python dictionaries in HTML text nodes",
     )
     parser.add_argument("html_file", help="Path to the HTML file to inspect")
-    parser.add_argument(
-        "-l",
-        "--log",
-        help="Write logs to the specified file",
-    )
+    add_log_argument(parser)
     return parser.parse_args(argv)
 
 
@@ -33,8 +29,7 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parse_args(argv)
 
-    if args.log:
-        add_file_logger(args.log, level="DEBUG")
+    setup_file_logger(args.log)
 
     with open(args.html_file, "r", encoding="utf-8") as f:
         soup = BeautifulSoup(f, "html.parser")

--- a/app/shell/py/pie/pie/include_filter.py
+++ b/app/shell/py/pie/pie/include_filter.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import IO, Iterable, Callable
 
 import yaml
-from pie.utils import add_file_logger, logger
+from pie.utils import logger, add_log_argument, setup_file_logger
 
 MD_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\.md\)")
 
@@ -165,11 +165,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("outdir", help="Output directory for diagrams")
     parser.add_argument("infile", help="Input Markdown file")
     parser.add_argument("outfile", help="Output Markdown file")
-    parser.add_argument(
-        "-l",
-        "--log",
-        help="Write logs to the specified file",
-    )
+    add_log_argument(parser)
     return parser.parse_args(argv)
 
 
@@ -186,8 +182,7 @@ def main(argv: list[str] | None = None) -> None:
 
     args = parse_args(argv)
 
-    if args.log:
-        add_file_logger(args.log, level="DEBUG")
+    setup_file_logger(args.log)
 
     outdir = args.outdir
     infilename = args.infile

--- a/app/shell/py/pie/pie/picasso.py
+++ b/app/shell/py/pie/pie/picasso.py
@@ -17,7 +17,7 @@ import sys
 from pathlib import Path
 
 import yaml
-from pie.utils import add_file_logger, logger
+from pie.utils import logger, add_log_argument, setup_file_logger
 
 
 def generate_rule(
@@ -236,11 +236,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="build",
         help="Directory where build artifacts are written",
     )
-    parser.add_argument(
-        "-l",
-        "--log",
-        help="Write logs to the specified file",
-    )
+    add_log_argument(parser)
     return parser.parse_args(argv)
 
 
@@ -248,8 +244,7 @@ def main(argv: list[str] | None = None) -> None:
     """Entry point: print Makefile rules for ``.yml`` files under ``src_root``."""
 
     args = parse_args(argv)
-    if args.log:
-        add_file_logger(args.log, level="DEBUG")
+    setup_file_logger(args.log)
     src_root = Path(args.src)
     build_root = Path(args.build)
 

--- a/app/shell/py/pie/pie/process_yaml.py
+++ b/app/shell/py/pie/pie/process_yaml.py
@@ -8,7 +8,7 @@ from typing import Iterable
 
 import yaml
 
-from pie.utils import add_file_logger, logger
+from pie.utils import logger, add_log_argument, setup_file_logger
 from pie import build_index
 
 
@@ -19,19 +19,14 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("input", help="Source YAML file")
     parser.add_argument("output", help="Destination file to write")
-    parser.add_argument(
-        "-l",
-        "--log",
-        help="Write logs to the specified file",
-    )
+    add_log_argument(parser)
     return parser.parse_args(list(argv) if argv is not None else None)
 
 
 def main(argv: Iterable[str] | None = None) -> None:
     """Entry point used by the ``process-yaml`` console script."""
     args = parse_args(argv)
-    if args.log:
-        add_file_logger(args.log, level="DEBUG")
+    setup_file_logger(args.log)
 
     try:
         metadata = build_index.parse_yaml_metadata(args.input)

--- a/app/shell/py/pie/pie/render_jinja_template.py
+++ b/app/shell/py/pie/pie/render_jinja_template.py
@@ -19,7 +19,7 @@ import redis
 import yaml
 from flatten_dict import unflatten
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
-from pie.utils import add_file_logger, logger, read_json, read_utf8
+from pie.utils import logger, read_json, read_utf8, add_log_argument, setup_file_logger
 
 DEFAULT_CONFIG = Path("cfg/render-jinja-template.yml")
 
@@ -363,11 +363,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--index",
         help="Optional path to index.json",
     )
-    parser.add_argument(
-        "-l",
-        "--log",
-        help="Write logs to the specified file",
-    )
+    add_log_argument(parser)
     parser.add_argument(
         "-c",
         "--config",
@@ -383,8 +379,7 @@ def main(argv: list[str] | None = None) -> None:
     global index_json
     args = parse_args(argv)
 
-    if args.log:
-        add_file_logger(args.log, level="DEBUG")
+    setup_file_logger(args.log)
 
     global config
     config = load_config(args.config)

--- a/app/shell/py/pie/pie/render_study_json.py
+++ b/app/shell/py/pie/pie/render_study_json.py
@@ -13,7 +13,7 @@ import json
 from pathlib import Path
 from typing import Any, Iterable, List
 
-from pie.utils import add_file_logger, logger, read_json
+from pie.utils import logger, read_json, add_log_argument, setup_file_logger
 
 from .render_jinja_template import create_env
 
@@ -58,11 +58,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--output",
         help="Optional file to write the rendered JSON (defaults to stdout)",
     )
-    parser.add_argument(
-        "-l",
-        "--log",
-        help="Write logs to the specified file",
-    )
+    add_log_argument(parser)
     return parser.parse_args(argv)
 
 
@@ -70,8 +66,7 @@ def main(argv: list[str] | None = None) -> None:
     """Entry point for the ``pie.render_study_json`` module."""
 
     args = parse_args(argv)
-    if args.log:
-        add_file_logger(args.log, level="DEBUG")
+    setup_file_logger(args.log)
 
     index_json = read_json(args.index)
     study_json = read_json(args.study)

--- a/app/shell/py/pie/pie/update_index.py
+++ b/app/shell/py/pie/pie/update_index.py
@@ -18,7 +18,7 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 
 import redis
-from pie.utils import add_file_logger, logger
+from pie.utils import logger, add_log_argument, setup_file_logger
 from pie.load_metadata import load_metadata_pair
 
 
@@ -64,7 +64,7 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
         "path",
         help="Path to index.json, a metadata file, or a directory containing YAML",
     )
-    parser.add_argument("-l", "--log", help="Write logs to the specified file")
+    add_log_argument(parser)
     parser.add_argument(
         "--host",
         default=os.getenv("REDIS_HOST", "dragonfly"),
@@ -152,8 +152,7 @@ def load_index_from_path(path: Path) -> tuple[dict[str, dict[str, Any]], int]:
 def main(argv: Iterable[str] | None = None) -> None:
     """Entry point for the ``update-index`` console script."""
     args = parse_args(argv)
-    if args.log:
-        add_file_logger(args.log, level="DEBUG")
+    setup_file_logger(args.log)
 
     start = time.perf_counter()
     path = Path(args.path)

--- a/app/shell/py/pie/pie/utils/__init__.py
+++ b/app/shell/py/pie/pie/utils/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import sys
+import argparse
 
 from loguru import logger
 
@@ -56,3 +57,24 @@ def add_file_logger(filename: str, level: str = "DEBUG") -> None:
     """Add a log sink that writes to *filename* at the given *level*."""
 
     logger.add(filename, format=LOG_FORMAT, level=level)
+
+
+def add_log_argument(parser: argparse.ArgumentParser, *, default: str | None = None) -> None:
+    """Add a standard ``--log`` argument to *parser*.
+
+    Parameters
+    ----------
+    parser:
+        ``argparse`` parser to which the argument should be added.
+    default:
+        Optional default path for the log file.
+    """
+
+    parser.add_argument("-l", "--log", default=default, help="Write logs to the specified file")
+
+
+def setup_file_logger(log_path: str | None, *, level: str = "DEBUG") -> None:
+    """Configure file logging when ``log_path`` is provided."""
+
+    if log_path:
+        add_file_logger(log_path, level=level)


### PR DESCRIPTION
## Summary
- centralize `--log` CLI argument and file logger setup in `pie.utils`
- refactor CLI helpers to use new logging utilities and reduce duplication

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68958472d33c83218cccf0952d877791