### PR TITLE
Sort help output by target

### DIFF
--- a/redo.mk
+++ b/redo.mk
@@ -144,6 +144,7 @@ rmi: ## Remove Docker images matching press-*
 .PHONY: help
 help: ## List available tasks
 	@grep -E '^[a-zA-Z0-9_-]+:.*##' $(MAKEFILE_LIST) | \
+	sort | \
 	awk -F ':.*##' '{printf "%-10s %s\n", $$1, $$2}'
 
 .PHONY: buildx


### PR DESCRIPTION
## Summary
- sort help target in redo.mk so listed tasks are alphabetical

## Testing
- `make -f redo.mk help`


------
https://chatgpt.com/codex/tasks/task_e_689b67b4e4148321b59eefde3ba1d067