### PR TITLE
feat: allow overriding author via CLI

### DIFF
--- a/app/shell/py/pie/pie/update/author.py
+++ b/app/shell/py/pie/pie/update/author.py
@@ -33,9 +33,10 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         description="Update the author field in modified metadata files",
     )
     parser.add_argument(
+        "-a",
         "--author",
         default=default_author,
-        help="Author name to set (default: value from cfg/update-author.yml)",
+        help="Author name to set; overrides value from cfg/update-author.yml",
     )
     parser.add_argument(
         "path",

--- a/docs/reference/update-author.md
+++ b/docs/reference/update-author.md
@@ -8,10 +8,12 @@ have been added or changed. When a directory is provided, all Markdown and YAML
 files under that path are examined instead. For each file it locates the
 associated Markdown and YAML metadata pair using `load_metadata_pair` and
 replaces the `author` field in Markdown frontmatter or metadata YAML with the
-author configured in `cfg/update-author.yml`.
+author configured in `cfg/update-author.yml`. Pass `--author` or `-a` to
+override this value, which is useful when batch updating book excerpts, quotes,
+or other content.
 
 ```bash
-update-author [-l LOGFILE] [DIR]
+update-author [-a AUTHOR] [-l LOGFILE] [DIR]
 ```
 
 Each updated file is printed as `<path>: <old> -> <new>` and logged to


### PR DESCRIPTION
## Summary
- add `-a` short option to `update-author` so CLI arguments can override config
- document `--author` option for batch updating excerpts, quotes, etc.
- test overriding author from the command line

## Testing
- `pytest app/shell/py/pie/tests/update/test_update_author.py`

------
https://chatgpt.com/codex/tasks/task_e_689b76893b788321b11b7cb1e8a68c9b