### PR TITLE
feat: add output argument to render-jinja-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ respectively when not set.
 
 Command: `render-jinja-template`
 
+Usage: `render-jinja-template <template> <output> [--index index.json]`
+
 You can put metadata at the top of a markdown file. This metadata is optional.
 The system collects it. Then it uses it to fill Jinja2 templates.
 

--- a/app/shell/bin/preprocess
+++ b/app/shell/bin/preprocess
@@ -23,7 +23,7 @@ process_file() {
     done
 
     # Render links using metadata from Redis
-    render-jinja-template "$output" > "$output.$$"
+    render-jinja-template "$output" "$output.$$"
     mv "$output.$$" "$output"
     (( VERBOSE )) && cat "$output"
 

--- a/app/shell/py/pie/pie/render_jinja_template.py
+++ b/app/shell/py/pie/pie/render_jinja_template.py
@@ -20,7 +20,7 @@ import yaml
 from flatten_dict import unflatten
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from pie.logging import logger, add_log_argument, setup_file_logger
-from pie.utils import read_json, read_utf8, read_yaml as load_yaml_file
+from pie.utils import read_json, read_utf8, write_utf8, read_yaml as load_yaml_file
 
 DEFAULT_CONFIG = Path("cfg/render-jinja-template.yml")
 
@@ -451,6 +451,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Render a template using metadata from Redis and an optional index file",
     )
     parser.add_argument("template", help="Template file to render")
+    parser.add_argument("output", help="File to write rendered template to")
     parser.add_argument(
         "-i",
         "--index",
@@ -478,7 +479,8 @@ def main(argv: list[str] | None = None) -> None:
     config = load_config(args.config)
     index_json = read_json(args.index) if args.index else {}
     template = env.get_template(args.template)
-    print(template.render(**index_json))
+    rendered = template.render(**index_json)
+    write_utf8(rendered, args.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make render-jinja-template write to a specified output file
- adjust preprocess script to pass output path instead of using shell redirection
- document new output argument in README
- use write_utf8 when writing rendered templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689637092514832192b7c39427890f2e