### PR TITLE
Allow custom s3cfg path for sync and seed services

### DIFF
--- a/app/s3/bin/seed
+++ b/app/s3/bin/seed
@@ -2,4 +2,5 @@
 
 SRC="${S3_BUCKET_PATH:-s3://press}"
 SRC="${SRC%/}/"
-s3cmd sync "$SRC" s3/
+CONFIG="${S3CFG_PATH:-/root/.s3cfg}"
+s3cmd --config "$CONFIG" sync "$SRC" s3/

--- a/app/s3/bin/sync
+++ b/app/s3/bin/sync
@@ -14,11 +14,12 @@ trap _on_signal SIGINT SIGTERM SIGHUP
 echo "Starting work… (PID $$)"
 
 # Example loop with interruptible sleep
+CONFIG="${S3CFG_PATH:-/root/.s3cfg}"
 while true; do
     echo "Starting sync $(date +'%T')"
     DEST="${S3_BUCKET_PATH:-s3://press}"
     DEST="${DEST%/}/"
-    s3cmd sync \
+    s3cmd --config "$CONFIG" sync \
         --delete-removed \
         --delete-after \
         --acl-public \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     entrypoint: ["/app/bin/sync"]
     environment:
       S3_BUCKET_PATH: ${S3_BUCKET_PATH:-s3://press}
+      S3CFG_PATH: ${S3CFG_PATH:-/root/.s3cfg}
     volumes:
       - ../s3:/s3
 
@@ -42,6 +43,7 @@ services:
     entrypoint: ["/app/bin/seed"]
     environment:
       S3_BUCKET_PATH: ${S3_BUCKET_PATH:-s3://press}
+      S3CFG_PATH: ${S3CFG_PATH:-/root/.s3cfg}
     volumes:
       - ../s3:/s3
 

--- a/docs/guides/redo-mk.md
+++ b/docs/guides/redo-mk.md
@@ -38,8 +38,8 @@ This repository actually uses three Makefiles that work together:
 | `clean` | Removes everything under `build/`. |
 | `prune` | Runs `docker system prune -f` to clean unused Docker resources. |
 | `setup` | Prepares `app/webp` directories and builds all services. |
-| `seed` | Runs the `seed` container to populate initial data (bucket from `S3_BUCKET_PATH`, default `s3://press`). |
-| `sync` | Runs the `sync` container to upload site files to S3 (bucket from `S3_BUCKET_PATH`, default `s3://press`). |
+| `seed` | Runs the `seed` container to populate initial data (bucket from `S3_BUCKET_PATH`, default `s3://press`; config from `S3CFG_PATH`, default `/root/.s3cfg`). |
+| `sync` | Runs the `sync` container to upload site files to S3 (bucket from `S3_BUCKET_PATH`, default `s3://press`; config from `S3CFG_PATH`, default `/root/.s3cfg`). |
 | `webp` | Runs the image conversion service. |
 | `shell` | Opens an interactive shell container. |
 | `redis` | Opens a Redis CLI connected to the `dragonfly` service. |

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -21,7 +21,7 @@ The top-level Makefile (`redo.mk`) drives all host-side automation. It launches 
 - `nginx` and `nginx-dev` serve generated content.
 - `shell` provides the build environment and exposes tools and tests.
 - `dragonfly` supplies a Redis-compatible store used for tracking document metadata.
-- Auxiliary services `sync`, `seed`, and `webp` handle S3 uploads, database seeding, and WebP image conversion. The `sync` and `seed` containers read the S3 bucket from the `S3_BUCKET_PATH` environment variable (default: `s3://press`).
+- Auxiliary services `sync`, `seed`, and `webp` handle S3 uploads, database seeding, and WebP image conversion. The `sync` and `seed` containers read the S3 bucket from the `S3_BUCKET_PATH` environment variable (default: `s3://press`) and the S3 configuration file from `S3CFG_PATH` (default: `/root/.s3cfg`).
 
 ## Build Pipeline
 The shell container executes `app/shell/mk/build.mk` to transform sources into deliverables:


### PR DESCRIPTION
## Summary
- allow sync and seed scripts to read S3 configuration from S3CFG_PATH
- expose S3CFG_PATH for sync and seed services and document usage

## Testing
- `pytest` *(fails: ModuleNotFoundError: yaml, bs4, loguru, redis, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68969d4a51748321b2b86ca451a1b218