### PR TITLE
feat: add verbosity flag to update-index

### DIFF
--- a/docs/guides/update-index.md
+++ b/docs/guides/update-index.md
@@ -5,13 +5,14 @@ Load a JSON index and insert each value into DragonflyDB or Redis. Keys use a do
 ## Usage
 
 - ```bash
-update-index index.json [--host HOST] [--port PORT] [-l LOGFILE]
+update-index index.json [--host HOST] [--port PORT] [-l LOGFILE] [-v]
 ```
 
 - `index` path to the JSON index file or a directory of metadata
 - `--host` Redis host (default `dragonfly` or `$REDIS_HOST`)
 - `--port` Redis port (default `6379` or `$REDIS_PORT`)
 - `-l, --log` optional log file
+- `-v, --verbose` show debug output
 
 `update-index` also reads the `REDIS_HOST` and `REDIS_PORT` environment
 variables when `--host` or `--port` are not specified.


### PR DESCRIPTION
## Summary
- add `--verbose` flag to `update-index` for debug-level console logs
- log redis connection and loaded index details
- document the verbose option and test logging configuration

## Testing
- `pytest app/shell/py/pie/tests/test_update_index.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6896af6c96688321965099cde4621dac