### PR TITLE
Document distclean target in redo.mk

### DIFF
--- a/docs/guides/redo-mk.md
+++ b/docs/guides/redo-mk.md
@@ -29,21 +29,22 @@ This repository actually uses three Makefiles that work together:
 | Target | Description |
 | ------ | ----------- |
 | `all`  | Builds the site by invoking `/app/mk/build.mk` inside the shell container. |
-| `docker` | Builds and pushes the Nginx image after running `test`. |
-| `test` | Restarts `nginx-dev` and runs tests defined in `/app/mk/build.mk`. |
-| `pytest` | Runs unit tests for the `pie` package inside the shell container. |
-| `cov` | Generates an HTML coverage report for the `pie` package inside the shell container (output in `log/cov`). |
-| `up` / `upd` | Starts development containers (`SERVICES`). `upd` runs detached. |
-| `down` | Stops and removes the compose stack. |
 | `clean` | Removes everything under `build/`. |
+| `cov` | Generates an HTML coverage report for the `pie` package inside the shell container (output in `log/cov`). |
+| `distclean` | Runs `clean` and removes `.init` markers and the Dragonfly index cache. |
+| `docker` | Builds and pushes the Nginx image after running `test`. |
+| `down` | Stops and removes the compose stack. |
 | `prune` | Runs `docker system prune -f` to clean unused Docker resources. |
-| `setup` | Prepares `app/webp` directories and builds all services. |
-| `seed` | Runs the `seed` container to populate initial data (bucket from `S3_BUCKET_PATH`, default `s3://press`; config from `S3CFG_PATH`, default `/root/.s3cfg`). |
-| `sync` | Runs the `sync` container to upload site files to S3 (bucket from `S3_BUCKET_PATH`, default `s3://press`; config from `S3CFG_PATH`, default `/root/.s3cfg`). |
-| `webp` | Runs the image conversion service. |
-| `shell` | Opens an interactive shell container. |
+| `pytest` | Runs unit tests for the `pie` package inside the shell container. |
 | `redis` | Opens a Redis CLI connected to the `dragonfly` service. |
 | `rmi` | Removes Docker images matching `press-*` using `./bin/docker-rmi-pattern`. |
+| `seed` | Runs the `seed` container to populate initial data (bucket from `S3_BUCKET_PATH`, default `s3://press`; config from `S3CFG_PATH`, default `/root/.s3cfg`). |
+| `setup` | Prepares `app/webp` directories and builds all services. |
+| `shell` | Opens an interactive shell container. |
+| `sync` | Runs the `sync` container to upload site files to S3 (bucket from `S3_BUCKET_PATH`, default `s3://press`; config from `S3CFG_PATH`, default `/root/.s3cfg`). |
+| `test` | Restarts `nginx-dev` and runs tests defined in `/app/mk/build.mk`. |
+| `up` / `upd` | Starts development containers (`SERVICES`). `upd` runs detached. |
+| `webp` | Runs the image conversion service. |
 
 Run `make -f redo.mk <target>` (or `r <target>` if you use the alias from the README) to execute any of these commands.
 

--- a/redo.mk
+++ b/redo.mk
@@ -94,7 +94,7 @@ clean: ## Remove everything under build/
 	$(Q)-rm -f $(BUILD_DIR)/.update-index
 
 .PHONY: distclean
-distclean: clean
+distclean: clean ## Remove .init markers and clear Dragonfly index cache
 	$(call status,Remove .init)
 	$(Q)-rm -f `find app/ -name .init`
 	$(call status,Empty Index Cache)


### PR DESCRIPTION
## Summary
- document the `distclean` target to clarify how it removes `.init` markers and clears the Dragonfly index cache
- document the `distclean` target in the `redo.mk` guide
- sort the common targets table alphabetically

## Testing
- `make -f redo.mk help`
- `make -f redo.mk test` *(fails: make: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896a9bfd9f0832199eb850b8af7ce84