### PR TITLE
feat(sync): make S3 bucket configurable

### DIFF
--- a/app/s3/bin/seed
+++ b/app/s3/bin/seed
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-s3cmd sync s3://artisticanatomy/ s3/
+SRC="${S3_BUCKET_PATH:-s3://press}"
+SRC="${SRC%/}/"
+s3cmd sync "$SRC" s3/

--- a/app/s3/bin/sync
+++ b/app/s3/bin/sync
@@ -16,12 +16,14 @@ echo "Starting work… (PID $$)"
 # Example loop with interruptible sleep
 while true; do
     echo "Starting sync $(date +'%T')"
+    DEST="${S3_BUCKET_PATH:-s3://press}"
+    DEST="${DEST%/}/"
     s3cmd sync \
         --delete-removed \
         --delete-after \
         --acl-public \
         /s3/ \
-        s3://artisticanatomy/
+        "$DEST"
 
     # Start sleep in the background and record its PID
     echo "Sleeping for 10 seconds..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     build: ./app/s3
     container_name: press-sync
     entrypoint: ["/app/bin/sync"]
+    environment:
+      S3_BUCKET_PATH: ${S3_BUCKET_PATH:-s3://press}
     volumes:
       - ../s3:/s3
 
@@ -38,6 +40,8 @@ services:
     build: ./app/s3
     container_name: press-seed
     entrypoint: ["/app/bin/seed"]
+    environment:
+      S3_BUCKET_PATH: ${S3_BUCKET_PATH:-s3://press}
     volumes:
       - ../s3:/s3
 

--- a/docs/guides/redo-mk.md
+++ b/docs/guides/redo-mk.md
@@ -38,8 +38,8 @@ This repository actually uses three Makefiles that work together:
 | `clean` | Removes everything under `build/`. |
 | `prune` | Runs `docker system prune -f` to clean unused Docker resources. |
 | `setup` | Prepares `app/webp` directories and builds all services. |
-| `seed` | Runs the `seed` container to populate initial data. |
-| `sync` | Runs the `sync` container to upload site files to S3. |
+| `seed` | Runs the `seed` container to populate initial data (bucket from `S3_BUCKET_PATH`, default `s3://press`). |
+| `sync` | Runs the `sync` container to upload site files to S3 (bucket from `S3_BUCKET_PATH`, default `s3://press`). |
 | `webp` | Runs the image conversion service. |
 | `shell` | Opens an interactive shell container. |
 | `redis` | Opens a Redis CLI connected to the `dragonfly` service. |

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -21,7 +21,7 @@ The top-level Makefile (`redo.mk`) drives all host-side automation. It launches 
 - `nginx` and `nginx-dev` serve generated content.
 - `shell` provides the build environment and exposes tools and tests.
 - `dragonfly` supplies a Redis-compatible store used for tracking document metadata.
-- Auxiliary services `sync`, `seed`, and `webp` handle S3 uploads, database seeding, and WebP image conversion.
+- Auxiliary services `sync`, `seed`, and `webp` handle S3 uploads, database seeding, and WebP image conversion. The `sync` and `seed` containers read the S3 bucket from the `S3_BUCKET_PATH` environment variable (default: `s3://press`).
 
 ## Build Pipeline
 The shell container executes `app/shell/mk/build.mk` to transform sources into deliverables:


### PR DESCRIPTION
## Summary
- allow overriding S3 bucket for sync and seed services via `S3_BUCKET_PATH`
- use `S3_BUCKET_PATH` in sync and seed scripts with default `s3://press`
- document how to configure the bucket path in sync workflows

## Testing
- `pytest app/shell/py/pie/tests`


------
https://chatgpt.com/codex/tasks/task_e_6896993e53148321bc9693e00fbf4d16