### PR TITLE
Add create-post script for generating post templates

### DIFF
--- a/app/shell/py/pie/pie/create_post.py
+++ b/app/shell/py/pie/pie/create_post.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+import yaml
+
+from pie.utils import add_file_logger, logger
+
+__all__ = ["main"]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Create a new post with Markdown and YAML files",
+    )
+    parser.add_argument("path", help="Base path for the new post without extension")
+    parser.add_argument(
+        "-l",
+        "--log",
+        help="Write logs to the specified file",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the ``create-post`` console script."""
+    args = parse_args(argv)
+    if args.log:
+        add_file_logger(args.log, level="INFO")
+
+    base = Path(args.path)
+    base.parent.mkdir(parents=True, exist_ok=True)
+
+    md_path = base.with_suffix(".md")
+    yml_path = base.with_suffix(".yml")
+
+    md_path.touch()
+    metadata = {"author": "", "pubdate": "", "title": "", "name": base.name}
+    with yml_path.open("w", encoding="utf-8") as yf:
+        yaml.safe_dump(metadata, yf, sort_keys=False)
+
+    logger.info("Created post", md=str(md_path), yml=str(yml_path))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -30,6 +30,7 @@ setup(
             'gen-markdown-index=pie.gen_markdown_index:main',
             'check-page-title=pie.check_page_title:main',
             'check-post-build=pie.check_post_build:main',
+            'create-post=pie.create_post:main',
         ],
     },
 )

--- a/app/shell/py/pie/tests/test_create_post.py
+++ b/app/shell/py/pie/tests/test_create_post.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from pie import create_post
+
+
+def test_create_post_creates_files(tmp_path: Path) -> None:
+    target = tmp_path / "blog" / "my-post"
+    create_post.main([str(target)])
+
+    md_file = target.with_suffix(".md")
+    yml_file = target.with_suffix(".yml")
+
+    assert md_file.exists(), "Markdown file should be created"
+    assert yml_file.exists(), "YAML file should be created"
+
+    data = yaml.safe_load(yml_file.read_text(encoding="utf-8"))
+    assert set(data) == {"author", "pubdate", "title", "name"}
+    assert data["name"] == "my-post"


### PR DESCRIPTION
## Summary
- add `create-post` console script to scaffold Markdown and YAML files
- register `create-post` as a pie console entry point
- test that `create-post` writes files with template metadata

## Testing
- `cd app/shell/py/pie && pytest`

------
https://chatgpt.com/codex/tasks/task_e_689585cf5fc88321bffd759b2644c952