### PR TITLE
Add dep.mk and robots.txt to site scaffolding

### DIFF
--- a/app/shell/py/pie/pie/create/site.py
+++ b/app/shell/py/pie/pie/create/site.py
@@ -39,6 +39,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         "src/index.yml": "index.yml.jinja",
         "src/style.css": "style.css.jinja",
         "src/pandoc-template.html": "pandoc-template.html.jinja",
+        "src/dep.mk": "dep.mk.jinja",
+        "src/robots.txt": "robots.txt.jinja",
         "README.md": "README.md.jinja",
         "app/shell/Dockerfile": "shell.Dockerfile.jinja",
         "redo.mk": "redo.mk.jinja",

--- a/app/shell/py/pie/pie/create/templates/robots.txt.jinja
+++ b/app/shell/py/pie/pie/create/templates/robots.txt.jinja
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:

--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -20,6 +20,15 @@ def test_create_scaffolding(tmp_path: Path) -> None:
     assert "      - ./src/dep.mk:/app/mk/dep.mk" in text
     assert (target / "src").is_dir()
 
+    dep_mk = target / "src/dep.mk"
+    assert dep_mk.exists()
+    assert dep_mk.read_text(encoding="utf-8") == ""
+
+    robots = target / "src/robots.txt"
+    assert robots.exists()
+    robots_text = robots.read_text(encoding="utf-8")
+    assert "User-agent: *" in robots_text
+
     assert (target / "redo.mk").exists()
 
     assert (target / "src/style.css").exists()


### PR DESCRIPTION
## Summary
- ensure `pie.create.site` scaffolding generates empty `src/dep.mk`
- add minimal `src/robots.txt` to new site scaffolding
- test scaffolding produces new files

## Testing
- `pytest app/shell/py/pie/tests`


------
https://chatgpt.com/codex/tasks/task_e_6897c492702c83218754b9371232438e