### PR TITLE
feat: scan directory in update-author

### DIFF
--- a/docs/reference/update-author.md
+++ b/docs/reference/update-author.md
@@ -1,15 +1,17 @@
 # update-author
 
-Update the `author` field in metadata files for documents modified in git.
+Update the `author` field in metadata files for documents modified in git or
+within a specified directory.
 
-The console script scans `git status --short` for tracked files that have been added
-or changed. For each path it locates the associated Markdown and YAML
-metadata pair using `load_metadata_pair` and replaces the `author` field in
-Markdown frontmatter or metadata YAML with the author configured in
-`cfg/update-author.yml`.
+By default the console script scans `git status --short` for tracked files that
+have been added or changed. When a directory is provided, all Markdown and YAML
+files under that path are examined instead. For each file it locates the
+associated Markdown and YAML metadata pair using `load_metadata_pair` and
+replaces the `author` field in Markdown frontmatter or metadata YAML with the
+author configured in `cfg/update-author.yml`.
 
 ```bash
-update-author [-l LOGFILE]
+update-author [-l LOGFILE] [DIR]
 ```
 
 Each updated file is printed as `<path>: <old> -> <new>` and logged to


### PR DESCRIPTION
## Summary
- allow `update-author` to scan a provided directory instead of relying on git status
- document optional DIR argument for `update-author`
- test scanning a directory for `update-author`

## Testing
- `pytest app/shell/py/pie/tests/update/test_update_author.py`

------
https://chatgpt.com/codex/tasks/task_e_689b70d1ab988321981060ca90aa402f