### PR TITLE
Add cite Jinja global for Chicago-style references

### DIFF
--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -11,6 +11,9 @@ for details on the structure of this metadata.
 - `to_alpha_index(i)` – convert `0`–`3` to `a`–`d`.
 - `read_json(path)` – read and parse a JSON file.
 - `read_yaml(path)` – read YAML and yield the sequence stored under `toc`.
+- `cite(*ids)` – format one or more metadata entries as Chicago style
+  citations. When multiple entries share the same author and year their page
+  numbers are combined.
 
 These helpers live in `app/shell/py/pie/pie/render_jinja_template.py` and are
 registered with the Jinja environment by `create_env()`.

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -30,5 +30,9 @@ During indexing, `build_index.py` fills in several fields when they are missing:
 The `citation` value is used as the anchor text when other pages link to this document using Jinja filters such as `linktitle`.
 The helper that assigns these defaults lives in `parse_yaml_metadata` within `pie.build_index`.
 
+For bibliographic references the `citation` field may instead be a mapping with
+`author`, `year`, and `page` keys.  This structure is consumed by the `cite`
+Jinja global to render Chicago style links.
+
 `link.tracking` defaults to `true`, meaning links open in the same tab. `link.class` defaults to `internal-link`.
 


### PR DESCRIPTION
## Summary
- Add `cite` Jinja global to render Chicago-style citation links, merging pages for identical sources and supporting legacy and structured metadata formats.
- Register the new helper with the Jinja environment and document its usage along with structured citation metadata.
- Test citation rendering for single, grouped, and multiple sources.

## Testing
- `pytest app/shell/py/pie/tests/test_render_template.py`
- `pytest app/shell/py/pie/tests`


------
https://chatgpt.com/codex/tasks/task_e_6896278361208321b1338222ac3bc6b4