### PR TITLE
Remove deprecated linkparent helper

### DIFF
--- a/app/shell/py/pie/pie/render_jinja_template.py
+++ b/app/shell/py/pie/pie/render_jinja_template.py
@@ -245,23 +245,6 @@ def link(desc, anchor: str | None = None):
 def linkshort(desc, anchor: str | None = None):
     return render_link(desc, use_icon=False, citation="short", anchor=anchor)
 
-
-def linkparent(parent_id: str | None = None) -> str:
-    """Return a link to a parent page.
-
-    When ``parent_id`` is ``None`` the ``parent`` field from ``index_json`` is
-    used.  Passing an explicit ``parent_id`` is useful when experimenting with
-    different hierarchies.  If no parent is available an empty string is
-    returned.
-    """
-
-    if parent_id is None:
-        parent_id = index_json.get("parent") if isinstance(index_json, dict) else None
-    if not parent_id:
-        return ""
-    return f"Parent: {linktitle(parent_id)}"
-
-
 def cite(*names: str) -> str:
     """Return Chicago style citation links for ``names``.
 
@@ -436,7 +419,6 @@ def create_env():
     env.globals["to_alpha_index"] = to_alpha_index
     env.globals["read_json"] = read_json
     env.globals["read_yaml"] = read_yaml
-    env.globals["linkparent"] = linkparent
     env.globals["cite"] = cite
     return env
 

--- a/app/shell/py/pie/tests/test_render_template_misc.py
+++ b/app/shell/py/pie/tests/test_render_template_misc.py
@@ -1,5 +1,4 @@
 import pytest
-import fakeredis
 from pie import render_jinja_template as render_template
 
 
@@ -46,29 +45,3 @@ def test_render_jinja_renders_snippet():
     """Template uses variables from index_json."""
     render_template.index_json = {"name": "world"}
     assert render_template.render_jinja("Hello {{ name }}") == "Hello world"
-
-
-def test_linkparent_uses_index_json(monkeypatch):
-    """linkparent() links to parent id from metadata."""
-    fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("p.citation", "Parent")
-    fake.set("p.url", "/p")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
-    render_template.index_json = {"parent": "p"}
-    html = render_template.linkparent()
-    assert html.startswith("Parent: ")
-    assert '<a href="/p"' in html
-
-
-def test_linkparent_override(monkeypatch):
-    """Explicit id overrides metadata value."""
-    fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("p.citation", "Parent")
-    fake.set("p.url", "/p")
-    fake.set("q.citation", "Q")
-    fake.set("q.url", "/q")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
-    render_template.index_json = {"parent": "p"}
-    html = render_template.linkparent("q")
-    assert '<a href="/q"' in html
-    assert '>Q<' in html

--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -11,20 +11,10 @@ for details on the structure of this metadata.
 - `to_alpha_index(i)` – convert `0`–`3` to `a`–`d`.
 - `read_json(path)` – read and parse a JSON file.
 - `read_yaml(path)` – read YAML and yield the sequence stored under `toc`.
-- `linkparent(id)` – render `Parent: <a …>` pointing to a parent page. When
-  called without an argument it uses the current page's `parent` metadata; pass
-  an explicit `id` to override.
 - `cite(*ids)` – format one or more metadata entries as Chicago style
   citations. When multiple entries share the same author and year their page
   numbers are combined.
 
 These helpers live in `app/shell/py/pie/pie/render_jinja_template.py` and are
 registered with the Jinja environment by `create_env()`.
-
-Example usage of `linkparent`:
-
-```jinja
-{{ linkparent() }}
-{{ linkparent("manual") }}
-```
 

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -14,8 +14,7 @@ This document lists the common metadata keys used by Press and explains how miss
 - `og_image` – OpenGraph image path.
 - `meta` – Array of additional `<meta>` tag definitions for Pandoc.
 - `icon` – Emoji or icon displayed by link filters.
-- `parent` – ID of a parent page. Used by the `linkparent` Jinja global to
-  render a link to the parent document.
+- `parent` – ID of a parent page.
 - `link.tracking` – Boolean controlling external link behaviour.
 - `link.class` – CSS class for rendered links.
 


### PR DESCRIPTION
## Summary
- drop linkparent helper from render_jinja_template
- remove linkparent references in docs and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68963ebe8b1083219d909817c07cdd09