### PR TITLE
refactor: remove YAML metadata loader

### DIFF
--- a/app/shell/py/pie/tests/test_gen_markdown_index.py
+++ b/app/shell/py/pie/tests/test_gen_markdown_index.py
@@ -1,7 +1,12 @@
+from pathlib import Path
+
+import yaml
+
 from pie.gen_markdown_index import generate
+from pie import index_tree, metadata
 
 
-def test_show_property(tmp_path):
+def test_show_property(tmp_path, monkeypatch):
     """Nodes with 'show: false' are skipped."""
     (tmp_path / "alpha.yml").write_text("id: alpha\ntitle: Alpha\n")
     (tmp_path / "beta.yml").write_text(
@@ -14,6 +19,30 @@ def test_show_property(tmp_path):
     )
     (hidden / "child.yml").write_text("id: child\ntitle: Child\n")
 
+    def fake_meta(filepath: str, keypath: str):
+        data = yaml.safe_load(Path(filepath).read_text()) or {}
+        if "id" not in data:
+            data["id"] = Path(filepath).with_suffix("").name
+        for key in keypath.split("."):
+            if not isinstance(data, dict):
+                return None
+            data = data.get(key)
+            if data is None:
+                return None
+        return data
+
+    monkeypatch.setattr(index_tree, "get_metadata_by_path", fake_meta)
+
+    def fake_build(prefix: str):
+        doc_id = prefix.rstrip(".")
+        for p in tmp_path.rglob("*.yml"):
+            data = yaml.safe_load(p.read_text()) or {}
+            if data.get("id", p.with_suffix("").name) == doc_id:
+                return data
+        return None
+
+    monkeypatch.setattr(metadata, "build_from_redis", fake_build)
+
     lines = list(generate(tmp_path))
     assert lines == [
         '- {{"alpha"|linktitle}}',
@@ -21,9 +50,33 @@ def test_show_property(tmp_path):
     ]
 
 
-def test_missing_id_uses_filename(tmp_path):
+def test_missing_id_uses_filename(tmp_path, monkeypatch):
     """Files without an explicit id derive it from the filename."""
     (tmp_path / "foo.yml").write_text("name: Foo\ntitle: Foo\n")
+
+    def fake_meta(filepath: str, keypath: str):
+        data = yaml.safe_load(Path(filepath).read_text()) or {}
+        if "id" not in data:
+            data["id"] = Path(filepath).with_suffix("").name
+        for key in keypath.split("."):
+            if not isinstance(data, dict):
+                return None
+            data = data.get(key)
+            if data is None:
+                return None
+        return data
+
+    monkeypatch.setattr(index_tree, "get_metadata_by_path", fake_meta)
+
+    def fake_build(prefix: str):
+        doc_id = prefix.rstrip(".")
+        for p in tmp_path.rglob("*.yml"):
+            data = yaml.safe_load(p.read_text()) or {}
+            if data.get("id", p.with_suffix("").name) == doc_id:
+                return data
+        return None
+
+    monkeypatch.setattr(metadata, "build_from_redis", fake_build)
 
     lines = list(generate(tmp_path))
 

--- a/app/shell/py/pie/tests/test_get_metadata_by_path.py
+++ b/app/shell/py/pie/tests/test_get_metadata_by_path.py
@@ -1,0 +1,23 @@
+from pie import metadata
+
+
+class DummyRedis:
+    def __init__(self, store):
+        self.store = store
+
+    def get(self, key):
+        return self.store.get(key)
+
+
+def test_returns_value(monkeypatch):
+    store = {"/doc.yml": "doc1", "doc1.title": "Title"}
+    monkeypatch.setattr(metadata, "redis_conn", DummyRedis(store))
+    assert metadata.get_metadata_by_path("/doc.yml", "title") == "Title"
+
+
+def test_missing_entries(monkeypatch):
+    store = {"/doc.yml": "doc1"}
+    monkeypatch.setattr(metadata, "redis_conn", DummyRedis(store))
+    assert metadata.get_metadata_by_path("/doc.yml", "title") is None
+    monkeypatch.setattr(metadata, "redis_conn", DummyRedis({}))
+    assert metadata.get_metadata_by_path("/other.yml", "title") is None

--- a/app/shell/py/pie/tests/test_load_from_redis.py
+++ b/app/shell/py/pie/tests/test_load_from_redis.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from pie import index_tree, metadata
+
+
+def test_build_from_redis_used(monkeypatch):
+    path = Path("/doc.yml")
+
+    def fake_get_metadata_by_path(filepath: str, keypath: str):
+        assert filepath == str(path)
+        assert keypath == "id"
+        return "doc1"
+
+    calls: list[str] = []
+
+    def fake_build(prefix: str):
+        calls.append(prefix)
+        return {
+            "id": "doc1",
+            "title": "Title",
+            "url": "URL",
+            "gen-markdown-index": {"link": "1", "show": "0"},
+        }
+
+    monkeypatch.setattr(index_tree, "get_metadata_by_path", fake_get_metadata_by_path)
+    monkeypatch.setattr(metadata, "build_from_redis", fake_build)
+
+    meta = index_tree.load_from_redis(path)
+
+    assert meta == {
+        "id": "doc1",
+        "title": "Title",
+        "url": "URL",
+        "gen-markdown-index": {"link": "1", "show": "0"},
+    }
+    assert calls == ["doc1."]
+

--- a/app/shell/py/pie/tests/test_render_template.py
+++ b/app/shell/py/pie/tests/test_render_template.py
@@ -1,6 +1,7 @@
 import pytest
 import fakeredis
 from pie import render_jinja_template as render_template
+from pie import metadata
 
 
 def test_default_class():
@@ -49,7 +50,7 @@ def test_linktitle_uses_redis(monkeypatch):
     fake = fakeredis.FakeRedis(decode_responses=True)
     fake.set("item.citation", "Item")
     fake.set("item.url", "/i")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
 
     html = render_template.render_link("item", style="title")
@@ -60,7 +61,7 @@ def test_linktitle_uses_redis(monkeypatch):
 def test_linktitle_missing_raises(monkeypatch):
     """Unknown key -> SystemExit."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
 
     with pytest.raises(SystemExit):
@@ -81,7 +82,7 @@ def test_link_uses_redis_tracking_and_ignores_icon(monkeypatch):
     fake.set("entry.url", "/link")
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
     monkeypatch.setattr(render_template, "_metadata_cache", {})
     render_template.index_json = {}
 
@@ -99,7 +100,7 @@ def test_linkcap_includes_icon_and_capitalizes(monkeypatch):
     fake.set("entry.url", "/link")
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
     monkeypatch.setattr(render_template, "_metadata_cache", {})
     render_template.index_json = {}
 
@@ -116,7 +117,7 @@ def test_linkicon_includes_icon_without_capitalization(monkeypatch):
     fake.set("entry.url", "/link")
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
     monkeypatch.setattr(render_template, "_metadata_cache", {})
     render_template.index_json = {}
 
@@ -133,7 +134,7 @@ def test_link_icon_title_capitalizes_each_word_and_includes_icon(monkeypatch):
     fake.set("entry.url", "/link")
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
     monkeypatch.setattr(render_template, "_metadata_cache", {})
     render_template.index_json = {}
 
@@ -149,7 +150,7 @@ def test_linkshort_uses_short_citation_and_ignores_icon(monkeypatch):
     fake.set("entry.url", "/link")
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
 
     html = render_template.render_link("entry", citation="short", use_icon=False)
@@ -165,7 +166,7 @@ def test_link_handles_citation_metadata(monkeypatch):
     fake.set("hull.citation.year", "2016")
     fake.set("hull.citation.page", "307")
     fake.set("hull.url", "/hull")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
 
     html = render_template.link("hull")
@@ -184,7 +185,7 @@ def test_wrapper_accepts_anchor(monkeypatch):
     fake = fakeredis.FakeRedis(decode_responses=True)
     fake.set("entry.citation", "Foo")
     fake.set("entry.url", "/link")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
 
     html = render_template.link("entry", anchor="top")
@@ -198,7 +199,7 @@ def test_cite_single(monkeypatch):
     fake.set("hull.citation.year", "2016")
     fake.set("hull.citation.page", "307")
     fake.set("hull.url", "/hull")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
 
     html = render_template.cite("hull")
@@ -217,7 +218,7 @@ def test_cite_combines_pages(monkeypatch):
     fake.set("hull2.citation.year", "2016")
     fake.set("hull2.citation.page", "311")
     fake.set("hull2.url", "/hull")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
 
     html = render_template.cite("hull1", "hull2")
@@ -236,7 +237,7 @@ def test_cite_multiple_sources(monkeypatch):
     fake.set("x.citation.year", "2016")
     fake.set("x.citation.page", "311")
     fake.set("x.url", "/x")
-    monkeypatch.setattr(render_template, "redis_conn", fake)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
 
     html = render_template.cite("hull", "x")


### PR DESCRIPTION
## Summary
- move `_build_from_redis` into a new `metadata.build_from_redis` with helpers for JSON decoding and list normalization
- drop the local Redis connection from `render_jinja_template` and delegate lookups to `metadata.build_from_redis`
- adjust tests to patch `metadata.redis_conn`, exercising the single global connection
- delegate `index_tree.load_from_redis` to `metadata.build_from_redis` and update tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68969e64893c832189e378d87ed4f3ee