### PR TITLE
docs: add Chicago citation examples

### DIFF
--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -15,6 +15,12 @@ for details on the structure of this metadata.
   citations. When multiple entries share the same author and year their page
   numbers are combined.
 
+Example:
+
+```jinja
+{{ cite("hull", "doe") }}
+```
+
 These helpers live in `app/shell/py/pie/pie/render/jinja.py` and are
 registered with the Jinja environment by `create_env()`.
 

--- a/src/examples/chicago-citations.md
+++ b/src/examples/chicago-citations.md
@@ -1,0 +1,22 @@
+---
+title: Chicago Citation Examples
+author: Brian Lee
+id: chicago-citations
+citation: chicago citations
+---
+
+Demonstrates Chicago-style citations using the `cite` global and the `link` filter.
+
+## cite
+
+Single source:
+
+{{ cite("hull") }}
+
+Multiple sources:
+
+{{ cite("hull", "doe") }}
+
+## link filter
+
+{{ {"citation": {"author": "hull", "year": 2016, "page": 307}, "url": "/hull"} | link }}

--- a/src/examples/doe.yml
+++ b/src/examples/doe.yml
@@ -1,0 +1,6 @@
+name: Example Book
+citation:
+  author: Doe
+  year: 2019
+  page: 42
+url: https://example.com/doe

--- a/src/examples/hull.yml
+++ b/src/examples/hull.yml
@@ -1,0 +1,6 @@
+name: Options, Futures, and Other Derivatives
+citation:
+  author: Hull
+  year: 2016
+  page: 307
+url: https://example.com/hull


### PR DESCRIPTION
## Summary
- document how to use the `cite` helper
- add example page demonstrating Chicago-style citations
- provide sample metadata entries for referenced sources

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6897b6189c808321842122e3fbe5759d