### PR TITLE
Handle missing git in get_changed_files

### DIFF
--- a/app/shell/py/pie/pie/update/common.py
+++ b/app/shell/py/pie/pie/update/common.py
@@ -25,12 +25,19 @@ __all__ = [
 def get_changed_files() -> list[Path]:
     """Return paths of tracked files changed in git. Skip submodules by checking
     for directories."""
-    result = subprocess.run(
-        ["git", "status", "--short"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "status", "--short"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as err:
+        logger.warning("git executable not found", error=str(err))
+        return []
+    except subprocess.CalledProcessError as err:
+        logger.warning("git repository not initialised", error=str(err))
+        return []
     paths: list[Path] = []
     for line in result.stdout.splitlines():
         if not line or line.startswith("??"):


### PR DESCRIPTION
## Summary
- handle missing git executable and uninitialised repos in `get_changed_files`
- test warning behavior when git is unavailable or repo isn't initialised

## Testing
- `pytest`
- `pytest app/shell/py/pie/tests/test_common.py`


------
https://chatgpt.com/codex/tasks/task_e_689a6f9374e88321a7adcca77c564f52