### PR TITLE
Refactor YAML metadata loading

### DIFF
--- a/app/shell/py/pie/pie/index_tree.py
+++ b/app/shell/py/pie/pie/index_tree.py
@@ -4,16 +4,7 @@ import warnings
 from pathlib import Path
 from typing import Iterator, Mapping, Any, Tuple, Callable
 
-from pie.utils import read_yaml
-
-
-def load_yaml_metadata(filepath: Path) -> Mapping[str, Any] | None:
-    """Return parsed YAML metadata for *filepath* or ``None`` if invalid."""
-    try:
-        return read_yaml(str(filepath)) or {}
-    except Exception as e:  # pragma: no cover - warning path
-        warnings.warn(f"Invalid YAML: {filepath} ({e})")
-        return None
+from pie.load_metadata import load_yaml_metadata
 
 
 def getopt_link(meta: Mapping[str, Any]) -> bool:

--- a/app/shell/py/pie/tests/test_gen_markdown_index.py
+++ b/app/shell/py/pie/tests/test_gen_markdown_index.py
@@ -19,3 +19,12 @@ def test_show_property(tmp_path):
         '- {{"alpha"|linktitle}}',
         '- {{"child"|linktitle}}',
     ]
+
+
+def test_missing_id_uses_filename(tmp_path):
+    """Files without an explicit id derive it from the filename."""
+    (tmp_path / "foo.yml").write_text("name: Foo\ntitle: Foo\n")
+
+    lines = list(generate(tmp_path))
+
+    assert lines == ['- {{"foo"|linktitle}}']


### PR DESCRIPTION
## Summary
- add `load_yaml_metadata` helper to centralize YAML parsing and default field generation
- switch index tree and picasso to shared metadata loaders
- test that missing `id` fields derive from filenames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689635c21e1883219a33f19d648133da