### PR TITLE
Add tests for utils write helpers

### DIFF
--- a/app/shell/py/pie/tests/test_utils.py
+++ b/app/shell/py/pie/tests/test_utils.py
@@ -1,0 +1,17 @@
+import json
+
+from pie import utils
+
+
+def test_write_json_roundtrip(tmp_path):
+    data = {"name": "pie", "value": 42}
+    path = tmp_path / "data.json"
+    utils.write_json(data, str(path))
+    assert utils.read_json(str(path)) == data
+
+
+def test_write_utf8_roundtrip(tmp_path):
+    text = "Hello π"
+    path = tmp_path / "file.txt"
+    utils.write_utf8(text, str(path))
+    assert utils.read_utf8(str(path)) == text


### PR DESCRIPTION
## Summary
- add unit tests covering pie.utils.write_json and write_utf8

## Testing
- `pytest app/shell/py/pie/tests/test_utils.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_689b6f375f8083218476811e2ce4c57e