### PR TITLE
Refactor include filter execution

### DIFF
--- a/app/shell/py/pie/pie/filter/include.py
+++ b/app/shell/py/pie/pie/filter/include.py
@@ -135,6 +135,13 @@ def yield_lines(infile: IO[str]) -> Iterable[str]:
         yield line
 
 
+def execute_python_block(lines: Iterable[str]) -> None:
+    """Execute a Python code block gathered from ``yield_lines``."""
+
+    code = "".join(lines)
+    exec(code, globals())
+
+
 def new_filestem(stem: str) -> str:
     """Return *stem* with a numeric suffix that doesn't clash with existing files."""
 
@@ -213,15 +220,7 @@ def main(argv: list[str] | None = None) -> None:
     ) as outfile:
         for line in infile:
             if line.strip() == "```python":
-                # FIXME Terrible. Some times, there is one statement with a
-                # multiline string. Some times, there are multiple statements.
-                # Probably need a proper parser here.
-                lines = list(yield_lines(infile))
-                try:
-                    eval("".join(lines))
-                except:
-                    for l in lines:
-                        eval(l)
+                execute_python_block(yield_lines(infile))
             else:
                 if line.startswith("#"):
                     parts = line.split(" ")

--- a/app/shell/py/pie/tests/test_include_filter.py
+++ b/app/shell/py/pie/tests/test_include_filter.py
@@ -112,6 +112,23 @@ def test_md_to_html_links_rewrites_extension():
     )
 
 
+def test_execute_python_block_executes_all_lines():
+    """execute_python_block runs multiple statements in order."""
+
+    include_filter.outfile = StringIO()
+    include_filter.execute_python_block(
+        [
+            "a = 1\n",
+            "b = 2\n",
+            "print(a + b, file=outfile)\n",
+        ]
+    )
+    try:
+        assert include_filter.outfile.getvalue() == "3\n"
+    finally:
+        include_filter.outfile = None
+
+
 def test_parse_args_parses_positions():
     """parse_args returns expected positional arguments."""
     args = include_filter.parse_args(["out", "in.md", "out.md"])


### PR DESCRIPTION
## Summary
- add `execute_python_block` to run fenced Python code with `exec`
- simplify `main` to use helper for executing fenced blocks
- cover new helper with tests

## Testing
- `pytest app/shell/py/pie/tests/test_include_filter.py`
- `pytest` *(fails: No module named 'bs4', No module named 'emoji', No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_6896b46be47083218feacadba234815f