### PR TITLE
Handle citation metadata in link filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Pandoc lets you define document metadata in two ways:
 ### Auto-Generated Fields
 If you don’t provide these, Pandoc (or your build tooling) will generate them automatically:
 - `id`: A unique identifier for cross-document linking (e.g., when using Jinja templates).
-- `citation`: Default anchor text for cross-document links. Jinja filters such as `linktitle` use this value.
+- `citation`: Default anchor text for cross-document links. Jinja filters such as `linktitle` use this value. For bibliographic references this may instead be a mapping with `author`, `year`, and `page`, which the filters and the `cite` global render as Chicago style text in parentheses.
 
 See [docs/reference/metadata-fields.md](docs/reference/metadata-fields.md) for a complete list of supported fields and defaults. For describing
 external URLs in YAML, refer to [docs/reference/link-metadata.md](docs/reference/link-metadata.md).

--- a/app/shell/py/pie/pie/render_jinja_template.py
+++ b/app/shell/py/pie/pie/render_jinja_template.py
@@ -174,11 +174,25 @@ def render_link(
 
     # Determine citation text
     citation_val = desc["citation"]
+    needs_parens = False
     if citation == "short":
         citation_text = citation_val["short"]
     else:
         if isinstance(citation_val, dict):
-            citation_text = citation_val.get(citation)
+            if {"author", "year"}.issubset(citation_val):
+                author = str(citation_val.get("author", "")).title()
+                year = citation_val.get("year")
+                pages = citation_val.get("page")
+                citation_text = author
+                if year is not None:
+                    citation_text += f" {year}"
+                if pages:
+                    if isinstance(pages, (list, tuple)):
+                        pages = ", ".join(str(p) for p in pages)
+                    citation_text += f", {pages}"
+                needs_parens = True
+            else:
+                citation_text = citation_val.get(citation)
         else:
             citation_text = citation_val
 
@@ -193,6 +207,9 @@ def render_link(
         citation_text = _whitespace_word_pattern.sub(cap_match, citation_text)
     elif style == "cap" and citation_text:
         citation_text = citation_text[0].upper() + citation_text[1:]
+
+    if needs_parens:
+        citation_text = f"({citation_text})"
 
     url = desc["url"]
     if anchor:

--- a/app/shell/py/pie/tests/test_render_template.py
+++ b/app/shell/py/pie/tests/test_render_template.py
@@ -154,6 +154,20 @@ def test_linkshort_uses_short_citation_and_ignores_icon(monkeypatch):
     assert 'rel="noopener noreferrer" target="_blank"' in html
 
 
+def test_link_handles_citation_metadata(monkeypatch):
+    """Bibliographic citation dict -> formatted text."""
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    fake.set("hull.citation.author", "hull")
+    fake.set("hull.citation.year", "2016")
+    fake.set("hull.citation.page", "307")
+    fake.set("hull.url", "/hull")
+    monkeypatch.setattr(render_template, "redis_conn", fake)
+    render_template.index_json = {}
+
+    html = render_template.link("hull")
+    assert '(Hull 2016, 307)' in html
+
+
 def test_render_link_with_anchor():
     """anchor='bar' -> href endswith '#bar'."""
     desc = {"citation": "foo", "url": "/f"}

--- a/app/shell/py/pie/tests/test_render_template_extra.py
+++ b/app/shell/py/pie/tests/test_render_template_extra.py
@@ -73,6 +73,13 @@ def test_render_link_uses_citation_dict():
     assert ">Alt<" in html
 
 
+def test_render_link_handles_citation_metadata():
+    """citation with author/year/page formats like cite."""
+    desc = {"citation": {"author": "hull", "year": "2016", "page": "307"}, "url": "/h"}
+    html = render_template.render_link(desc, use_icon=False)
+    assert ">(Hull 2016, 307)<" in html
+
+
 def test_wrapper_functions():
     """Wrapper helpers render variants of links."""
     desc = {"citation": "foo bar", "url": "/f", "icon": "I"}

--- a/docs/reference/jinja-filters.md
+++ b/docs/reference/jinja-filters.md
@@ -21,6 +21,11 @@ accepts a few optional parameters to control the output:
 - `citation` – selects which citation field to render.  The default `"citation"`
   uses the main citation value; pass `"short"` to use `citation.short`.
 
+When the `citation` field is itself a mapping with `author`, `year`, and an
+optional `page`, the filter formats the text using Chicago style
+(`"Author Year, Page"`) and encloses it in parentheses, matching the behaviour
+of the `cite` global.
+
 Example:
 
 ```jinja
@@ -32,6 +37,18 @@ renders as:
 
 ```html
 <a href="/humerus.html#deltoid_tuberosity" class="internal-link">Deltoid Tuberosity</a>
+```
+
+Bibliographic citations render similarly:
+
+```jinja
+{{ {"citation": {"author": "hull", "year": 2016, "page": 307}, "url": "/hull"} | link }}
+```
+
+produces:
+
+```html
+<a href="/hull" class="internal-link">(Hull 2016, 307)</a>
 ```
 
 When you pass a string instead of a dictionary, the filter fetches the

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -32,7 +32,8 @@ The helper that assigns these defaults lives in `parse_yaml_metadata` within `pi
 
 For bibliographic references the `citation` field may instead be a mapping with
 `author`, `year`, and `page` keys.  This structure is consumed by the `cite`
-Jinja global to render Chicago style links.
+Jinja global and by the link-formatting filters to render Chicago style text in
+parentheses.
 
 `link.tracking` defaults to `true`, meaning links open in the same tab. `link.class` defaults to `internal-link`.
 


### PR DESCRIPTION
## Summary
- support bibliographic citation dictionaries across all Jinja link filters
- document citation-metadata handling in filter and metadata references
- cover new citation formatting with tests
- enclose Chicago-style link citations in parentheses for consistency with `cite`

## Testing
- `pytest app/shell/py/pie/tests/test_render_template.py app/shell/py/pie/tests/test_render_template_extra.py`


------
https://chatgpt.com/codex/tasks/task_e_68962bbe66e883218810efaf0b935248