### PR TITLE
Document redis CLI helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,4 @@ build. Use `--src DIR` to search a different directory for `.yml` files and
 - [Architecture](docs/reference/architecture.md)
 - [Link Metadata](docs/reference/link-metadata.md)
 - [checklinks](docs/guides/checklinks.md)
+- [redis-cli helper](docs/guides/redis-cli.md)

--- a/bin/redis-cli
+++ b/bin/redis-cli
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Run redis-cli inside the dragonfly service.
+# Any arguments provided are forwarded to redis-cli.
 CMD="docker compose exec dragonfly redis-cli"
 
 $CMD "$@"

--- a/docs/guides/redis-cli.md
+++ b/docs/guides/redis-cli.md
@@ -1,0 +1,15 @@
+# redis-cli helper
+
+`bin/redis-cli` wraps `docker compose exec dragonfly redis-cli` to connect to the
+project's DragonflyDB/Redis instance. Any arguments passed to the script are
+forwarded to `redis-cli`.
+
+## Usage
+
+```bash
+./bin/redis-cli
+./bin/redis-cli --scan --pattern '*'
+```
+
+The Docker compose stack must be running and include the `dragonfly` service.
+You can also run the same client via `make -f redo.mk redis`.

--- a/docs/guides/redo-mk.md
+++ b/docs/guides/redo-mk.md
@@ -42,6 +42,7 @@ This repository actually uses three Makefiles that work together:
 | `sync` | Runs the `sync` container to upload site files to S3. |
 | `webp` | Runs the image conversion service. |
 | `shell` | Opens an interactive shell container. |
+| `redis` | Opens a Redis CLI connected to the `dragonfly` service. |
 | `rmi` | Removes Docker images matching `press-*` using `./bin/docker-rmi-pattern`. |
 
 Run `make -f redo.mk <target>` (or `r <target>` if you use the alias from the README) to execute any of these commands.

--- a/redo.mk
+++ b/redo.mk
@@ -166,8 +166,8 @@ t: ## Restart nginx-dev and run tests, ansi colors
 	$(Q)$(DOCKER_COMPOSE) run --entrypoint make --rm shell -f /app/mk/build.mk VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
 	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell /press/py/pie/tests
 
-.PHONY: t
-redis:
+.PHONY: redis
+redis: ## Open redis-cli on the dragonfly service
 	$(Q)$(DOCKER_COMPOSE) exec dragonfly redis-cli
 
 .PHONY: tags


### PR DESCRIPTION
## Summary
- add description and usage for `bin/redis-cli`
- expose `redis` target in `redo.mk` help and docs

## Testing
- `make -f redo.mk help`

------
https://chatgpt.com/codex/tasks/task_e_68962eec41f483219160741122dd8bdc