### PR TITLE
Exclude untracked files from get_changed_files

### DIFF
--- a/app/shell/py/pie/pie/update_common.py
+++ b/app/shell/py/pie/pie/update_common.py
@@ -22,7 +22,7 @@ __all__ = [
 
 
 def get_changed_files() -> list[Path]:
-    """Return paths of files changed or untracked in git."""
+    """Return paths of tracked files changed in git."""
     result = subprocess.run(
         ["git", "status", "--short"],
         check=True,
@@ -34,6 +34,8 @@ def get_changed_files() -> list[Path]:
         if not line:
             continue
         parts = line.split()
+        if parts and parts[0] == "??":
+            continue
         if len(parts) >= 2:
             paths.append(Path(parts[-1]))
     return paths

--- a/app/shell/py/pie/tests/test_update_common.py
+++ b/app/shell/py/pie/tests/test_update_common.py
@@ -6,7 +6,7 @@ from pie import update_common
 
 
 def test_get_changed_files_parses_git_status(monkeypatch: object) -> None:
-    """Tracked and untracked modifications are returned."""
+    """Only tracked modifications are returned."""
     def fake_run(cmd, check, capture_output, text):
         class Result:
             stdout = " M src/doc.md\n?? src/untracked.txt\nA src/doc.yml\n"
@@ -16,7 +16,6 @@ def test_get_changed_files_parses_git_status(monkeypatch: object) -> None:
     paths = update_common.get_changed_files()
     assert paths == [
         Path("src/doc.md"),
-        Path("src/untracked.txt"),
         Path("src/doc.yml"),
     ]
 

--- a/docs/reference/update-author.md
+++ b/docs/reference/update-author.md
@@ -2,8 +2,8 @@
 
 Update the `author` field in metadata files for documents modified in git.
 
-The console script scans `git status --short` for files that have been added,
-changed, or are untracked. For each path it locates the associated Markdown and YAML
+The console script scans `git status --short` for tracked files that have been added
+or changed. For each path it locates the associated Markdown and YAML
 metadata pair using `load_metadata_pair` and replaces the `author` field in
 Markdown frontmatter or metadata YAML with the author configured in
 `cfg/update-author.yml`.

--- a/docs/reference/update-common.md
+++ b/docs/reference/update-common.md
@@ -5,7 +5,7 @@ Shared helpers for the metadata update scripts.
 The module provides utilities used by command line tools such as
 `update-author` and `update-pubdate`:
 
-- `get_changed_files()` – return a list of files modified or untracked in git.
+- `get_changed_files()` – return a list of tracked files modified in git.
 - `replace_field(fp, field, value)` – replace a metadata field in YAML or
   Markdown frontmatter.
 - `update_files(paths, field, value)` – update a metadata field across the

--- a/docs/reference/update-pubdate.md
+++ b/docs/reference/update-pubdate.md
@@ -2,8 +2,8 @@
 
 Update the `pubdate` field in metadata files for documents modified in git.
 
-The console script scans `git status --short` for files that have been added,
-changed, or are untracked. For each path it locates the associated Markdown and YAML
+The console script scans `git status --short` for tracked files that have been added
+or changed. For each path it locates the associated Markdown and YAML
 metadata pair using `load_metadata_pair` and replaces the `pubdate` field in
 Markdown frontmatter or metadata YAML with today's date in the format `%b %d, %Y`.
 


### PR DESCRIPTION
## Summary
- ignore untracked files when gathering changed paths
- document that only tracked modifications are processed
- adjust tests for updated behavior

## Testing
- `pytest app/shell/py/pie/tests/test_update_common.py::test_get_changed_files_parses_git_status -q`
- `pytest app/shell/py/pie/tests -q` *(fails: ImportError: cannot import name 'add_log_argument' from 'pie.utils')*


------
https://chatgpt.com/codex/tasks/task_e_6895a8b20c4c83219449be7695282d1d