### PR TITLE
refactor: deprecate name metadata

### DIFF
--- a/app/shell/py/pie/pie/build_index.py
+++ b/app/shell/py/pie/pie/build_index.py
@@ -108,9 +108,15 @@ def parse_yaml_metadata(filepath: str) -> Optional[Dict[str, Any]]:
         if "url" not in metadata:
             metadata["url"] = get_url(filepath)
         if "citation" not in metadata:
-            # Intentionally use indexing so we get an exception here.
-            # The name field must exist.
-            metadata["citation"] = metadata["name"].lower()
+            title = metadata.get("title")
+            if title:
+                metadata["citation"] = title.lower()
+            elif "name" in metadata:
+                logger.warning(
+                    "'name' field is deprecated; use 'title' instead",
+                    filename=filepath,
+                )
+                metadata["citation"] = metadata["name"].lower()
         if "id" not in metadata:
             base, _ = os.path.splitext(filepath)
             metadata["id"] = base.split(os.sep)[-1]

--- a/app/shell/py/pie/pie/create/post.py
+++ b/app/shell/py/pie/pie/create/post.py
@@ -38,7 +38,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     yml_path = base.with_suffix(".yml")
 
     md_path.touch()
-    metadata = {"author": "", "pubdate": get_pubdate(), "title": "", "name": base.name}
+    metadata = {
+        "author": "",
+        "pubdate": get_pubdate(),
+        "title": "",
+    }
     write_yaml(metadata, str(yml_path))
     
     logger.info("Created post", md=str(md_path), yml=str(yml_path))

--- a/app/shell/py/pie/pie/create/templates/index.yml.jinja
+++ b/app/shell/py/pie/pie/create/templates/index.yml.jinja
@@ -1,3 +1,2 @@
 title: Home
-name: Home
 

--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -150,12 +150,12 @@ def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
 
     Example
     -------
-    >>> (tmp / 'post.md').write_text('---\nname: Post\n---\n')
+    >>> (tmp / 'post.md').write_text('---\ntitle: Draft\n---\n')
     17
     >>> (tmp / 'post.yml').write_text('title: Example')
     17
     >>> load_metadata_pair(tmp / 'post.yml')
-    {'name': 'Post', 'title': 'Example', 'id': 'post', 'path': ['post.yml', 'post.md']}
+    {'title': 'Example', 'id': 'post', 'path': ['post.yml', 'post.md']}
     """
 
     base = path.with_suffix("")

--- a/app/shell/py/pie/pie/update/remove_name.py
+++ b/app/shell/py/pie/pie/update/remove_name.py
@@ -1,0 +1,120 @@
+"""Remove deprecated ``name`` fields from metadata files.
+
+This script scans a directory for Markdown and YAML files and removes the
+top‑level ``name`` field from each file's metadata. It is intended as a
+one‑time cleanup tool while deprecating the ``name`` field in favour of
+``title``/``citation``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Sequence, Tuple
+
+__all__ = ["main", "remove_name_fields"]
+
+
+def remove_name_from_yaml(path: Path) -> tuple[bool, str | None]:
+    """Remove ``name`` from a YAML file.
+
+    Returns ``(changed, value)`` where ``value`` is the removed field's value
+    if a change occurred.
+    """
+
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    new_lines = []
+    removed: str | None = None
+    for line in lines:
+        if line.startswith("name:"):
+            removed = line.split(":", 1)[1].strip()
+            continue
+        new_lines.append(line)
+    if removed is not None:
+        path.write_text("".join(new_lines), encoding="utf-8")
+        return True, removed
+    return False, None
+
+
+def remove_name_from_markdown(path: Path) -> tuple[bool, str | None]:
+    """Remove ``name`` from Markdown front matter."""
+
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    if not lines or not lines[0].startswith("---"):
+        return False, None
+    try:
+        end = next(i for i, line in enumerate(lines[1:], start=1) if line.startswith("---"))
+    except StopIteration:
+        return False, None
+    new_lines = lines[:1]
+    removed: str | None = None
+    for line in lines[1:end]:
+        if line.startswith("name:"):
+            removed = line.split(":", 1)[1].strip()
+            continue
+        new_lines.append(line)
+    new_lines.extend(lines[end:])
+    if removed is not None:
+        path.write_text("".join(new_lines), encoding="utf-8")
+        return True, removed
+    return False, None
+
+
+def remove_name_fields(paths: Iterable[Path]) -> tuple[list[str], int]:
+    """Remove ``name`` from all *paths*.
+
+    Returns a tuple ``(messages, checked)`` with log messages for each
+    modified file and the number of files examined.
+    """
+
+    changes: list[str] = []
+    checked = 0
+    for path in paths:
+        if path.suffix in {".yml", ".yaml"}:
+            checked += 1
+            changed, val = remove_name_from_yaml(path)
+        elif path.suffix == ".md":
+            checked += 1
+            changed, val = remove_name_from_markdown(path)
+        else:
+            continue
+        if changed and val is not None:
+            changes.append(f"{path}: {val}")
+    return changes, checked
+
+
+def walk_files(root: Path) -> Iterable[Path]:
+    """Yield metadata files under *root*."""
+
+    for path in root.rglob("*"):
+        if path.suffix.lower() in {".md", ".yml", ".yaml"} and path.is_file():
+            yield path
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Remove deprecated 'name' fields from metadata files",
+    )
+    parser.add_argument(
+        "root",
+        nargs="?",
+        default="src",
+        help="Root directory to scan (default: src)",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    root = Path(args.root)
+    changes, checked = remove_name_fields(walk_files(root))
+    for msg in changes:
+        print(msg)
+    print(f"{checked} {'file' if checked == 1 else 'files'} checked")
+    print(f"{len(changes)} {'file' if len(changes) == 1 else 'files'} changed")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())
+

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -21,6 +21,7 @@ setup(
             'update-index=pie.update.index:main',
             'update-pubdate=pie.update.pubdate:main',
             'update-author=pie.update.author:main',
+            'remove-name=pie.update.remove_name:main',
             'picasso=pie.build.picasso:main',
             'render-jinja-template=pie.render.jinja:main',
             'render-study-json=pie.render_study_json:main',

--- a/app/shell/py/pie/tests/test_build_index.py
+++ b/app/shell/py/pie/tests/test_build_index.py
@@ -44,16 +44,16 @@ def test_process_markdown_parses_frontmatter(tmp_path):
 
 
 def test_parse_yaml_metadata_generates_fields(tmp_path):
-    """YAML {'name': 'Foo'} -> metadata with url/id/citation."""
+    """YAML {'title': 'Foo'} -> metadata with url/id/citation."""
     yml = tmp_path / "src" / "item.yml"
     yml.parent.mkdir(parents=True)
-    yml.write_text('{"name": "Foo"}')
+    yml.write_text('{"title": "Foo"}')
     os.chdir(tmp_path)
     try:
         data = build_index.parse_yaml_metadata("src/item.yml")
     finally:
         os.chdir("/tmp")
-    assert data["name"] == "Foo"
+    assert data["title"] == "Foo"
     assert data["url"] == "/item.html"
     assert data["citation"] == "foo"
     assert data["id"] == "item"
@@ -73,7 +73,7 @@ def test_build_index_handles_multiple_extensions(tmp_path):
     md = src / "doc.md"
     md.write_text("---\n{\"title\": \"T\", \"id\": \"doc\"}\n---\n")
     yml = src / "item.yml"
-    yml.write_text('{"name": "Foo"}')
+    yml.write_text('{"title": "Foo"}')
 
     os.chdir(tmp_path)
     try:
@@ -91,7 +91,7 @@ def test_main_writes_log_file(tmp_path):
     md = src / "doc.md"
     md.write_text("---\n{\"title\": \"T\", \"id\": \"doc\"}\n---\n")
     yml = src / "item.yml"
-    yml.write_text('{"name": "Foo"}')
+    yml.write_text('{"title": "Foo"}')
     out = tmp_path / "index.json"
     log = tmp_path / "build.log"
 

--- a/app/shell/py/pie/tests/test_common.py
+++ b/app/shell/py/pie/tests/test_common.py
@@ -49,7 +49,7 @@ def test_update_files_updates_all_related(tmp_path: Path, monkeypatch: object) -
     md = src / "doc.md"
     md.write_text("---\ntitle: T\nauthor: Old\n---\n", encoding="utf-8")
     yml = src / "doc.yml"
-    yml.write_text("name: T\ntitle: T\nauthor: Old\n", encoding="utf-8")
+    yml.write_text("title: T\nauthor: Old\n", encoding="utf-8")
 
     monkeypatch.chdir(tmp_path)
     messages, checked = common.update_files([Path("src/doc.md")], "author", "New")

--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -47,7 +47,7 @@ def test_create_scaffolding(tmp_path: Path) -> None:
     index_yml = target / "src/index.yml"
     assert index_yml.exists()
     yml_text = index_yml.read_text(encoding="utf-8")
-    assert "name:" in yml_text
+    assert "title:" in yml_text
 
     readme = target / "README.md"
     assert readme.exists(), "README should be created"

--- a/app/shell/py/pie/tests/test_create_post.py
+++ b/app/shell/py/pie/tests/test_create_post.py
@@ -19,6 +19,6 @@ def test_create_post_creates_files(tmp_path: Path) -> None:
     assert yml_file.exists(), "YAML file should be created"
 
     data = yaml.safe_load(yml_file.read_text(encoding="utf-8"))
-    assert set(data) == {"author", "pubdate", "title", "name"}
-    assert data["name"] == "my-post"
+    assert set(data) == {"author", "pubdate", "title"}
+    assert "name" not in data
     assert data["pubdate"] == get_pubdate()

--- a/app/shell/py/pie/tests/test_gen_markdown_index.py
+++ b/app/shell/py/pie/tests/test_gen_markdown_index.py
@@ -52,7 +52,7 @@ def test_show_property(tmp_path, monkeypatch):
 
 def test_missing_id_uses_filename(tmp_path, monkeypatch):
     """Files without an explicit id derive it from the filename."""
-    (tmp_path / "foo.yml").write_text("name: Foo\ntitle: Foo\n")
+    (tmp_path / "foo.yml").write_text("title: Foo\n")
 
     def fake_meta(filepath: str, keypath: str):
         data = yaml.safe_load(Path(filepath).read_text()) or {}

--- a/app/shell/py/pie/tests/test_process_yaml.py
+++ b/app/shell/py/pie/tests/test_process_yaml.py
@@ -8,7 +8,7 @@ def test_main_generates_metadata(tmp_path):
     src = tmp_path / "src"
     src.mkdir()
     inp = src / "item.yml"
-    inp.write_text("{\"name\": \"Foo\"}")
+    inp.write_text("{\"title\": \"Foo\"}")
     out = tmp_path / "out.yml"
     os.chdir(tmp_path)
     try:
@@ -17,7 +17,7 @@ def test_main_generates_metadata(tmp_path):
         os.chdir("/tmp")
 
     data = yaml.safe_load(out.read_text())
-    assert data["name"] == "Foo"
+    assert data["title"] == "Foo"
     assert data["url"] == "/item.html"
     assert data["citation"] == "foo"
     assert data["id"] == "item"
@@ -28,7 +28,7 @@ def test_main_writes_log_file(tmp_path):
     src = tmp_path / "src"
     src.mkdir()
     inp = src / "doc.yml"
-    inp.write_text("{\"name\": \"Foo\"}")
+    inp.write_text("{\"title\": \"Foo\"}")
     out = tmp_path / "out.yml"
     log = tmp_path / "proc.log"
     os.chdir(tmp_path)

--- a/app/shell/py/pie/tests/test_remove_name.py
+++ b/app/shell/py/pie/tests/test_remove_name.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pie.update import remove_name
+
+
+def test_removes_name_fields(tmp_path: Path, capsys) -> None:
+    """The remove-name script strips name fields from metadata files."""
+    src = tmp_path / "src"
+    src.mkdir()
+
+    yml = src / "doc.yml"
+    yml.write_text("title: Test\nname: Old\n", encoding="utf-8")
+
+    md = src / "doc.md"
+    md.write_text("---\nname: Old\n---\nbody\n", encoding="utf-8")
+
+    remove_name.main([str(src)])
+
+    assert "name:" not in yml.read_text(encoding="utf-8")
+    assert "name:" not in md.read_text(encoding="utf-8")
+
+    out_lines = capsys.readouterr().out.strip().splitlines()
+    assert f"{yml}: Old" in out_lines
+    assert f"{md}: Old" in out_lines
+    assert "2 files checked" in out_lines
+    assert "2 files changed" in out_lines
+

--- a/app/shell/py/pie/tests/test_render_study_json.py
+++ b/app/shell/py/pie/tests/test_render_study_json.py
@@ -6,20 +6,20 @@ from pie import render_study_json
 
 def test_render_study_basic():
     """Template question -> rendered with index data."""
-    index = {"item": {"name": "Foo"}}
+    index = {"item": {"title": "Foo"}}
     questions = [
-        {"q": "Name {{item['name']}}", "c": ["A", "B"], "a": [0, "Because {{item['name']}}"]}
+        {"q": "Title {{item['title']}}", "c": ["A", "B"], "a": [0, "Because {{item['title']}}"]}
     ]
     rendered = render_study_json.render_study(index, questions)
-    assert rendered == [{"q": "Name Foo", "c": ["A", "B"], "a": [0, "Because Foo"]}]
+    assert rendered == [{"q": "Title Foo", "c": ["A", "B"], "a": [0, "Because Foo"]}]
 
 
 def test_main_outputs_stdout(tmp_path, capsys):
     """CLI prints rendered study JSON."""
     index_file = tmp_path / "index.json"
     study_file = tmp_path / "study.json"
-    index = {"val": {"name": "Bar"}}
-    study = [{"q": "{{val['name']}}?", "c": ["X"], "a": [0, "{{val['name']}}"]}]
+    index = {"val": {"title": "Bar"}}
+    study = [{"q": "{{val['title']}}?", "c": ["X"], "a": [0, "{{val['title']}}"]}]
     index_file.write_text(json.dumps(index))
     study_file.write_text(json.dumps(study))
 
@@ -33,8 +33,8 @@ def test_main_writes_file(tmp_path):
     index_file = tmp_path / "index.json"
     study_file = tmp_path / "study.json"
     out_file = tmp_path / "out.json"
-    index_file.write_text(json.dumps({"x": {"name": "Baz"}}))
-    study_file.write_text(json.dumps([{"q": "{{x['name']}}", "c": ["Y"], "a": [0, ""]}]))
+    index_file.write_text(json.dumps({"x": {"title": "Baz"}}))
+    study_file.write_text(json.dumps([{"q": "{{x['title']}}", "c": ["Y"], "a": [0, ""]}]))
 
     render_study_json.main([str(index_file), str(study_file), "-o", str(out_file)])
     data = json.loads(out_file.read_text())
@@ -46,8 +46,8 @@ def test_main_writes_log_file(tmp_path):
     index_file = tmp_path / "index.json"
     study_file = tmp_path / "study.json"
     log_file = tmp_path / "study.log"
-    index_file.write_text(json.dumps({"x": {"name": "Baz"}}))
-    study_file.write_text(json.dumps([{"q": "{{x['name']}}", "c": ["Y"], "a": [0, ""]}]))
+    index_file.write_text(json.dumps({"x": {"title": "Baz"}}))
+    study_file.write_text(json.dumps([{"q": "{{x['title']}}", "c": ["Y"], "a": [0, ""]}]))
 
     render_study_json.main([
         str(index_file),

--- a/app/shell/py/pie/tests/test_update_author.py
+++ b/app/shell/py/pie/tests/test_update_author.py
@@ -13,7 +13,7 @@ def test_updates_yaml_from_markdown_change(tmp_path: Path, monkeypatch, capsys) 
     md.write_text("---\ntitle: Test\n---\n", encoding="utf-8")
     yml = src / "doc.yml"
     yml.write_text(
-        "name: Test\ntitle: Test\nauthor: Jane Doe\n",
+        "title: Test\nauthor: Jane Doe\n",
         encoding="utf-8",
     )
 

--- a/app/shell/py/pie/tests/test_update_index.py
+++ b/app/shell/py/pie/tests/test_update_index.py
@@ -62,8 +62,8 @@ def test_main_directory_processes_yamls(tmp_path, monkeypatch):
     """Directory of yml -> Redis entries for each."""
     src = tmp_path / "src"
     src.mkdir()
-    (src / "a.yml").write_text('{"name": "Foo"}')
-    (src / "b.yml").write_text('{"name": "Bar"}')
+    (src / "a.yml").write_text('{"title": "Foo"}')
+    (src / "b.yml").write_text('{"title": "Bar"}')
 
     fake = fakeredis.FakeRedis(decode_responses=True)
     monkeypatch.setattr(update_index.redis, "Redis", lambda *a, **kw: fake)
@@ -74,9 +74,9 @@ def test_main_directory_processes_yamls(tmp_path, monkeypatch):
     finally:
         os.chdir("/tmp")
 
-    assert fake.get("a.name") == "Foo"
+    assert fake.get("a.title") == "Foo"
     assert fake.get("a.url") == "/a.html"
-    assert fake.get("b.name") == "Bar"
+    assert fake.get("b.title") == "Bar"
     assert fake.get("b.url") == "/b.html"
 
 
@@ -85,7 +85,7 @@ def test_main_single_yaml_file(tmp_path, monkeypatch):
     src = tmp_path / "src"
     src.mkdir()
     yml = src / "item.yml"
-    yml.write_text('{"name": "Foo"}')
+    yml.write_text('{"title": "Foo"}')
 
     fake = fakeredis.FakeRedis(decode_responses=True)
     monkeypatch.setattr(update_index.redis, "Redis", lambda *a, **kw: fake)
@@ -96,7 +96,7 @@ def test_main_single_yaml_file(tmp_path, monkeypatch):
     finally:
         os.chdir("/tmp")
 
-    assert fake.get("item.name") == "Foo"
+    assert fake.get("item.title") == "Foo"
     assert fake.get("item.url") == "/item.html"
 
 
@@ -107,7 +107,7 @@ def test_main_combines_md_and_yaml(tmp_path, monkeypatch):
     md = src / "doc.md"
     md.write_text("---\n{\"title\": \"Md\", \"foo\": \"bar\"}\n---\n")
     yml = src / "doc.yml"
-    yml.write_text('{"id": "doc", "title": "Yaml", "baz": "qux", "name": "D"}')
+    yml.write_text('{"id": "doc", "title": "Yaml", "baz": "qux"}')
 
     fake = fakeredis.FakeRedis(decode_responses=True)
     monkeypatch.setattr(update_index.redis, "Redis", lambda *a, **kw: fake)
@@ -129,7 +129,7 @@ def test_directory_pair_processed_once(tmp_path, monkeypatch):
     src = tmp_path / "src"
     src.mkdir()
     (src / "doc.md").write_text("---\n{\"title\": \"Md\"}\n---\n")
-    (src / "doc.yml").write_text('{"title": "Yaml", "name": "D"}')
+    (src / "doc.yml").write_text('{"title": "Yaml"}')
 
     fake = fakeredis.FakeRedis(decode_responses=True)
     monkeypatch.setattr(update_index.redis, "Redis", lambda *a, **kw: fake)
@@ -152,7 +152,7 @@ def test_main_inserts_path(tmp_path, monkeypatch):
     md = src / "doc.md"
     md.write_text("---\n{\"title\": \"Md\"}\n---\n")
     yml = src / "doc.yml"
-    yml.write_text('{"title": "Yaml", "name": "Y"}')
+    yml.write_text('{"title": "Yaml"}')
 
     fake = fakeredis.FakeRedis(decode_responses=True)
     monkeypatch.setattr(update_index.redis, "Redis", lambda *a, **kw: fake)
@@ -173,7 +173,7 @@ def test_main_adds_path_id_mapping(tmp_path, monkeypatch):
     md = src / "doc.md"
     md.write_text("---\n{\"title\": \"Md\"}\n---\n")
     yml = src / "doc.yml"
-    yml.write_text('{"title": "Yaml", "name": "Y"}')
+    yml.write_text('{"title": "Yaml"}')
 
     fake = fakeredis.FakeRedis(decode_responses=True)
     monkeypatch.setattr(update_index.redis, "Redis", lambda *a, **kw: fake)
@@ -211,8 +211,8 @@ def test_directory_processed_in_parallel(tmp_path, monkeypatch):
     """Concurrent processing still populates Redis."""
     src = tmp_path / "src"
     src.mkdir()
-    (src / "a.yml").write_text('{"name": "A"}')
-    (src / "b.yml").write_text('{"name": "B"}')
+    (src / "a.yml").write_text('{"title": "A"}')
+    (src / "b.yml").write_text('{"title": "B"}')
 
     fake = fakeredis.FakeRedis(decode_responses=True)
     monkeypatch.setattr(update_index.redis, "Redis", lambda *a, **kw: fake)
@@ -222,7 +222,7 @@ def test_directory_processed_in_parallel(tmp_path, monkeypatch):
     def fake_loader(path):
         barrier.wait(timeout=1)
         base = path.with_suffix("")
-        return {"id": base.name, "name": base.name}
+        return {"id": base.name, "title": base.name}
 
     monkeypatch.setattr(update_index, "load_metadata_pair", fake_loader)
 
@@ -232,16 +232,16 @@ def test_directory_processed_in_parallel(tmp_path, monkeypatch):
     finally:
         os.chdir("/tmp")
 
-    assert fake.get("a.name") == "a"
-    assert fake.get("b.name") == "b"
+    assert fake.get("a.title") == "a"
+    assert fake.get("b.title") == "b"
 
 
 def test_logs_execution_time_and_count(tmp_path, monkeypatch):
     """Logging shows file count and elapsed time."""
     src = tmp_path / "src"
     src.mkdir()
-    (src / "a.yml").write_text('{"name": "A"}')
-    (src / "b.yml").write_text('{"name": "B"}')
+    (src / "a.yml").write_text('{"title": "A"}')
+    (src / "b.yml").write_text('{"title": "B"}')
 
     fake = fakeredis.FakeRedis(decode_responses=True)
     monkeypatch.setattr(update_index.redis, "Redis", lambda *a, **kw: fake)

--- a/app/shell/py/pie/tests/test_update_pubdate.py
+++ b/app/shell/py/pie/tests/test_update_pubdate.py
@@ -14,7 +14,7 @@ def test_updates_yaml_from_markdown_change(tmp_path: Path, monkeypatch, capsys) 
     md.write_text("---\ntitle: Test\n---\n", encoding="utf-8")
     yml = src / "doc.yml"
     yml.write_text(
-        "name: Test\ntitle: Test\npubdate: Jan 01, 2000\n",
+        "title: Test\npubdate: Jan 01, 2000\n",
         encoding="utf-8",
     )
 

--- a/docs/reference/link-metadata.md
+++ b/docs/reference/link-metadata.md
@@ -4,12 +4,12 @@ This document explains how to describe external links using YAML files and how t
 
 ## Creating a Metadata File
 
-Place YAML files under `src/links/`. Each file defines at least a `name` and a `url` for the destination. Any additional fields become part of the build index. When the file does not specify an `id`, it is derived from the filename.
+Place YAML files under `src/links/`. Each file defines at least a `citation` and a `url` for the destination. Any additional fields become part of the build index. When the file does not specify an `id`, it is derived from the filename.
 
 Example `src/links/press_io_home.yml`:
 
 ```yaml
-name: press.io home
+citation: press.io home
 url: https://press.io
 link:
   tracking: false

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -4,11 +4,10 @@ This document lists the common metadata keys used by Press and explains how miss
 
 ## Required
 
-- `name` – Display name used in navigation and indexes.
+- `title` – Heading shown in the rendered page.
 
 ## Optional Fields
 
-- `title` – Heading shown in the rendered page.
 - `author` – Author string passed to Pandoc.
 - `description` – Short summary used for meta tags.
 - `og_image` – OpenGraph image path.
@@ -16,6 +15,7 @@ This document lists the common metadata keys used by Press and explains how miss
 - `icon` – Emoji or icon displayed by link filters.
 - `link.tracking` – Boolean controlling external link behaviour.
 - `link.class` – CSS class for rendered links.
+- `name` – **Deprecated.** Former display name used in navigation and indexes.
 
 ## Auto‑Generated Values
 
@@ -24,7 +24,7 @@ During indexing, `build_index.py` fills in several fields when they are missing:
 | Field      | Default value                                  |
 | ---------- | ---------------------------------------------- |
 | `id`       | Filename without the extension                 |
-| `citation` | Lowercase form of the `name` value             |
+| `citation` | Lowercase form of the `title` value            |
 | `url`      | Derived from the source path (e.g. `src/foo.md` → `/foo.html`) |
 
 The `citation` value is used as the anchor text when other pages link to this document using Jinja filters such as `linktitle`.

--- a/src/examples/chicago-citations.md
+++ b/src/examples/chicago-citations.md
@@ -18,7 +18,7 @@ Example metadata file:
 
 ```yaml
 # hull.yml
-name: Options, Futures, and Other Derivatives
+title: Options, Futures, and Other Derivatives
 citation:
   author: Hull
   year: 2016
@@ -30,7 +30,7 @@ Add as many sources as you need.  A second entry might look like:
 
 ```yaml
 # doe.yml
-name: Example Book
+title: Example Book
 citation:
   author: Doe
   year: 2019

--- a/src/examples/doe.yml
+++ b/src/examples/doe.yml
@@ -1,4 +1,3 @@
-name: Example Book
 title: Example Book
 citation:
   author: Doe

--- a/src/examples/hull.yml
+++ b/src/examples/hull.yml
@@ -1,4 +1,3 @@
-name: Options, Futures, and Other Derivatives
 title: Options, Futures, and Other Derivatives
 citation:
   author: Hull

--- a/src/examples/index.yml
+++ b/src/examples/index.yml
@@ -1,5 +1,4 @@
 id: examples
-name: examples
 title: Examples
 gen-markdown-index:
   link: false

--- a/src/examples/indextree/index.yml
+++ b/src/examples/indextree/index.yml
@@ -1,3 +1,2 @@
 title: IndexTree Demo
-name: IndexTree Demo
 id: indextree-demo

--- a/src/gen-markdown-index/d1/index.yml
+++ b/src/gen-markdown-index/d1/index.yml
@@ -1,3 +1,2 @@
 title: d1
-name: d1
 id: d1

--- a/src/gen-markdown-index/f0.yml
+++ b/src/gen-markdown-index/f0.yml
@@ -1,3 +1,2 @@
 title: f0
-name: f0
 id: f0

--- a/src/gen-markdown-index/index.yml
+++ b/src/gen-markdown-index/index.yml
@@ -1,5 +1,4 @@
 title: gen-markdown-index
-name: gen-markdown-index
 id: dist_gen_markdown_index
 gen-markdown-index:
   link: false

--- a/src/include-filter/index.yml
+++ b/src/include-filter/index.yml
@@ -1,3 +1,2 @@
-name: include-filter
 title: include-filter
 id: dist_include_filter

--- a/src/index.yml
+++ b/src/index.yml
@@ -1,5 +1,4 @@
 title: Home
-name: Home
 author: Brian Lee
 description: Example home page
 og_image: /img/home.png

--- a/src/links/press_io_home.yml
+++ b/src/links/press_io_home.yml
@@ -1,4 +1,4 @@
-name: press.io home
+citation: press.io home
 title: press.io home
 url: https://press.io
 link:

--- a/src/quiz/index.yml
+++ b/src/quiz/index.yml
@@ -1,3 +1,2 @@
 title: Quiz
-name: Quiz
 id: quiz


### PR DESCRIPTION
## Summary
- purge deprecated `name` from all source metadata
- add `remove-name` script and register it as a console command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68987b5e08b08321a97ef2ef28074436