### PR TITLE
Add metadata lookup for include-filter and path id mapping

### DIFF
--- a/app/shell/py/pie/pie/__init__.py
+++ b/app/shell/py/pie/pie/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "build_index",
     "update_index",
     "include_filter",
+    "metadata",
     "render_jinja_template",
     "render_study_json",
     "gen_markdown_index",

--- a/app/shell/py/pie/pie/include_filter.py
+++ b/app/shell/py/pie/pie/include_filter.py
@@ -22,8 +22,7 @@ from typing import IO, Iterable, Callable
 
 import yaml
 from pie.logging import logger, add_log_argument, setup_file_logger
-from pie.render_jinja_template import get_cached_metadata
-from pie.load_metadata import load_metadata_pair
+from pie.metadata import get_metadata_by_path
 
 MD_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\.md\)")
 
@@ -112,10 +111,10 @@ def include_deflist_entry(
     for filename in files:
         logger.debug("include_deflist_entry", filename=str(filename))
         with open(filename, "r", encoding="utf-8") as f:
-            metadata = load_metadata_pair(filename)
-            if metadata and metadata.get("title"):
-                title = metadata["title"]
-                url = metadata.get("url")
+            rel = os.path.relpath(Path(filename).resolve(), Path.cwd())
+            title = get_metadata_by_path(rel, "title")
+            url = get_metadata_by_path(rel, "url")
+            if title:
                 if url:
                     print(f"<dt>{title} <a href=\"{url}\">↗</a></dt>", file=outfile)
                 else:

--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Helpers for retrieving metadata from Redis by file path."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import redis
+
+redis_conn: redis.Redis | None = None
+
+
+def get_metadata_by_path(filepath: str, keypath: str) -> Any | None:
+    """Return metadata value for ``keypath`` associated with ``filepath``.
+
+    The function first looks up the document ``id`` stored under ``filepath``
+    in Redis and then retrieves ``<id>.<keypath>``.
+    """
+
+    global redis_conn
+    if redis_conn is None:
+        host = os.getenv("REDIS_HOST", "dragonfly")
+        port = int(os.getenv("REDIS_PORT", "6379"))
+        redis_conn = redis.Redis(host=host, port=port, decode_responses=True)
+
+    doc_id = redis_conn.get(filepath)
+    if not doc_id:
+        return None
+    return redis_conn.get(f"{doc_id}.{keypath}")

--- a/app/shell/py/pie/pie/update_index.py
+++ b/app/shell/py/pie/pie/update_index.py
@@ -51,6 +51,10 @@ def flatten_index(index: Mapping[str, Mapping[str, Any]]) -> Iterable[tuple[str,
 
     for doc_id, props in index.items():
         yield from _walk(doc_id, props)
+        paths = props.get("path")
+        if isinstance(paths, list):
+            for p in paths:
+                yield p, doc_id
 
 
 

--- a/docs/guides/include-filter.md
+++ b/docs/guides/include-filter.md
@@ -20,11 +20,11 @@ Within fenced `python` blocks the following functions are available:
 - `include(path)` – insert another Markdown file and adjust heading levels
 - `include_deflist_entry(*paths, glob='*', sort_fn=None)` – insert Markdown
   files as definition list entries using their `title` metadata. Metadata is
-  looked up via `get_cached_metadata()` and the resulting title is followed by a
-  `#` that links to the entry's `url` when available. Each argument may be a
-  file or directory. Directories are searched recursively for files matching
-  `glob` and processed in alphabetical order by default. A custom `sort_fn` can
-  be provided to override the ordering.
+  retrieved from Redis via `get_metadata_by_path()` and the resulting title is
+  followed by a `#` that links to the entry's `url` when available. Each
+  argument may be a file or directory. Directories are searched recursively for
+  files matching `glob` and processed in alphabetical order by default. A
+  custom `sort_fn` can be provided to override the ordering.
 - `mermaid(file, alt, id)` – convert a Mermaid code block into an image using
   `mmdc` and emit a Markdown image link
 

--- a/docs/guides/update-index.md
+++ b/docs/guides/update-index.md
@@ -1,6 +1,6 @@
 # update-index
 
-Load a JSON index and insert each value into DragonflyDB or Redis. Keys use a dot-separated format of `<id>.<property>` with nested objects and arrays flattened. Complex values are stored as JSON strings. When processing metadata files, the paths to the source files are recorded under `<id>.path` as a JSON array; this `path` array is stored unflattened.
+Load a JSON index and insert each value into DragonflyDB or Redis. Keys use a dot-separated format of `<id>.<property>` with nested objects and arrays flattened. Complex values are stored as JSON strings. When processing metadata files, the paths to the source files are recorded under `<id>.path` as a JSON array; this `path` array is stored unflattened. Each source path is also stored separately with the path as the key and the document `id` as the value for quick reverse lookups.
 
 ## Usage
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -26,7 +26,7 @@ The top-level Makefile (`redo.mk`) drives all host-side automation. It launches 
 ## Build Pipeline
 The shell container executes `app/shell/mk/build.mk` to transform sources into deliverables:
 
-1. Discover Markdown and YAML files and update a Redis-backed index. See [build-index](../guides/build-index.md) and [update-index](../guides/update-index.md) for details on this step. Each document's source paths are stored under `<id>.path`.
+1. Discover Markdown and YAML files and update a Redis-backed index. See [build-index](../guides/build-index.md) and [update-index](../guides/update-index.md) for details on this step. Each document's source paths are stored under `<id>.path`, and each path also maps back to the document `id` for reverse lookups.
 2. Convert preprocessed Markdown to HTML and PDF using Pandoc with a shared template and options for table of contents, math rendering, and cross references.
 3. Copy CSS assets and minify the resulting site.
 4. Run link checking and page title validation before marking the build complete. See [checklinks](../guides/checklinks.md) and [check-page-title](../guides/check-page-title.md).


### PR DESCRIPTION
## Summary
- map source file paths to document ids in update-index
- add metadata lookup helper backed by Redis
- use Redis metadata in include-filter deflist entries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68968f1042748321951c8a1624a3e3e2