### PR TITLE
refactor: centralize logging helpers

### DIFF
--- a/app/shell/py/pie/pie/build_index.py
+++ b/app/shell/py/pie/pie/build_index.py
@@ -11,7 +11,8 @@ import os
 from typing import Any, Dict, Optional
 
 import yaml
-from pie.utils import logger, add_log_argument, setup_file_logger, read_yaml
+from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.utils import read_yaml
 
 
 def get_url(filename: str) -> Optional[str]:

--- a/app/shell/py/pie/pie/check_post_build.py
+++ b/app/shell/py/pie/pie/check_post_build.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from pie.utils import logger, add_log_argument, setup_file_logger, read_yaml
+from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.utils import read_yaml
 
 DEFAULT_LOG = "log/check-post-build.txt"
 DEFAULT_CFG = "cfg/check-post-build.yml"

--- a/app/shell/py/pie/pie/create_post.py
+++ b/app/shell/py/pie/pie/create_post.py
@@ -4,7 +4,8 @@ import argparse
 from pathlib import Path
 from typing import Sequence
 
-from pie.utils import add_file_logger, get_pubdate, logger, write_yaml
+from pie.logging import add_file_logger, logger
+from pie.utils import get_pubdate, write_yaml
 
 
 __all__ = ["main"]

--- a/app/shell/py/pie/pie/detect_html_dicts.py
+++ b/app/shell/py/pie/pie/detect_html_dicts.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import re
 from bs4 import BeautifulSoup
-from pie.utils import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, setup_file_logger
 
 def contains_python_dict(text: str) -> bool:
     """Return ``True`` if *text* looks like a Python dictionary literal."""

--- a/app/shell/py/pie/pie/include_filter.py
+++ b/app/shell/py/pie/pie/include_filter.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import IO, Iterable, Callable
 
 import yaml
-from pie.utils import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, setup_file_logger
 
 MD_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\.md\)")
 

--- a/app/shell/py/pie/pie/load_metadata.py
+++ b/app/shell/py/pie/pie/load_metadata.py
@@ -5,7 +5,7 @@ from typing import Any, Mapping
 import warnings
 
 from pie import build_index
-from pie.utils import logger
+from pie.logging import logger
 
 
 def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:

--- a/app/shell/py/pie/pie/logging.py
+++ b/app/shell/py/pie/pie/logging.py
@@ -1,0 +1,56 @@
+"""Centralised logging helpers for the :mod:`pie` package.
+
+This module configures a :class:`loguru.logger` instance for use across the
+project and provides small helper functions for integrating logging with
+command line interfaces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from loguru import logger
+
+# Remove default handlers provided by :mod:`loguru` so we can configure logging
+# behaviour explicitly.
+logger.remove()
+
+LOG_FORMAT = (
+    "{time:HH:mm:ss} {module:>25}:{function:<25}:{line:<4} {level:.4s} {message} {extra}"
+)
+
+# Configure the console sink that all tests and scripts rely on.
+logger.add(sys.stderr, format=LOG_FORMAT, level="INFO")
+
+
+def disable_logging() -> None:
+    """Disable all logging output for the :mod:`pie` helpers."""
+
+    logger.remove()
+
+
+def add_file_logger(filename: str, level: str = "DEBUG") -> None:
+    """Add a log sink that writes to *filename* at the given *level*."""
+
+    logger.add(filename, format=LOG_FORMAT, level=level)
+
+
+def add_log_argument(parser: argparse.ArgumentParser, *, default: str | None = None) -> None:
+    """Add a standard ``--log`` argument to *parser*.
+
+    Parameters
+    ----------
+    parser:
+        ``argparse`` parser to which the argument should be added.
+    default:
+        Optional default path for the log file.
+    """
+
+    parser.add_argument("-l", "--log", default=default, help="Write logs to the specified file")
+
+
+def setup_file_logger(log_path: str | None, *, level: str = "DEBUG") -> None:
+    """Configure file logging when ``log_path`` is provided."""
+
+    if log_path:
+        add_file_logger(log_path, level=level)

--- a/app/shell/py/pie/pie/picasso.py
+++ b/app/shell/py/pie/pie/picasso.py
@@ -17,7 +17,8 @@ import sys
 from pathlib import Path
 
 import yaml
-from pie.utils import logger, add_log_argument, setup_file_logger, read_yaml
+from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.utils import read_yaml
 
 
 def generate_rule(

--- a/app/shell/py/pie/pie/process_yaml.py
+++ b/app/shell/py/pie/pie/process_yaml.py
@@ -6,7 +6,8 @@ import argparse
 import sys
 from typing import Iterable
 
-from pie.utils import logger, add_log_argument, setup_file_logger, write_yaml
+from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.utils import write_yaml
 from pie import build_index
 
 

--- a/app/shell/py/pie/pie/render_jinja_template.py
+++ b/app/shell/py/pie/pie/render_jinja_template.py
@@ -19,14 +19,8 @@ import redis
 import yaml
 from flatten_dict import unflatten
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
-from pie.utils import (
-    logger,
-    read_json,
-    read_utf8,
-    read_yaml as load_yaml_file,
-    add_log_argument,
-    setup_file_logger,
-)
+from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.utils import read_json, read_utf8, read_yaml as load_yaml_file
 
 DEFAULT_CONFIG = Path("cfg/render-jinja-template.yml")
 

--- a/app/shell/py/pie/pie/render_study_json.py
+++ b/app/shell/py/pie/pie/render_study_json.py
@@ -13,7 +13,8 @@ import json
 from pathlib import Path
 from typing import Any, Iterable, List
 
-from pie.utils import logger, read_json, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.utils import read_json
 
 from .render_jinja_template import create_env
 

--- a/app/shell/py/pie/pie/update_author.py
+++ b/app/shell/py/pie/pie/update_author.py
@@ -6,11 +6,8 @@ from typing import Iterable, Sequence
 
 import yaml
 
-from pie.update_common import (
-    configure_logging as common_configure_logging,
-    get_changed_files,
-    update_files as update_common_files,
-)
+from pie.logging import add_log_argument, setup_file_logger
+from pie.update_common import get_changed_files, update_files as update_common_files
 
 __all__ = ["main"]
 
@@ -40,6 +37,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=default_author,
         help="Author name to set (default: value from cfg/update-author.yml)",
     )
+    add_log_argument(parser, default="log/update-author.txt")
     return parser.parse_args(list(argv) if argv is not None else None)
 
 
@@ -48,15 +46,12 @@ def update_files(paths: Iterable[Path], author: str) -> list[str]:
     return update_common_files(paths, "author", author)
 
 
-def configure_logging() -> None:
-    """Configure logging to write to ``log/update-author.txt``."""
-    common_configure_logging("update-author.txt")
-
-
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point for the ``update-author`` console script."""
     args = parse_args(argv)
-    configure_logging()
+    if args.log:
+        Path(args.log).parent.mkdir(parents=True, exist_ok=True)
+    setup_file_logger(args.log, level="INFO")
     changed = get_changed_files()
     messages = update_files(changed, args.author)
     for msg in messages:

--- a/app/shell/py/pie/pie/update_common.py
+++ b/app/shell/py/pie/pie/update_common.py
@@ -12,13 +12,12 @@ import subprocess
 from typing import Iterable
 
 from pie.load_metadata import load_metadata_pair
-from pie.utils import add_file_logger, logger
+from pie.logging import logger
 
 __all__ = [
     "get_changed_files",
     "replace_field",
     "update_files",
-    "configure_logging",
 ]
 
 
@@ -106,8 +105,3 @@ def update_files(paths: Iterable[Path], field: str, value: str) -> list[str]:
     return changes
 
 
-def configure_logging(log_name: str) -> None:
-    """Configure logging to write to ``log/<log_name>``."""
-    log_file = Path("log") / log_name
-    log_file.parent.mkdir(parents=True, exist_ok=True)
-    add_file_logger(str(log_file), level="INFO")

--- a/app/shell/py/pie/pie/update_index.py
+++ b/app/shell/py/pie/pie/update_index.py
@@ -18,7 +18,7 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 
 import redis
-from pie.utils import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, setup_file_logger
 from pie.load_metadata import load_metadata_pair
 
 

--- a/app/shell/py/pie/pie/utils/__init__.py
+++ b/app/shell/py/pie/pie/utils/__init__.py
@@ -1,31 +1,20 @@
 """Utility helpers used throughout the ``pie`` package.
 
-This module exposes a pre-configured :class:`loguru.logger` instance and a few
-convenience functions for reading and writing UTF-8 encoded files.  The logger
-defaults to writing INFO level messages to standard error but can be disabled or
-directed to additional files if required.
+This module provides convenience functions for reading and writing UTF-8
+encoded files as well as helper routines such as :func:`get_pubdate`. Logging
+behaviour is centralised in :mod:`pie.logging` and the pre-configured
+``loguru`` logger from that module is re-exported here for backwards
+compatibility.
 """
 
 from __future__ import annotations
 
-import argparse
 import json
-import sys
 from datetime import datetime
 
 import yaml
-from loguru import logger
 
-# Remove default handlers provided by :mod:`loguru` so we can configure logging
-# behaviour explicitly.
-logger.remove()
-
-LOG_FORMAT = (
-    "{time:HH:mm:ss} {module:>25}:{function:<25}:{line:<4} {level:.4s} {message} {extra}"
-)
-
-# Configure the console sink that all tests and scripts rely on.
-logger.add(sys.stderr, format=LOG_FORMAT, level="INFO")
+from pie.logging import logger
 
 
 def read_utf8(filename: str) -> str:
@@ -72,39 +61,6 @@ def write_yaml(data, filename: str) -> None:
     logger.debug("Writing YAML", filename=filename)
     with open(filename, "w", encoding="utf-8") as f:
         yaml.safe_dump(data, f, allow_unicode=True, sort_keys=False)
-
-
-def disable_logging() -> None:
-    """Disable all logging output for the :mod:`pie` helpers."""
-
-    logger.remove()
-
-
-def add_file_logger(filename: str, level: str = "DEBUG") -> None:
-    """Add a log sink that writes to *filename* at the given *level*."""
-
-    logger.add(filename, format=LOG_FORMAT, level=level)
-
-
-def add_log_argument(parser: argparse.ArgumentParser, *, default: str | None = None) -> None:
-    """Add a standard ``--log`` argument to *parser*.
-
-    Parameters
-    ----------
-    parser:
-        ``argparse`` parser to which the argument should be added.
-    default:
-        Optional default path for the log file.
-    """
-
-    parser.add_argument("-l", "--log", default=default, help="Write logs to the specified file")
-
-
-def setup_file_logger(log_path: str | None, *, level: str = "DEBUG") -> None:
-    """Configure file logging when ``log_path`` is provided."""
-
-    if log_path:
-        add_file_logger(log_path, level=level)
 
 
 def get_pubdate(date: datetime | None = None) -> str:

--- a/docs/reference/update-author.md
+++ b/docs/reference/update-author.md
@@ -9,11 +9,12 @@ Markdown frontmatter or metadata YAML with the author configured in
 `cfg/update-author.yml`.
 
 ```bash
-update-author
+update-author [-l LOGFILE]
 ```
 
-Each updated file is printed as `<path>: <old> -> <new>` and the same
-information is logged to `log/update-author.txt`.
+Each updated file is printed as `<path>: <old> -> <new>` and logged to
+`LOGFILE`.  When not specified, log output is written to
+`log/update-author.txt`.
 
 If a file under `src` is modified but no `author` field can be updated, a
 warning is logged.

--- a/docs/reference/update-common.md
+++ b/docs/reference/update-common.md
@@ -10,7 +10,6 @@ The module provides utilities used by command line tools such as
   Markdown frontmatter.
 - `update_files(paths, field, value)` – update a metadata field across the
   Markdown/YAML pair associated with each path.
-- `configure_logging(log_name)` – write log output to `log/<log_name>`.
 
 These helpers centralize behavior that was previously duplicated across the
 individual update scripts.

--- a/docs/reference/update-pubdate.md
+++ b/docs/reference/update-pubdate.md
@@ -8,11 +8,12 @@ metadata pair using `load_metadata_pair` and replaces the `pubdate` field in
 Markdown frontmatter or metadata YAML with today's date in the format `%b %d, %Y`.
 
 ```bash
-update-pubdate
+update-pubdate [-l LOGFILE]
 ```
 
 Each updated file is printed as `<path>: <old> -> <new>` and the same information
-is logged to `log/update-pubdate.txt`.
+is logged to `LOGFILE`. When omitted, log output is written to
+`log/update-pubdate.txt`.
 
 If a file under `src` is modified but no `pubdate` field can be updated, a
 warning is logged.


### PR DESCRIPTION
## Summary
- extend centralized logging to update scripts and remove obsolete helper
- document new log options for `update-author` and `update-pubdate`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68959e5c8d1c8321a71b8bae72cc7386