### PR TITLE
docs: add guide for creating new site

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -5,6 +5,7 @@ concepts and data formats, see the
 [reference documentation](../reference/README.md).
 
 ## Build process
+- [create-site.md](create-site.md) – scaffold a new Press project.
 - [build-process.md](build-process.md) – overview of the build pipeline for new engineers.
 - [build-index.md](build-index.md) – generate a JSON index of document
   metadata. See the [metadata fields reference](../reference/metadata-fields.md).

--- a/docs/guides/create-site.md
+++ b/docs/guides/create-site.md
@@ -1,0 +1,27 @@
+# Creating a New Site
+
+This tutorial shows how to scaffold and run a new Press site.
+
+## Generate project scaffolding
+
+Run the helper script with the desired project name:
+
+```bash
+./bin/bash -c "create-site newsite"
+cd newsite
+git init
+```
+
+These commands generate the initial directory structure and initialize a Git repository for your site.
+
+## Build and start the development stack
+
+Define a handy alias to invoke the project's Makefile and then build and start services:
+
+```bash
+alias r='make -f redo.mk'
+r
+r up
+```
+
+The first `r` builds the site, while `r up` launches the development containers. Once complete, visit [http://localhost](http://localhost) to view the site.


### PR DESCRIPTION
## Summary
- document how to scaffold a new Press site and start the dev stack
- reference the new guide from the guides index

## Testing
- `make -f redo.mk pytest` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a6c05e9c88321bc6256671cc35aa2