### PR TITLE
Consolidate metadata readers into metadata module

### DIFF
--- a/app/shell/py/pie/pie/process_yaml.py
+++ b/app/shell/py/pie/pie/process_yaml.py
@@ -8,7 +8,7 @@ from typing import Iterable
 
 from pie.logging import logger, add_log_argument, setup_file_logger
 from pie.utils import write_yaml
-from pie import build_index
+from pie.metadata import read_from_yaml
 
 
 def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
@@ -28,7 +28,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     setup_file_logger(args.log)
 
     try:
-        metadata = build_index.parse_yaml_metadata(args.input)
+        metadata = read_from_yaml(args.input)
     except Exception as exc:  # pragma: no cover - pass through message
         logger.error("Failed to process YAML", filename=args.input)
         raise SystemExit(1) from exc

--- a/app/shell/py/pie/tests/test_build_index.py
+++ b/app/shell/py/pie/tests/test_build_index.py
@@ -2,61 +2,7 @@ import os
 import json
 from pathlib import Path
 import pytest
-
 from pie import build_index
-
-
-def test_get_url_from_src_md(tmp_path):
-    """'src/foo.md' -> '/foo.html'."""
-    path = tmp_path / "src" / "foo.md"
-    path.parent.mkdir(parents=True)
-    path.write_text("")
-    os.chdir(tmp_path)
-    try:
-        assert build_index.get_url("src/foo.md") == "/foo.html"
-    finally:
-        os.chdir("/tmp")
-
-
-def test_get_url_invalid_raises(tmp_path):
-    """Unknown path raises an error."""
-    bad = tmp_path / "foo.md"
-    bad.write_text("")
-    os.chdir(tmp_path)
-    try:
-        with pytest.raises(Exception):
-            build_index.get_url("foo.md")
-    finally:
-        os.chdir("/tmp")
-
-
-def test_process_markdown_parses_frontmatter(tmp_path):
-    """Frontmatter {'title': 'T'} -> {'title': 'T', 'url': '/doc.html'}."""
-    md = tmp_path / "src" / "doc.md"
-    md.parent.mkdir(parents=True)
-    md.write_text("---\n{\"title\": \"T\"}\n---\nbody")
-    os.chdir(tmp_path)
-    try:
-        data = build_index.process_markdown("src/doc.md")
-    finally:
-        os.chdir("/tmp")
-    assert data == {"title": "T", "url": "/doc.html"}
-
-
-def test_parse_yaml_metadata_generates_fields(tmp_path):
-    """YAML {'title': 'Foo'} -> metadata with url/id/citation."""
-    yml = tmp_path / "src" / "item.yml"
-    yml.parent.mkdir(parents=True)
-    yml.write_text('{"title": "Foo"}')
-    os.chdir(tmp_path)
-    try:
-        data = build_index.parse_yaml_metadata("src/item.yml")
-    finally:
-        os.chdir("/tmp")
-    assert data["title"] == "Foo"
-    assert data["url"] == "/item.html"
-    assert data["citation"] == "foo"
-    assert data["id"] == "item"
 
 
 def test_validate_and_insert_duplicate(tmp_path):

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -1,0 +1,61 @@
+import os
+import pytest
+
+from pie import metadata
+
+
+def test_get_url_from_src_md(tmp_path):
+    """'src/foo.md' -> '/foo.html'."""
+    path = tmp_path / "src" / "foo.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("")
+    os.chdir(tmp_path)
+    try:
+        assert metadata.get_url("src/foo.md") == "/foo.html"
+    finally:
+        os.chdir("/tmp")
+
+
+def test_get_url_invalid_raises(tmp_path):
+    """Unknown path raises an error."""
+    bad = tmp_path / "foo.md"
+    bad.write_text("")
+    os.chdir(tmp_path)
+    try:
+        with pytest.raises(Exception):
+            metadata.get_url("foo.md")
+    finally:
+        os.chdir("/tmp")
+
+
+def test_read_from_markdown_generates_fields(tmp_path):
+    """Frontmatter {'title': 'T'} -> url/id/citation added."""
+    md = tmp_path / "src" / "doc.md"
+    md.parent.mkdir(parents=True)
+    md.write_text("---\n{\"title\": \"T\"}\n---\nbody")
+    os.chdir(tmp_path)
+    try:
+        data = metadata.read_from_markdown("src/doc.md")
+    finally:
+        os.chdir("/tmp")
+    assert data["title"] == "T"
+    assert data["url"] == "/doc.html"
+    assert data["citation"] == "t"
+    assert data["id"] == "doc"
+
+
+def test_read_from_yaml_generates_fields(tmp_path):
+    """YAML {'title': 'Foo'} -> metadata with url/id/citation."""
+    yml = tmp_path / "src" / "item.yml"
+    yml.parent.mkdir(parents=True)
+    yml.write_text('{"title": "Foo"}')
+    os.chdir(tmp_path)
+    try:
+        data = metadata.read_from_yaml("src/item.yml")
+    finally:
+        os.chdir("/tmp")
+    assert data["title"] == "Foo"
+    assert data["url"] == "/item.html"
+    assert data["citation"] == "foo"
+    assert data["id"] == "item"
+

--- a/docs/reference/link-metadata.md
+++ b/docs/reference/link-metadata.md
@@ -42,7 +42,7 @@ link:
 
 ## How IDs Are Generated
 
-During indexing, `parse_yaml_metadata` from `pie.build_index` loads the file and assigns an `id` if it is absent:
+During indexing, `read_from_yaml` from `pie.metadata` loads the file and assigns an `id` if it is absent:
 
 ```
 base, _ = os.path.splitext(filepath)

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -19,7 +19,7 @@ This document lists the common metadata keys used by Press and explains how miss
 
 ## Auto‑Generated Values
 
-During indexing, `build_index.py` fills in several fields when they are missing:
+During indexing, `read_from_yaml` in `pie.metadata` fills in several fields when they are missing:
 
 | Field      | Default value                                  |
 | ---------- | ---------------------------------------------- |
@@ -28,7 +28,7 @@ During indexing, `build_index.py` fills in several fields when they are missing:
 | `url`      | Derived from the source path (e.g. `src/foo.md` → `/foo.html`) |
 
 The `citation` value is used as the anchor text when other pages link to this document using Jinja globals such as `linktitle`.
-The helper that assigns these defaults lives in `parse_yaml_metadata` within `pie.build_index`.
+The helper that assigns these defaults lives in `read_from_yaml` within `pie.metadata`.
 
 For bibliographic references the `citation` field may instead be a mapping with
 `author`, `year`, and `page` keys.  This structure is consumed by the `cite`


### PR DESCRIPTION
## Summary
- centralize URL, citation, and ID defaults via `generate_missing_metadata`
- move metadata helper tests into `test_metadata.py` and expand coverage
- streamline `load_metadata_pair` by removing redundant ID generation

## Testing
- `pytest` *(fails: app/shell/py/pie/tests/test_update_index.py::test_directory_pair_processed_once - assert 2 == 1)*
- `pytest app/shell/py/pie/tests/test_metadata.py app/shell/py/pie/tests/test_build_index.py`


------
https://chatgpt.com/codex/tasks/task_e_689889770484832180e2aba2021cedcc