### PR TITLE
refactor bin scripts to use shared shell helpers

### DIFF
--- a/app/shell/sh/lib.sh
+++ b/app/shell/sh/lib.sh
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
 
-press_bash() {
+press_run() {
   docker compose run \
-    --rm --entrypoint bash -u "$(id -u)" \
-    shell "$@"
+    --rm --entrypoint "$1" -u "$(id -u)" \
+    shell "${@:2}"
+}
+
+press_bash() {
+  press_run bash "$@"
+}
+
+press_make() {
+  press_run make -f /app/mk/build.mk "$@"
+}
+
+press_redis_cli() {
+  docker compose exec dragonfly redis-cli "$@"
 }
 

--- a/bin/make
+++ b/bin/make
@@ -17,8 +17,8 @@
 # generated files are owned by the invoking user. The container is
 # removed after completion.
 
-MAKE_CMD="docker compose run \
-  --rm --entrypoint make -u $(id -u) \
-  shell"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=app/shell/sh/lib.sh
+source "$ROOT/app/shell/sh/lib.sh"
 
-$MAKE_CMD -f /app/mk/build.mk "$@"
+press_make "$@"

--- a/bin/redis-cli
+++ b/bin/redis-cli
@@ -2,6 +2,9 @@
 
 # Run redis-cli inside the dragonfly service.
 # Any arguments provided are forwarded to redis-cli.
-CMD="docker compose exec dragonfly redis-cli"
 
-$CMD "$@"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=app/shell/sh/lib.sh
+source "$ROOT/app/shell/sh/lib.sh"
+
+press_redis_cli "$@"

--- a/bin/remake
+++ b/bin/remake
@@ -15,6 +15,9 @@
 # delegating to `make` so the build artifacts are regenerated
 # from scratch.
 
-bin=$(dirname "$0")
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=app/shell/sh/lib.sh
+source "$ROOT/app/shell/sh/lib.sh"
+
 rm -rf "$@"
-$bin/make "$@"
+press_make "$@"


### PR DESCRIPTION
## Summary
- add reusable `press_run`, `press_make`, and `press_redis_cli` helpers for container execution
- update `make`, `remake`, and `redis-cli` scripts to use shared helpers

## Testing
- `shellcheck app/shell/sh/lib.sh bin/make bin/redis-cli bin/remake`
- `bash -n app/shell/sh/lib.sh bin/make bin/redis-cli bin/remake`


------
https://chatgpt.com/codex/tasks/task_e_689a70abdce883219a4803ce1f1706a4