### PR TITLE
Extract shell target into script with optional user id

### DIFF
--- a/bin/shell
+++ b/bin/shell
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Description:
+#   Run the project's shell service via docker compose.
+#   Supports an optional `-u` flag to set the UID inside the container.
+#
+# Usage:
+#   bin/shell [-u [UID]] [-- COMMAND...]
+#
+# Options:
+#   -u [UID]  Run as the specified user ID. When UID is omitted,
+#             the current user's UID is used.
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [-u [UID]] [-- COMMAND...]" >&2
+  exit 1
+}
+
+uid_flag=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -u)
+      if [[ $# -gt 1 && "$2" != -* ]]; then
+        uid_flag=(-u "$2")
+        shift 2
+      else
+        uid_flag=(-u "$(id -u)")
+        shift 1
+      fi
+      ;;
+    -u*)
+      arg="${1#-u}"
+      if [[ -n "$arg" ]]; then
+        uid_flag=(-u "$arg")
+      else
+        uid_flag=(-u "$(id -u)")
+      fi
+      shift 1
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -* )
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+COMPOSE_FILE="docker-compose.yml"
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  COMPOSE_FILE="dist/docker-compose.yml"
+fi
+
+exec docker compose -f "$COMPOSE_FILE" run --rm --build "${uid_flag[@]}" shell "$@"

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -17,6 +17,7 @@ documents provide context for the task‑oriented
 - [update-index.md](update-index.md) – insert index values into Redis.
 - [update-pubdate.md](update-pubdate.md) – update the `pubdate` field for modified files.
 - [update-link-filters.md](update-link-filters.md) – convert legacy `link*` filters into globals.
+- [shell.md](shell.md) – run the project's shell service via docker compose.
 - [standalone-bin-scripts.md](standalone-bin-scripts.md) – rationale for self-contained helper scripts.
 
 For step‑by‑step workflows and tutorials, head back to the

--- a/docs/reference/shell.md
+++ b/docs/reference/shell.md
@@ -1,0 +1,11 @@
+# shell
+
+Run the project's shell service defined in docker-compose. If no command is specified, an interactive shell is launched.
+
+```bash
+shell [-u [UID]] [-- COMMAND...]
+```
+
+- `-u [UID]` – run as the given numeric user ID. When UID is omitted, the current user's UID is used.
+
+Arguments after `--` are passed to the container's entry point.

--- a/redo.mk
+++ b/redo.mk
@@ -134,7 +134,7 @@ webp: ## Convert images to webp format
 .PHONY: shell
 shell: ## Open an interactive shell container
 	$(call status,Open shell)
-	$(Q)$(DOCKER_COMPOSE) run --rm --build shell
+	$(Q)./bin/shell
 
 .PHONY: rmi
 rmi: ## Remove Docker images matching press-*


### PR DESCRIPTION
## Summary
- move shell recipe into executable script bin/shell
- allow passing optional user id via `-u` to docker compose run
- invoke new script from `shell` target
- document usage of `bin/shell` and link from reference docs

## Testing
- `make -f redo.mk test` *(fails: docker: No such file or directory)*
- `./bin/shell -u 1000 -- echo hi` *(fails: exec: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b66bd7ba48321bf80032c4feb027d