### PR TITLE
Add scaffolding assets for create-site

### DIFF
--- a/app/shell/py/pie/pie/create/site.py
+++ b/app/shell/py/pie/pie/create/site.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-import shutil
 from typing import Sequence
 
 from jinja2 import Environment
@@ -38,8 +37,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         "docker-compose.yml": "docker-compose.yml.jinja",
         "src/index.md": "index.md.jinja",
         "src/index.yml": "index.yml.jinja",
+        "src/style.css": "style.css.jinja",
+        "src/pandoc-template.html": "pandoc-template.html.jinja",
         "README.md": "README.md.jinja",
         "app/shell/Dockerfile": "shell.Dockerfile.jinja",
+        "redo.mk": "redo.mk.jinja",
     }
 
     for rel_path, template_name in files.items():
@@ -48,14 +50,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         template_text = (template_dir / template_name).read_text(encoding="utf-8")
         content = env.from_string(template_text).render()
         target.write_text(content, encoding="utf-8")
-
-    # Copy redo.mk from repository root
-    for parent in Path(__file__).resolve().parents:
-        source = parent / "redo.mk"
-        if source.exists():
-            shutil.copy(source, root / "redo.mk")
-            break
-
 
     logger.info("Created project scaffolding", path=str(root))
     return 0

--- a/app/shell/py/pie/pie/create/templates/index.yml.jinja
+++ b/app/shell/py/pie/pie/create/templates/index.yml.jinja
@@ -1,2 +1,3 @@
 title: Home
+name: Home
 

--- a/app/shell/py/pie/pie/create/templates/pandoc-template.html.jinja
+++ b/app/shell/py/pie/pie/create/templates/pandoc-template.html.jinja
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>$title$</title>
+    $for(css)$
+    <link rel="stylesheet" href="$css$" />
+    $endfor$
+  </head>
+  <body>
+    $body$
+  </body>
+</html>
+

--- a/app/shell/py/pie/pie/create/templates/redo.mk.jinja
+++ b/app/shell/py/pie/pie/create/templates/redo.mk.jinja
@@ -1,0 +1,180 @@
+# Makefile for building and managing Press
+
+# Override MAKEFLAGS (so your settings can’t be clobbered by the environment)
+override MAKEFLAGS += --warn-undefined-variables  \
+	              --no-builtin-rules        \
+	              -j16                      \
+
+# Export it so sub-makes see the same flags
+export MAKEFLAGS
+
+# Containers started when running `up`/`upd`.
+# See docs/guides/redo-mk.md for details on targets and variables and
+# docs/guides/dep-mk.md for dependency file conventions.
+SERVICES := nginx-dev dragonfly
+
+SRC_DIR   := src
+BUILD_DIR := build
+
+VPATH := $(SRC_DIR)
+
+COMPOSE_FILE := $(if $(wildcard docker-compose.yml),docker-compose.yml,dist/docker-compose.yml)
+DOCKER_COMPOSE := docker compose -f $(COMPOSE_FILE)
+
+MAKE_CMD := $(DOCKER_COMPOSE) run --rm --entrypoint make -u $(shell id -u) -T shell
+
+# Verbosity control
+VERBOSE ?= 0
+ifeq ($(VERBOSE),1)
+Q :=
+else
+Q := @
+endif
+
+# Helper to print status messages
+status = @echo "==> $(1)"
+
+# Default make target
+.DEFAULT_GOAL := all
+
+# Define the default target to build everything
+.PHONY: all
+all: ## Build the site by invoking /app/mk/build.mk inside the shell container
+	$(call status,Build site)
+	$(Q)$(DOCKER_COMPOSE) up -d dragonfly
+	$(Q)$(MAKE_CMD) -f /app/mk/build.mk VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR)
+
+$(BUILD_DIR): ## Helper target used by other rules
+	$(call status,Prepare build directory $@)
+	$(Q)mkdir -p $@
+
+# Docker-related targets
+# Initialize Docker authentication and build the Nginx image
+# Uncomment the lines below to tag and push the Docker image
+# doctl auth init; remove extraneous context as necessary
+# doctl registry login
+
+CONTAINER_REGISTRY := registry.digitalocean.com/artisticanatomy
+
+.PHONY: docker
+docker: test ## Build and push the Nginx image after running test
+	$(call status,Build nginx image)
+	$(Q)$(DOCKER_COMPOSE) build nginx
+	$(call status,Tag image)
+	$(Q)docker tag koreanbriancom-nginx $(CONTAINER_REGISTRY)/koreanbrian.com:latest
+	$(call status,Push image)
+	$(Q)docker push registry.digitalocean.com/artisticanatomy/koreanbrian.com:latest
+
+.PHONY: test
+test: ## Restart nginx-dev and run tests
+	$(call status,Run tests)
+	$(Q)$(MAKE_CMD) -f /app/mk/build.mk VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
+
+# Target to bring up the development Nginx container
+.PHONY: up
+up: ## Start development containers defined in SERVICES
+	$(call status,Start services $(SERVICES))
+	$(Q)$(DOCKER_COMPOSE) up $(SERVICES) --build --remove-orphans
+
+.PHONY: upd
+upd: ## Start development containers in detached mode
+	$(call status,Start services $(SERVICES) detached)
+	$(Q)$(DOCKER_COMPOSE) up $(SERVICES) --build --remove-orphans -d
+
+.PHONY: down
+down: ## Stop and remove the compose stack
+	$(call status,Stop compose stack)
+	$(Q)$(DOCKER_COMPOSE) down
+
+# Clean the build directory by removing all build artifacts
+.PHONY: clean
+clean: ## Remove everything under build/
+	$(call status,Remove build artifacts)
+	$(Q)-rm -rf $(BUILD_DIR)/*
+	$(Q)-rm -f $(BUILD_DIR)/.update-index
+
+.PHONY: distclean
+distclean: clean ## Remove .init markers and clear Dragonfly index cache
+	$(call status,Remove .init)
+	$(Q)-rm -f `find app/ -name .init`
+	$(call status,Empty Index Cache)
+	$(Q)./bin/redis-cli flushall
+
+.PHONY: prune
+prune: ## Run docker system prune -f to clean unused resources
+	$(call status,Docker prune)
+	$(Q)docker system prune -f
+
+.PHONY: setup
+setup: ## Prepare app/webp directories and build all services
+	$(call status,Prepare webp directories)
+	$(Q)mkdir -p app/webp/input
+	$(Q)mkdir -p app/webp/output
+	$(call status,Build all services)
+	$(Q)$(DOCKER_COMPOSE) build
+
+.PHONY: seed
+seed: ## Run the seed container to populate initial data
+	$(call status,Seed database)
+	$(Q)$(DOCKER_COMPOSE) run --build --rm -T seed
+
+.PHONY: sync
+sync: ## Upload site files to S3 using the sync container
+	$(call status,Run sync container)
+	$(Q)$(DOCKER_COMPOSE) run --build --rm -T sync
+
+.PHONY: webp
+webp: ## Convert images to webp format
+	$(call status,Convert images to webp)
+	$(Q)$(DOCKER_COMPOSE) run --build --rm -T webp
+
+.PHONY: shell
+shell: ## Open an interactive shell container
+	$(call status,Open shell)
+	$(Q)$(DOCKER_COMPOSE) run --rm --build shell
+
+.PHONY: rmi
+rmi: ## Remove Docker images matching press-*
+	$(call status,Remove images matching press-*)
+	$(Q)./bin/docker-rmi-pattern 'press-*'
+
+.PHONY: help
+help: ## List available tasks
+	@grep -E '^[a-zA-Z0-9_-]+:.*##' $(MAKEFILE_LIST) | \
+	awk -F ':.*##' '{printf "%-10s %s\n", $$1, $$2}'
+
+.PHONY: buildx
+buildx: ## Run Docker buildx
+	$(call status,Run buildx)
+	$(Q)docker buildx build app/shell/
+
+
+.PHONY: pytest
+pytest:
+	# Add option -s to see stdout.
+	$(call status,Run pytest)
+	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell /press/py/pie/tests
+
+.PHONY: cov
+cov:
+	$(call status,Run coverage)
+	$(Q)mkdir -p log/cov
+	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell --cov=pie --cov-report=term-missing --cov-report=html:/data/log/cov /press/py/pie/tests
+.PHONY: t
+t: ## Restart nginx-dev and run tests, ansi colors
+	$(call status,Run tests with colors)
+	$(Q)$(DOCKER_COMPOSE) run --entrypoint make --rm shell -f /app/mk/build.mk VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
+	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell /press/py/pie/tests
+
+.PHONY: redis
+redis: ## Open redis-cli on the dragonfly service
+	$(Q)$(DOCKER_COMPOSE) exec dragonfly redis-cli
+
+.PHONY: tags
+tags:
+	$(Q)ctags -R app/shell/py
+
+.PHONY: release
+release: all test
+	$(Q)$(DOCKER_COMPOSE) build shell
+	$(Q)$(DOCKER_COMPOSE) build release

--- a/app/shell/py/pie/pie/create/templates/style.css.jinja
+++ b/app/shell/py/pie/pie/create/templates/style.css.jinja
@@ -1,0 +1,7 @@
+/* Minimal stylesheet */
+body {
+  font-family: sans-serif;
+  margin: 1em auto;
+  max-width: 40em;
+}
+

--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -22,6 +22,9 @@ def test_create_scaffolding(tmp_path: Path) -> None:
 
     assert (target / "redo.mk").exists()
 
+    assert (target / "src/style.css").exists()
+    assert (target / "src/pandoc-template.html").exists()
+
     shell_dockerfile = target / "app/shell/Dockerfile"
     assert shell_dockerfile.exists()
     assert shell_dockerfile.read_text(encoding="utf-8").startswith("FROM press-release")
@@ -32,7 +35,10 @@ def test_create_scaffolding(tmp_path: Path) -> None:
     assert "Welcome" in md_text
     assert "view it locally" in md_text
 
-    assert (target / "src/index.yml").exists()
+    index_yml = target / "src/index.yml"
+    assert index_yml.exists()
+    yml_text = index_yml.read_text(encoding="utf-8")
+    assert "name:" in yml_text
 
     readme = target / "README.md"
     assert readme.exists(), "README should be created"


### PR DESCRIPTION
## Summary
- ensure create-site scaffolding generates style.css, pandoc template, and redo.mk
- include name field in default index.yml
- test scaffolding for new files

## Testing
- `pytest app/shell/py/pie/tests/test_create.py -q`
- `pytest app/shell/py/pie/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c0771ea483219fd895b4d7322d6c