### PR TITLE
docs: describe update-index input options

### DIFF
--- a/docs/guides/update-index.md
+++ b/docs/guides/update-index.md
@@ -1,14 +1,14 @@
 # update-index
 
-Load a JSON index and insert each value into DragonflyDB or Redis. Keys use a dot-separated format of `<id>.<property>` with nested objects and arrays flattened. Complex values are stored as JSON strings. When processing metadata files, the paths to the source files are recorded under `<id>.path` as a JSON array; this `path` array is stored unflattened. Each source path is also stored separately with the path as the key and the document `id` as the value for quick reverse lookups.
+Load a JSON index, metadata file, or directory of metadata and insert each value into DragonflyDB or Redis. Keys use a dot-separated format of `<id>.<property>` with nested objects and arrays flattened. Complex values are stored as JSON strings. When processing metadata files, the paths to the source files are recorded under `<id>.path` as a JSON array; this `path` array is stored unflattened. Each source path is also stored separately with the path as the key and the document `id` as the value for quick reverse lookups.
 
 ## Usage
 
 - ```bash
-update-index index.json [--host HOST] [--port PORT] [-l LOGFILE]
+update-index PATH [--host HOST] [--port PORT] [-l LOGFILE]
 ```
 
-- `index` path to the JSON index file or a directory of metadata
+- `PATH` path to `index.json`, a metadata file, or a directory of metadata
 - `--host` Redis host (default `dragonfly` or `$REDIS_HOST`)
 - `--port` Redis port (default `6379` or `$REDIS_PORT`)
 - `-l, --log` optional log file
@@ -27,4 +27,4 @@ from pie.update import index
 index.main(["index.json"])
 ```
 
-When a directory is given, `update-index` scans recursively for `.md`, `.yml`, and `.yaml` files, processing each Markdown/YAML pair only once. The command expects an index produced by [`build-index`](build-index.md). Entries are written to the configured Redis instance using pipelined batch writes, with each value stored under its own key, including `id.path` entries pointing to the original files.
+When a directory is given, `update-index` scans recursively for `.md`, `.yml`, and `.yaml` files, processing each Markdown/YAML pair only once. A single metadata file may also be supplied and is processed directly. When an index JSON file is provided, it should be produced by [`build-index`](build-index.md). Entries are written to the configured Redis instance using pipelined batch writes, with each value stored under its own key, including `id.path` entries pointing to the original files.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -14,6 +14,7 @@ documents provide context for the task‑oriented
 - [metadata-fields.md](metadata-fields.md) – description of common metadata fields referenced in
   [build-index](../guides/build-index.md).
 - [update-author.md](update-author.md) – refresh the `author` field for existing documents.
+- [update-index.md](update-index.md) – insert index values into Redis.
 - [update-pubdate.md](update-pubdate.md) – update the `pubdate` field for modified files.
 
 For step‑by‑step workflows and tutorials, head back to the

--- a/docs/reference/update-index.md
+++ b/docs/reference/update-index.md
@@ -1,0 +1,21 @@
+# update-index
+
+Insert index values into DragonflyDB or Redis.
+
+The console script loads `index.json`, a metadata file, or scans a directory of
+metadata files and flattens each document into `<id>.<property>` keys. Complex
+values are stored as JSON strings. Source paths are recorded under
+`<id>.path` and each path also maps back to the document `id`.
+
+```bash
+update-index PATH [--host HOST] [--port PORT] [-l LOGFILE]
+```
+
+- `PATH` path to `index.json`, a metadata file, or a directory of metadata
+- `--host` Redis host (default `dragonfly` or `$REDIS_HOST`)
+- `--port` Redis port (default `6379` or `$REDIS_PORT`)
+- `-l, --log` optional log file
+
+Values are inserted using pipelined writes and a summary of the number of files
+processed and the elapsed time is logged. Environment variables `REDIS_HOST`
+and `REDIS_PORT` are used when `--host` or `--port` are not supplied.


### PR DESCRIPTION
## Summary
- document that `update-index` accepts JSON indexes, metadata files, or directories
- add reference entry for `update-index`

## Testing
- `pytest -q` *(fails: No module named 'bs4')*


------
https://chatgpt.com/codex/tasks/task_e_6896aea8890883218236a899930d9cc9