### PR TITLE
Use Redis metadata in indextree-json

### DIFF
--- a/app/shell/py/pie/pie/indextree_json.py
+++ b/app/shell/py/pie/pie/indextree_json.py
@@ -4,13 +4,12 @@ import json
 from pathlib import Path
 
 from pie.index_tree import walk, getopt_link, getopt_show
-from pie.metadata import load_metadata_pair
 
 
 def process_dir(directory: Path):
     """Recursively process *directory* to yield structured entries."""
     entries = sorted(
-        walk(directory, loader=load_metadata_pair),
+        walk(directory),
         key=lambda x: x[0]["title"].lower(),
     )
     for meta, path in entries:


### PR DESCRIPTION
## Summary
- Switch indextree-json to use Redis-backed metadata loader
- Rewrite indextree_json tests to populate a fake Redis store

## Testing
- `pytest app/shell/py/pie/tests/test_indextree_json.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b3bca4588321821aa8f560b44778