### PR TITLE
Deprecate gen_markdown_index and add tests

### DIFF
--- a/app/shell/py/pie/pie/gen_markdown_index.py
+++ b/app/shell/py/pie/pie/gen_markdown_index.py
@@ -1,13 +1,23 @@
 #!/usr/bin/env python3
-"""Generate a Markdown index from YAML metadata files."""
+"""Generate a Markdown index from YAML metadata files.
+
+This module is deprecated and will be removed in a future release.
+"""
 
 from __future__ import annotations
 
 import argparse
+import warnings
 from pathlib import Path
 from typing import Iterator
 
 from pie.index_tree import walk, getopt_link, getopt_show
+
+warnings.warn(
+    "pie.gen_markdown_index is deprecated and will be removed in a future release",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 def generate(directory: Path, level: int = 0) -> Iterator[str]:


### PR DESCRIPTION
## Summary
- deprecate `gen_markdown_index` with a runtime warning
- add tests covering link-less entries, recursion, and main output

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `pytest app/shell/py/pie/tests/test_gen_markdown_index.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689a6cfb370883219df1a34a9cea9fba