### PR TITLE
feat(indextree): add indextree-json wrapper

### DIFF
--- a/app/indextree/bin/indextree-json
+++ b/app/indextree/bin/indextree-json
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 # shellcheck source=app/shell/sh/lib.sh
 source "$ROOT/app/shell/sh/lib.sh"
-
-press_bash "$@"
+cd "$ROOT"
+press_bash -c 'indextree-json "$@"' _ "$@"

--- a/app/shell/sh/lib.sh
+++ b/app/shell/sh/lib.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+press_bash() {
+  docker compose run \
+    --rm --entrypoint bash -u "$(id -u)" \
+    shell "$@"
+}
+


### PR DESCRIPTION
## Summary
- add indextree-json helper script for indextree app
- extract shared shell library and refactor wrappers

## Testing
- `shellcheck app/shell/sh/lib.sh && shellcheck -x bin/bash app/indextree/bin/indextree-json`
- `bin/make test` *(fails: docker: command not found)*
- `cd app/indextree && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68987ebf7a7c832192e8746176474462