### PR TITLE
feat: allow update-author to take file paths

### DIFF
--- a/docs/reference/update-author.md
+++ b/docs/reference/update-author.md
@@ -1,19 +1,20 @@
 # update-author
 
 Update the `author` field in metadata files for documents modified in git or
-within a specified directory.
+within a specified path.
 
 By default the console script scans `git status --short` for tracked files that
-have been added or changed. When a directory is provided, all Markdown and YAML
-files under that path are examined instead. For each file it locates the
-associated Markdown and YAML metadata pair using `load_metadata_pair` and
-replaces the `author` field in Markdown frontmatter or metadata YAML with the
-author configured in `cfg/update-author.yml`. Pass `--author` or `-a` to
+have been added or changed. When a directory or file is provided, Markdown and
+YAML files under that path—or the specified file itself—are examined instead.
+For each file it locates the associated Markdown and YAML metadata pair using
+`load_metadata_pair` and replaces the `author` field in Markdown frontmatter or
+metadata YAML with the author configured in `cfg/update-author.yml`. Pass
+`--author` or `-a` to
 override this value, which is useful when batch updating book excerpts, quotes,
 or other content.
 
 ```bash
-update-author [-a AUTHOR] [-l LOGFILE] [DIR]
+update-author [-a AUTHOR] [-l LOGFILE] [PATH]
 ```
 
 Each updated file is printed as `<path>: <old> -> <new>` and logged to


### PR DESCRIPTION
## Summary
- allow `update-author` script to accept individual file paths in addition to directories
- document path-based usage and add regression tests

## Testing
- `pytest app/shell/py/pie/tests/update/test_update_author.py`


------
https://chatgpt.com/codex/tasks/task_e_689b78297fc88321b493f0524dcb5fb4