### PR TITLE
docs: explain process-yaml integration

### DIFF
--- a/docs/guides/process-yaml.md
+++ b/docs/guides/process-yaml.md
@@ -13,3 +13,19 @@ Example:
 ```bash
 process-yaml in.yml out.yml --log build.log
 ```
+
+## Integration
+
+`process-yaml` is typically invoked automatically during a build. The
+[`picasso`](picasso.md) tool scans metadata files and emits Makefile rules
+that call this script before running Pandoc. A generated rule looks like:
+
+```make
+build/foo/bar.yml: src/foo/bar.yml
+    $(Q)mkdir -p $(dir $@)
+    $(Q)emojify < $< > $@
+    $(Q)process-yaml $< $@
+```
+
+Running the script ensures each document has a complete metadata block
+so Pandoc and other tools can rely on fields like `id` or `citation`.


### PR DESCRIPTION
## Summary
- document how process-yaml fits into the build workflow
- show example Makefile rule generated by picasso that uses process-yaml

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689633fc2ee88321bbbd0b01307e016f