### PR TITLE
refactor: deduplicate update scripts

### DIFF
--- a/app/shell/py/pie/pie/update_author.py
+++ b/app/shell/py/pie/pie/update_author.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-import subprocess
 from typing import Iterable, Sequence
 
 import yaml
 
-from pie.load_metadata import load_metadata_pair
-from pie.utils import add_file_logger, logger
+from pie.update_common import (
+    configure_logging as common_configure_logging,
+    get_changed_files,
+    update_files as update_common_files,
+)
 
 __all__ = ["main"]
 
@@ -41,95 +43,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(list(argv) if argv is not None else None)
 
 
-def get_changed_files() -> list[Path]:
-    """Return paths of files changed in git, excluding untracked files."""
-    result = subprocess.run(
-        ["git", "status", "--short"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    paths: list[Path] = []
-    for line in result.stdout.splitlines():
-        if not line or line.startswith("??"):
-            continue
-        parts = line.split()
-        if len(parts) >= 2:
-            paths.append(Path(parts[-1]))
-    return paths
-
-
-def _replace_author(fp: Path, author: str) -> tuple[bool, str | None]:
-    """Replace ``author`` in *fp* and return (changed, old_value)."""
-    text = fp.read_text(encoding="utf-8")
-    if fp.suffix in {".yml", ".yaml"}:
-        lines = text.splitlines(keepends=True)
-        for i, line in enumerate(lines):
-            if line.startswith("author:"):
-                old = line.split(":", 1)[1].strip()
-                if old != author:
-                    lines[i] = f"author: {author}\n"
-                    fp.write_text("".join(lines), encoding="utf-8")
-                    return True, old
-                else:
-                    return True, None
-        lines.append(f"author: {author}\n")
-        fp.write_text("".join(lines), encoding="utf-8")
-        return True, "undefined"
-
-    if fp.suffix == ".md":
-        lines = text.splitlines(keepends=True)
-        if not lines or not lines[0].startswith("---"):
-            return False, None
-        end = None
-        for i in range(1, len(lines)):
-            if lines[i].startswith("---"):
-                end = i
-                break
-        if end is None:
-            return False, None
-        for i in range(1, end):
-            if lines[i].startswith("author:"):
-                old = lines[i].split(":", 1)[1].strip()
-                lines[i] = f"author: {author}\n"
-                fp.write_text("".join(lines), encoding="utf-8")
-                return True, old
-        return False, None
-
-    return False, None
-
-
 def update_files(paths: Iterable[Path], author: str) -> list[str]:
     """Update ``author`` in files related to *paths* and return messages."""
-    changes: list[str] = []
-    processed: set[Path] = set()
-    for path in paths:
-        base = path.with_suffix("")
-        if base in processed:
-            continue
-        processed.add(base)
-
-        metadata = load_metadata_pair(path)
-        file_paths: set[Path] = {path}
-        if metadata and "path" in metadata:
-            file_paths.update(Path(p) for p in metadata["path"])
-
-        for fp in file_paths:
-            if not fp.exists():
-                continue
-            changed, old = _replace_author(fp, author)
-            if changed and old is not None:
-                msg = f"{fp}: {old} -> {author}"
-                logger.info(msg)
-                changes.append(msg)
-    return changes
+    return update_common_files(paths, "author", author)
 
 
 def configure_logging() -> None:
     """Configure logging to write to ``log/update-author.txt``."""
-    log_file = Path("log") / "update-author.txt"
-    log_file.parent.mkdir(parents=True, exist_ok=True)
-    add_file_logger(str(log_file), level="INFO")
+    common_configure_logging("update-author.txt")
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/app/shell/py/pie/pie/update_common.py
+++ b/app/shell/py/pie/pie/update_common.py
@@ -1,0 +1,113 @@
+"""Shared helpers for metadata update scripts.
+
+These utilities power :mod:`pie.update_author` and :mod:`pie.update_pubdate` by
+providing common routines for discovering changed files, modifying metadata, and
+configuring log output.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+from typing import Iterable
+
+from pie.load_metadata import load_metadata_pair
+from pie.utils import add_file_logger, logger
+
+__all__ = [
+    "get_changed_files",
+    "replace_field",
+    "update_files",
+    "configure_logging",
+]
+
+
+def get_changed_files() -> list[Path]:
+    """Return paths of files changed in git, excluding untracked files."""
+    result = subprocess.run(
+        ["git", "status", "--short"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    paths: list[Path] = []
+    for line in result.stdout.splitlines():
+        if not line or line.startswith("??"):
+            continue
+        parts = line.split()
+        if len(parts) >= 2:
+            paths.append(Path(parts[-1]))
+    return paths
+
+
+def replace_field(fp: Path, field: str, value: str) -> tuple[bool, str | None]:
+    """Replace ``field`` in *fp* and return (changed, old_value)."""
+    text = fp.read_text(encoding="utf-8")
+    if fp.suffix in {".yml", ".yaml"}:
+        lines = text.splitlines(keepends=True)
+        for i, line in enumerate(lines):
+            if line.startswith(f"{field}:"):
+                old = line.split(":", 1)[1].strip()
+                if old != value:
+                    lines[i] = f"{field}: {value}\n"
+                    fp.write_text("".join(lines), encoding="utf-8")
+                    return True, old
+                else:
+                    return True, None
+        lines.append(f"{field}: {value}\n")
+        fp.write_text("".join(lines), encoding="utf-8")
+        return True, "undefined"
+
+    if fp.suffix == ".md":
+        lines = text.splitlines(keepends=True)
+        if not lines or not lines[0].startswith("---"):
+            return False, None
+        end = None
+        for i in range(1, len(lines)):
+            if lines[i].startswith("---"):
+                end = i
+                break
+        if end is None:
+            return False, None
+        for i in range(1, end):
+            if lines[i].startswith(f"{field}:"):
+                old = lines[i].split(":", 1)[1].strip()
+                lines[i] = f"{field}: {value}\n"
+                fp.write_text("".join(lines), encoding="utf-8")
+                return True, old
+        return False, None
+
+    return False, None
+
+
+def update_files(paths: Iterable[Path], field: str, value: str) -> list[str]:
+    """Update ``field`` in files related to *paths* and return messages."""
+    changes: list[str] = []
+    processed: set[Path] = set()
+    for path in paths:
+        base = path.with_suffix("")
+        if base in processed:
+            continue
+        processed.add(base)
+
+        metadata = load_metadata_pair(path)
+        file_paths: set[Path] = {path}
+        if metadata and "path" in metadata:
+            file_paths.update(Path(p) for p in metadata["path"])
+
+        for fp in file_paths:
+            if not fp.exists():
+                continue
+            changed, old = replace_field(fp, field, value)
+            if changed and old is not None:
+                msg = f"{fp}: {old} -> {value}"
+                logger.info(msg)
+                changes.append(msg)
+    return changes
+
+
+def configure_logging(log_name: str) -> None:
+    """Configure logging to write to ``log/<log_name>``."""
+    log_file = Path("log") / log_name
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    add_file_logger(str(log_file), level="INFO")

--- a/app/shell/py/pie/pie/update_pubdate.py
+++ b/app/shell/py/pie/pie/update_pubdate.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-import subprocess
 from typing import Iterable, Sequence
 
-from pie.load_metadata import load_metadata_pair
-from pie.utils import add_file_logger, get_pubdate, logger
+from pie.update_common import (
+    configure_logging as common_configure_logging,
+    get_changed_files,
+    update_files as update_common_files,
+)
+from pie.utils import get_pubdate
 
 
 __all__ = ["main"]
@@ -20,97 +23,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(list(argv) if argv is not None else None)
 
 
-def get_changed_files() -> list[Path]:
-    """Return paths of files changed in git, excluding untracked files."""
-    result = subprocess.run(
-        ["git", "status", "--short"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    paths: list[Path] = []
-    for line in result.stdout.splitlines():
-        if not line or line.startswith("??"):
-            continue
-        parts = line.split()
-        if len(parts) >= 2:
-            paths.append(Path(parts[-1]))
-    return paths
-
-
-def _replace_pubdate(fp: Path, pubdate: str) -> tuple[bool, str | None]:
-    """Replace ``pubdate`` in *fp* and return (changed, old_value)."""
-    text = fp.read_text(encoding="utf-8")
-    if fp.suffix in {".yml", ".yaml"}:
-        lines = text.splitlines(keepends=True)
-        for i, line in enumerate(lines):
-            if line.startswith("pubdate:"):
-                old = line.split(":", 1)[1].strip()
-                if old != pubdate:
-                    lines[i] = f"pubdate: {pubdate}\n"
-                    fp.write_text("".join(lines), encoding="utf-8")
-                    return True, old
-                else:
-                    return True, None
-        lines.append(f"pubdate: {pubdate}\n")
-        fp.write_text("".join(lines), encoding="utf-8")
-        return True, "undefined"
-
-    if fp.suffix == ".md":
-        lines = text.splitlines(keepends=True)
-        if not lines or not lines[0].startswith("---"):
-            return False, None
-        end = None
-        for i in range(1, len(lines)):
-            if lines[i].startswith("---"):
-                end = i
-                break
-        if end is None:
-            return False, None
-        for i in range(1, end):
-            if lines[i].startswith("pubdate:"):
-                old = lines[i].split(":", 1)[1].strip()
-                lines[i] = f"pubdate: {pubdate}\n"
-                fp.write_text("".join(lines), encoding="utf-8")
-                return True, old
-        return False, None
-
-    return False, None
-
-
 def update_files(paths: Iterable[Path], pubdate: str) -> list[str]:
     """Update ``pubdate`` in files related to *paths* and return messages."""
-    changes: list[str] = []
-    processed: set[Path] = set()
-    for path in paths:
-        base = path.with_suffix("")
-        if base in processed:
-            continue
-        processed.add(base)
-
-        metadata = load_metadata_pair(path)
-        file_paths: set[Path] = {path}
-        if metadata and "path" in metadata:
-            file_paths.update(Path(p) for p in metadata["path"])
-
-        updated = False
-        for fp in file_paths:
-            if not fp.exists():
-                continue
-            changed, old = _replace_pubdate(fp, pubdate)
-            if changed and old is not None:
-                msg = f"{fp}: {old} -> {pubdate}"
-                logger.info(msg)
-                changes.append(msg)
-                updated = True
-    return changes
+    return update_common_files(paths, "pubdate", pubdate)
 
 
 def configure_logging() -> None:
     """Configure logging to write to ``log/update-pubdate.txt``."""
-    log_file = Path("log") / "update-pubdate.txt"
-    log_file.parent.mkdir(parents=True, exist_ok=True)
-    add_file_logger(str(log_file), level="INFO")
+    common_configure_logging("update-pubdate.txt")
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/app/shell/py/pie/tests/test_update_common.py
+++ b/app/shell/py/pie/tests/test_update_common.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pie import update_common
+
+
+def test_get_changed_files_parses_git_status(monkeypatch: object) -> None:
+    """Only tracked modifications are returned."""
+    def fake_run(cmd, check, capture_output, text):
+        class Result:
+            stdout = " M src/doc.md\n?? src/untracked.txt\nA src/doc.yml\n"
+        return Result()
+    monkeypatch.setattr(update_common.subprocess, "run", fake_run)
+
+    paths = update_common.get_changed_files()
+    assert paths == [Path("src/doc.md"), Path("src/doc.yml")]
+
+
+def test_replace_field_updates_yaml(tmp_path: Path) -> None:
+    """Existing YAML field is replaced and old value returned."""
+    yml = tmp_path / "doc.yml"
+    yml.write_text("title: T\nauthor: Old\n", encoding="utf-8")
+
+    changed, old = update_common.replace_field(yml, "author", "New")
+    assert changed is True
+    assert old == "Old"
+    assert "author: New" in yml.read_text(encoding="utf-8")
+
+
+def test_replace_field_updates_markdown_frontmatter(tmp_path: Path) -> None:
+    """Frontmatter field in Markdown is replaced."""
+    md = tmp_path / "doc.md"
+    md.write_text("---\ntitle: T\nauthor: Old\n---\n", encoding="utf-8")
+
+    changed, old = update_common.replace_field(md, "author", "New")
+    assert changed is True
+    assert old == "Old"
+    assert "author: New" in md.read_text(encoding="utf-8")
+
+
+def test_update_files_updates_all_related(tmp_path: Path, monkeypatch: object) -> None:
+    """Both Markdown and YAML files are updated for a changed path."""
+    src = tmp_path / "src"
+    src.mkdir()
+    md = src / "doc.md"
+    md.write_text("---\ntitle: T\nauthor: Old\n---\n", encoding="utf-8")
+    yml = src / "doc.yml"
+    yml.write_text("name: T\ntitle: T\nauthor: Old\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    messages = update_common.update_files([Path("src/doc.md")], "author", "New")
+    assert set(messages) == {
+        "src/doc.md: Old -> New",
+        "src/doc.yml: Old -> New",
+    }
+    assert "author: New" in md.read_text(encoding="utf-8")
+    assert "author: New" in yml.read_text(encoding="utf-8")

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -9,6 +9,8 @@ This section contains background material and technical specifications for the p
 - `keyterms.md` – glossary of important terminology.
 - `link-metadata.md` – link metadata format and usage.
 - `metadata-fields.md` – description of common metadata fields.
+- `update-author.md` – update the `author` field for modified files.
+- `update-common.md` – shared helpers for metadata update scripts.
 - `update-pubdate.md` – update the `pubdate` field for modified files.
 
 Refer back to [../guides](../guides) for step-by-step workflows and tutorials.

--- a/docs/reference/update-common.md
+++ b/docs/reference/update-common.md
@@ -1,0 +1,16 @@
+# update-common
+
+Shared helpers for the metadata update scripts.
+
+The module provides utilities used by command line tools such as
+`update-author` and `update-pubdate`:
+
+- `get_changed_files()` – return a list of tracked files modified in git.
+- `replace_field(fp, field, value)` – replace a metadata field in YAML or
+  Markdown frontmatter.
+- `update_files(paths, field, value)` – update a metadata field across the
+  Markdown/YAML pair associated with each path.
+- `configure_logging(log_name)` – write log output to `log/<log_name>`.
+
+These helpers centralize behavior that was previously duplicated across the
+individual update scripts.


### PR DESCRIPTION
## Summary
- extract shared metadata update helpers
- refactor update-author and update-pubdate to use shared helpers
- document update-common helper module and link in reference docs
- add tests for update_common utilities

## Testing
- `pytest app/shell/py/pie/tests/test_update_common.py app/shell/py/pie/tests/test_update_author.py app/shell/py/pie/tests/test_update_pubdate.py`


------
https://chatgpt.com/codex/tasks/task_e_68958f57594883219ac2f47cd1e7d16d