### PR TITLE
docs: expand Jinja examples

### DIFF
--- a/docs/reference/jinja-filters.md
+++ b/docs/reference/jinja-filters.md
@@ -78,3 +78,15 @@ renders as:
 
 Looks up a description object from the build index. If the name is not present,
 `get_desc` returns the name unchanged.
+
+Example:
+
+```jinja
+{{ "hull" | get_desc }}
+```
+
+renders as:
+
+```json
+{{ "hull" | get_desc }}
+```

--- a/src/examples/jinja.md
+++ b/src/examples/jinja.md
@@ -5,22 +5,67 @@ id: jinja
 citation: jinja
 ---
 
-## For-loop
+This tutorial introduces the basics of embedding Jinja in Markdown. Each
+snippet shows the template followed by its rendered output.
 
-Markdown files can include Jinja2 templates. This loop generates three list items:
+## Variables
 
+Insert the value of a variable:
+
+```jinja
+{% raw %}{{ "Hello, world!" }}{% endraw %}
 ```
-{% raw %}
-{% for i in range(0, 3): -%}
+
+renders as:
+
+{{ "Hello, world!" }}
+
+## For loop
+
+Generate repeated content with a loop:
+
+```jinja
+{% raw %}{% for i in range(0, 3) -%}
+- Jinja test {{ i }}
+{% endfor %}{% endraw %}
+```
+
+Output:
+
+{% for i in range(0, 3) -%}
 - Jinja test {{ i }}
 {% endfor %}
-{% endraw %}
+
+## Conditional
+
+Only show text when a condition is true:
+
+```jinja
+{% raw %}{% if 2 > 1 %}Two is greater than one{% endif %}{% endraw %}
 ```
 
-When the page is built the loop outputs items numbered 0–2.
+Output:
 
-Example output:
+{% if 2 > 1 %}Two is greater than one{% endif %}
 
-{% for i in range(0, 3): -%}
-- Jinja test {{ i }}
-{% endfor %}
+## Filters
+
+Filters transform values. This uses the built-in `upper` filter:
+
+```jinja
+{% raw %}{{ "press" | upper }}{% endraw %}
+```
+
+Output:
+
+{{ "press" | upper }}
+
+Custom filters work the same way. The `link` filter turns metadata into an anchor tag:
+
+```jinja
+{% raw %}{{ {"citation": "Quickstart", "url": "/quickstart.html"} | link }}{% endraw %}
+```
+
+Output:
+
+{{ {"citation": "Quickstart", "url": "/quickstart.html"} | link }}

--- a/src/examples/link-filters.md
+++ b/src/examples/link-filters.md
@@ -5,22 +5,68 @@ id: link-filters
 citation: link filters
 ---
 
-Press provides custom Jinja filters for formatting links. Each filter accepts a metadata dictionary with at least `citation` and `url`.
+Press provides custom Jinja filters for formatting links. Each example
+shows the template followed by its rendered result. Filters accept either a
+metadata ID string or a dictionary with at least `citation` and `url`.
 
 ## linktitle
-{{"quickstart"|linktitle}}
+
+```jinja
+{% raw %}{{ "quickstart" | linktitle }}{% endraw %}
+```
+
+Output:
+
+{{ "quickstart" | linktitle }}
 
 ## linktitle with anchor
+
+```jinja
+{% raw %}{{ {"citation": "home", "url": "/"} | linktitle(anchor="#example") }}{% endraw %}
+```
+
+Output:
+
 {{ {"citation": "home", "url": "/"} | linktitle(anchor="#example") }}
 
 ## linkcap
-{{"quickstart"|linkcap}}
+
+```jinja
+{% raw %}{{ "quickstart" | linkcap }}{% endraw %}
+```
+
+Output:
+
+{{ "quickstart" | linkcap }}
 
 ## linkicon
+
+```jinja
+{% raw %}{{ {"citation": "Quickstart", "url": "/quickstart.html", "icon": "👉"} | linkicon }}{% endraw %}
+```
+
+Output:
+
 {{ {"citation": "Quickstart", "url": "/quickstart.html", "icon": "👉"} | linkicon }}
 
 ## link_icon_title
+
+```jinja
+{% raw %}{{ {"citation": "Quickstart", "url": "/quickstart.html", "icon": "👉"} | link_icon_title }}{% endraw %}
+```
+
+Output:
+
 {{ {"citation": "Quickstart", "url": "/quickstart.html", "icon": "👉"} | link_icon_title }}
 
 ## link
-{{"quickstart"|link}}
+
+The `link` filter combines all the others and is the preferred option:
+
+```jinja
+{% raw %}{{ "quickstart" | link }}{% endraw %}
+```
+
+Output:
+
+{{ "quickstart" | link }}


### PR DESCRIPTION
## Summary
- Rewrite Jinja example page with step-by-step tutorial covering variables, loops, conditionals, and filters
- Expand link filter examples with rendered output for each custom filter
- Document usage of `get_desc` filter in Jinja reference

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6897c8fe53108321a058cc4b2fd21dc3