### PR TITLE
refactor: make root directory positional

### DIFF
--- a/app/shell/py/pie/pie/update/remove_name.py
+++ b/app/shell/py/pie/pie/update/remove_name.py
@@ -97,9 +97,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "root",
-        nargs="?",
-        default="src",
-        help="Root directory to scan (default: src)",
+        help="Root directory to scan",
     )
     return parser.parse_args(list(argv) if argv is not None else None)
 


### PR DESCRIPTION
## Summary
- make `remove-name` take its root directory as a positional argument

## Testing
- `pytest app/shell/py/pie/tests/update/test_remove_name.py -q`
- `pytest app/shell/py/pie/tests/test_build_index.py -q` *(fails: No module named 'flatten_dict')*


------
https://chatgpt.com/codex/tasks/task_e_689b5a919698832185114f9f69a1b4d4