### PR TITLE
Add create script for Press project scaffolding

### DIFF
--- a/app/shell/py/pie/pie/create.py
+++ b/app/shell/py/pie/pie/create.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+from pie.utils import logger, add_log_argument, setup_file_logger
+
+
+__all__ = ["main"]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Create scaffolding for a Press project",
+    )
+    parser.add_argument("path", help="Target directory for the project")
+    add_log_argument(parser)
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the ``create`` console script."""
+    args = parse_args(argv)
+    setup_file_logger(args.log)
+
+    root = Path(args.path)
+    root.mkdir(parents=True, exist_ok=True)
+
+    # Create required files and directories
+    (root / "docker-compose.yml").touch()
+    (root / "src").mkdir(exist_ok=True)
+
+    readme = root / "README.md"
+    if not readme.exists():
+        readme.write_text(
+            "# New Press Project\n\n"
+            "## Building\n\n"
+            "Run `docker-compose build` to build the project.\n",
+            encoding="utf-8",
+        )
+
+    logger.info("Created project scaffolding", path=str(root))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -32,6 +32,7 @@ setup(
             'check-page-title=pie.check_page_title:main',
             'check-post-build=pie.check_post_build:main',
             'create-post=pie.create_post:main',
+            'create=pie.create:main',
         ],
     },
 )

--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pie import create
+
+
+def test_create_scaffolding(tmp_path: Path) -> None:
+    target = tmp_path / "press-project"
+    create.main([str(target)])
+
+    assert (target / "docker-compose.yml").exists()
+    assert (target / "src").is_dir()
+
+    readme = target / "README.md"
+    assert readme.exists(), "README should be created"
+    text = readme.read_text(encoding="utf-8")
+    assert "docker-compose build" in text


### PR DESCRIPTION
## Summary
- add `create` console script to scaffold a new Press project
- register the script in pie's console entry points
- test project scaffolding generation

## Testing
- `pytest app/shell/py/pie/tests`

------
https://chatgpt.com/codex/tasks/task_e_68959cabf54c8321ac85eeb5285a2084