### PR TITLE
Refactor YAML file handling with utility helpers

### DIFF
--- a/app/shell/py/pie/pie/build_index.py
+++ b/app/shell/py/pie/pie/build_index.py
@@ -11,7 +11,7 @@ import os
 from typing import Any, Dict, Optional
 
 import yaml
-from pie.utils import logger, add_log_argument, setup_file_logger
+from pie.utils import logger, add_log_argument, setup_file_logger, read_yaml
 
 
 def get_url(filename: str) -> Optional[str]:
@@ -103,18 +103,17 @@ def parse_yaml_metadata(filepath: str) -> Optional[Dict[str, Any]]:
         `None`.
     """
     try:
-        with open(filepath, encoding="utf-8") as yf:
-            metadata = yaml.safe_load(yf)
-            if "url" not in metadata:
-                metadata["url"] = get_url(filepath)
-            if "citation" not in metadata:
-                # Intentionally use indexing so we get an exception here.
-                # The name field must exist.
-                metadata["citation"] = metadata["name"].lower()
-            if "id" not in metadata:
-                base, _ = os.path.splitext(filepath)
-                metadata["id"] = base.split(os.sep)[-1]
-            return metadata
+        metadata = read_yaml(filepath)
+        if "url" not in metadata:
+            metadata["url"] = get_url(filepath)
+        if "citation" not in metadata:
+            # Intentionally use indexing so we get an exception here.
+            # The name field must exist.
+            metadata["citation"] = metadata["name"].lower()
+        if "id" not in metadata:
+            base, _ = os.path.splitext(filepath)
+            metadata["id"] = base.split(os.sep)[-1]
+        return metadata
     except yaml.YAMLError:
         logger.warning("Failed to parse YAML file", filename=filepath)
         raise

--- a/app/shell/py/pie/pie/check_page_title.py
+++ b/app/shell/py/pie/pie/check_page_title.py
@@ -14,7 +14,7 @@ import sys
 from pathlib import Path
 
 from bs4 import BeautifulSoup
-import yaml
+from pie.utils import read_yaml
 
 
 # Detect whether we should emit ANSI colour codes. We only use colours when
@@ -67,8 +67,7 @@ def main(argv: list[str] | None = None) -> int:
     html_files = list(directory.rglob("*.html"))
     exclude: set[Path] = set()
     if args.exclude:
-        with open(args.exclude, "r", encoding="utf-8") as exf:
-            data = yaml.safe_load(exf) or []
+        data = read_yaml(args.exclude) or []
         for item in data:
             p = Path(item)
             if not p.is_absolute():

--- a/app/shell/py/pie/pie/check_post_build.py
+++ b/app/shell/py/pie/pie/check_post_build.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-import yaml
-
-from pie.utils import logger, add_log_argument, setup_file_logger
+from pie.utils import logger, add_log_argument, setup_file_logger, read_yaml
 
 DEFAULT_LOG = "log/check-post-build.txt"
 DEFAULT_CFG = "cfg/check-post-build.yml"
@@ -42,8 +40,7 @@ def main(argv: list[str] | None = None) -> int:
     Path(args.log).parent.mkdir(parents=True, exist_ok=True)
     setup_file_logger(args.log)
 
-    with open(args.config, "r", encoding="utf-8") as cfg:
-        required = yaml.safe_load(cfg) or []
+    required = read_yaml(args.config) or []
 
     base = Path(args.directory)
     missing = False

--- a/app/shell/py/pie/pie/create_post.py
+++ b/app/shell/py/pie/pie/create_post.py
@@ -4,9 +4,7 @@ import argparse
 from pathlib import Path
 from typing import Sequence
 
-import yaml
-
-from pie.utils import add_file_logger, logger
+from pie.utils import add_file_logger, logger, write_yaml
 
 __all__ = ["main"]
 
@@ -39,8 +37,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     md_path.touch()
     metadata = {"author": "", "pubdate": "", "title": "", "name": base.name}
-    with yml_path.open("w", encoding="utf-8") as yf:
-        yaml.safe_dump(metadata, yf, sort_keys=False)
+    write_yaml(metadata, str(yml_path))
 
     logger.info("Created post", md=str(md_path), yml=str(yml_path))
     return 0

--- a/app/shell/py/pie/pie/index_tree.py
+++ b/app/shell/py/pie/pie/index_tree.py
@@ -4,14 +4,13 @@ import warnings
 from pathlib import Path
 from typing import Iterator, Mapping, Any, Tuple, Callable
 
-import yaml
+from pie.utils import read_yaml
 
 
 def load_yaml_metadata(filepath: Path) -> Mapping[str, Any] | None:
     """Return parsed YAML metadata for *filepath* or ``None`` if invalid."""
     try:
-        with filepath.open("r", encoding="utf-8") as f:
-            return yaml.safe_load(f) or {}
+        return read_yaml(str(filepath)) or {}
     except Exception as e:  # pragma: no cover - warning path
         warnings.warn(f"Invalid YAML: {filepath} ({e})")
         return None

--- a/app/shell/py/pie/pie/picasso.py
+++ b/app/shell/py/pie/pie/picasso.py
@@ -17,7 +17,7 @@ import sys
 from pathlib import Path
 
 import yaml
-from pie.utils import logger, add_log_argument, setup_file_logger
+from pie.utils import logger, add_log_argument, setup_file_logger, read_yaml
 
 
 def generate_rule(
@@ -88,10 +88,9 @@ def collect_ids(src_root: Path) -> dict[str, Path]:
                         if isinstance(data, dict):
                             doc_id = data.get("id")
                 else:
-                    with open(path, "r", encoding="utf-8") as f:
-                        data = yaml.safe_load(f) or {}
-                        if isinstance(data, dict):
-                            doc_id = data.get("id")
+                    data = read_yaml(str(path)) or {}
+                    if isinstance(data, dict):
+                        doc_id = data.get("id")
             except Exception:
                 logger.warning("Failed to parse metadata", file=str(path))
 

--- a/app/shell/py/pie/pie/process_yaml.py
+++ b/app/shell/py/pie/pie/process_yaml.py
@@ -6,9 +6,7 @@ import argparse
 import sys
 from typing import Iterable
 
-import yaml
-
-from pie.utils import logger, add_log_argument, setup_file_logger
+from pie.utils import logger, add_log_argument, setup_file_logger, write_yaml
 from pie import build_index
 
 
@@ -38,8 +36,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         logger.error("No metadata found", filename=args.input)
         sys.exit(1)
 
-    with open(args.output, "w", encoding="utf-8") as out:
-        yaml.safe_dump(metadata, out, allow_unicode=True, sort_keys=False)
+    write_yaml(metadata, args.output)
 
     logger.info("Processed YAML written", path=args.output)
 

--- a/app/shell/py/pie/pie/render_jinja_template.py
+++ b/app/shell/py/pie/pie/render_jinja_template.py
@@ -19,7 +19,14 @@ import redis
 import yaml
 from flatten_dict import unflatten
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
-from pie.utils import logger, read_json, read_utf8, add_log_argument, setup_file_logger
+from pie.utils import (
+    logger,
+    read_json,
+    read_utf8,
+    read_yaml as load_yaml_file,
+    add_log_argument,
+    setup_file_logger,
+)
 
 DEFAULT_CONFIG = Path("cfg/render-jinja-template.yml")
 
@@ -321,8 +328,7 @@ def load_config(path: str | Path = DEFAULT_CONFIG) -> dict:
         logger.error("Configuration file not found", path=str(cfg_path))
         raise SystemExit(1)
     try:
-        with cfg_path.open("r", encoding="utf-8") as cf:
-            return yaml.safe_load(cf) or {}
+        return load_yaml_file(str(cfg_path)) or {}
     except Exception as exc:
         logger.error(
             "Failed to load configuration", path=str(cfg_path), exception=str(exc)

--- a/app/shell/py/pie/pie/utils/__init__.py
+++ b/app/shell/py/pie/pie/utils/__init__.py
@@ -8,10 +8,11 @@ directed to additional files if required.
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
-import argparse
 
+import yaml
 from loguru import logger
 
 # Remove default handlers provided by :mod:`loguru` so we can configure logging
@@ -36,8 +37,17 @@ def read_utf8(filename: str) -> str:
 def read_json(filename: str):
     """Return JSON-decoded data from *filename*."""
 
+    logger.debug("Reading JSON", filename=filename)
     with open(filename, "r", encoding="utf-8") as f:
         return json.load(f)
+
+
+def write_json(data, filename: str) -> None:
+    """Write *data* as JSON to *filename*."""
+
+    logger.debug("Writing JSON", filename=filename)
+    with open(filename, "w", encoding="utf-8") as f:
+        json.dump(data, f)
 
 
 def write_utf8(text: str, filename: str) -> None:
@@ -45,6 +55,22 @@ def write_utf8(text: str, filename: str) -> None:
 
     with open(filename, "w", encoding="utf-8") as f:
         f.write(text)
+
+
+def read_yaml(filename: str):
+    """Return YAML-decoded data from *filename*."""
+
+    logger.debug("Reading YAML", filename=filename)
+    with open(filename, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def write_yaml(data, filename: str) -> None:
+    """Write *data* as YAML to *filename*."""
+
+    logger.debug("Writing YAML", filename=filename)
+    with open(filename, "w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, allow_unicode=True, sort_keys=False)
 
 
 def disable_logging() -> None:


### PR DESCRIPTION
## Summary
- add `read_yaml`/`write_yaml` utilities with UTF-8 handling and debug logs
- refactor commands to use shared YAML helpers for reading/writing
- log JSON/YAML file operations for easier tracing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689588feece8832196c440b8c18c334e