### PR TITLE
Expand create site scaffolding

### DIFF
--- a/app/shell/py/pie/pie/create/templates/README.md.jinja
+++ b/app/shell/py/pie/pie/create/templates/README.md.jinja
@@ -1,0 +1,6 @@
+# New Press Project
+
+## Building
+
+Run `docker-compose build` to build the project.
+

--- a/app/shell/py/pie/pie/create/templates/docker-compose.yml.jinja
+++ b/app/shell/py/pie/pie/create/templates/docker-compose.yml.jinja
@@ -1,0 +1,23 @@
+services:
+  nginx:
+    image: nginx:latest
+    ports:
+      - "80:80"
+
+  nginx-dev:
+    image: nginx:latest
+    ports:
+      - "80:80"
+    volumes:
+      - ./build:/usr/share/nginx/html
+
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly
+
+  shell:
+    build: app/shell
+    entrypoint: ["bash"]
+
+    volumes:
+      - ./:/data
+      - ./src/dep.mk:/app/mk/dep.mk

--- a/app/shell/py/pie/pie/create/templates/index.md.jinja
+++ b/app/shell/py/pie/pie/create/templates/index.md.jinja
@@ -1,0 +1,6 @@
+# Welcome
+
+Welcome to your new Press project.
+
+Run `redo build` to build the project then `docker compose up` to view it locally.
+

--- a/app/shell/py/pie/pie/create/templates/index.yml.jinja
+++ b/app/shell/py/pie/pie/create/templates/index.yml.jinja
@@ -1,0 +1,2 @@
+title: Home
+

--- a/app/shell/py/pie/pie/create/templates/shell.Dockerfile.jinja
+++ b/app/shell/py/pie/pie/create/templates/shell.Dockerfile.jinja
@@ -1,0 +1,2 @@
+FROM press-release
+

--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -9,10 +9,32 @@ def test_create_scaffolding(tmp_path: Path) -> None:
     target = tmp_path / "press-project"
     site.main([str(target)])
 
-    assert (target / "docker-compose.yml").exists()
+    compose = target / "docker-compose.yml"
+    assert compose.exists()
+    text = compose.read_text(encoding="utf-8")
+    for svc in ["nginx:", "nginx-dev:", "dragonfly:", "shell:"]:
+        assert svc in text
+    assert "    build: app/shell" in text
+    assert '    entrypoint: ["bash"]' in text
+    assert "      - ./:/data" in text
+    assert "      - ./src/dep.mk:/app/mk/dep.mk" in text
     assert (target / "src").is_dir()
+
+    assert (target / "redo.mk").exists()
+
+    shell_dockerfile = target / "app/shell/Dockerfile"
+    assert shell_dockerfile.exists()
+    assert shell_dockerfile.read_text(encoding="utf-8").startswith("FROM press-release")
+
+    index_md = target / "src/index.md"
+    assert index_md.exists()
+    md_text = index_md.read_text(encoding="utf-8")
+    assert "Welcome" in md_text
+    assert "view it locally" in md_text
+
+    assert (target / "src/index.yml").exists()
 
     readme = target / "README.md"
     assert readme.exists(), "README should be created"
-    text = readme.read_text(encoding="utf-8")
-    assert "docker-compose build" in text
+    readme_text = readme.read_text(encoding="utf-8")
+    assert "docker-compose build" in readme_text


### PR DESCRIPTION
## Summary
- externalize scaffolding for docker-compose, README, and index files using Jinja templates
- generate shell Dockerfile referencing press-release image in new projects
- test create-site scaffolding for expected services, files, and shell Dockerfile presence

## Testing
- `pytest app/shell/py/pie/tests/test_create.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897b5048e24832199365792ec0c4375