### PR TITLE
Cache metadata lookups and enhance deflist entries

### DIFF
--- a/app/shell/py/pie/tests/test_render_template.py
+++ b/app/shell/py/pie/tests/test_render_template.py
@@ -82,6 +82,7 @@ def test_link_uses_redis_tracking_and_ignores_icon(monkeypatch):
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
     monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(render_template, "_metadata_cache", {})
     render_template.index_json = {}
 
     html = render_template.render_link("entry", use_icon=False)
@@ -99,6 +100,7 @@ def test_linkcap_includes_icon_and_capitalizes(monkeypatch):
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
     monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(render_template, "_metadata_cache", {})
     render_template.index_json = {}
 
     html = render_template.render_link("entry", style="cap")
@@ -115,6 +117,7 @@ def test_linkicon_includes_icon_without_capitalization(monkeypatch):
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
     monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(render_template, "_metadata_cache", {})
     render_template.index_json = {}
 
     html = render_template.render_link("entry")
@@ -131,6 +134,7 @@ def test_link_icon_title_capitalizes_each_word_and_includes_icon(monkeypatch):
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
     monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(render_template, "_metadata_cache", {})
     render_template.index_json = {}
 
     html = render_template.render_link("entry", style="title")

--- a/app/shell/py/pie/tests/test_render_template_extra.py
+++ b/app/shell/py/pie/tests/test_render_template_extra.py
@@ -60,10 +60,19 @@ def test_convert_lists():
     assert render_template._convert_lists(obj) == [["x", "y"], [["z"]]]
 
 
-def test_load_desc_invalid_type():
-    """Non-str/dict input -> SystemExit."""
-    with pytest.raises(SystemExit):
-        render_template._load_desc(123)
+def test_get_cached_metadata_caches(monkeypatch):
+    """Second lookup uses cached value."""
+    calls: list[str] = []
+
+    def fake_get(key):
+        calls.append(key)
+        return {"id": key}
+
+    monkeypatch.setattr(render_template, "_get_metadata", fake_get)
+    monkeypatch.setattr(render_template, "_metadata_cache", {})
+    assert render_template.get_cached_metadata("x") == {"id": "x"}
+    assert render_template.get_cached_metadata("x") == {"id": "x"}
+    assert calls == ["x"]
 
 
 def test_render_link_uses_citation_dict():

--- a/docs/guides/include-filter.md
+++ b/docs/guides/include-filter.md
@@ -19,10 +19,12 @@ Within fenced `python` blocks the following functions are available:
 
 - `include(path)` – insert another Markdown file and adjust heading levels
 - `include_deflist_entry(*paths, glob='*', sort_fn=None)` – insert Markdown
-  files as definition list entries using their `title` metadata.  Each argument
-  may be a file or directory.  Directories are searched recursively for files
-  matching `glob` and processed in alphabetical order by default.  A custom
-  `sort_fn` can be provided to override the ordering.
+  files as definition list entries using their `title` metadata. Metadata is
+  looked up via `get_cached_metadata()` and the resulting title is followed by a
+  `#` that links to the entry's `url` when available. Each argument may be a
+  file or directory. Directories are searched recursively for files matching
+  `glob` and processed in alphabetical order by default. A custom `sort_fn` can
+  be provided to override the ordering.
 - `mermaid(file, alt, id)` – convert a Mermaid code block into an image using
   `mmdc` and emit a Markdown image link
 


### PR DESCRIPTION
## Summary
- add `get_cached_metadata` for cached metadata lookups in Jinja rendering
- link definition list titles to metadata URLs and use cached metadata in include-filter
- document and test caching and deflist link behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896860a082c8321b92ef660faca6df2