### PR TITLE
Ensure update-author adds missing metadata fields

### DIFF
--- a/app/shell/py/pie/tests/update/test_update_pubdate.py
+++ b/app/shell/py/pie/tests/update/test_update_pubdate.py
@@ -24,15 +24,17 @@ def test_updates_yaml_from_markdown_change(tmp_path: Path, monkeypatch, capsys) 
     update_pubdate.main([])
     expected = get_pubdate()
     assert f"pubdate: {expected}" in yml.read_text(encoding="utf-8")
-    expected_line = f"src/doc.yml: Jan 01, 2000 -> {expected}"
+    assert f"pubdate: {expected}" in md.read_text(encoding="utf-8")
     captured = capsys.readouterr()
-    assert captured.out.strip().splitlines() == [
-        expected_line,
-        "2 files checked",
-        "1 file changed",
-    ]
+    lines = captured.out.strip().splitlines()
+    assert f"src/doc.md: undefined -> {expected}" in lines
+    assert f"src/doc.yml: Jan 01, 2000 -> {expected}" in lines
+    assert "2 files checked" in lines
+    assert "2 files changed" in lines
+    assert len(lines) == 4
     log_text = (tmp_path / "log/update-pubdate.txt").read_text(encoding="utf-8")
-    assert expected_line in log_text
+    assert f"src/doc.md: undefined -> {expected}" in log_text
+    assert f"src/doc.yml: Jan 01, 2000 -> {expected}" in log_text
 
 
 def test_updates_markdown_frontmatter(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -62,8 +64,8 @@ def test_updates_markdown_frontmatter(tmp_path: Path, monkeypatch, capsys) -> No
     assert expected_line in log_text
 
 
-def test_ignores_pubdate_in_body(tmp_path: Path, monkeypatch, capsys) -> None:
-    """Pubdate outside frontmatter is ignored."""
+def test_adds_frontmatter_when_pubdate_in_body(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Pubdate outside frontmatter is ignored and field added to frontmatter."""
     src = tmp_path / "src"
     src.mkdir()
     md = src / "doc.md"
@@ -73,9 +75,13 @@ def test_ignores_pubdate_in_body(tmp_path: Path, monkeypatch, capsys) -> None:
     monkeypatch.setattr(update_pubdate, "get_changed_files", lambda: [Path("src/doc.md")])
 
     update_pubdate.main([])
-    assert "Jan 01, 2000" in md.read_text(encoding="utf-8")
+    expected = get_pubdate()
+    text = md.read_text(encoding="utf-8")
+    assert f"pubdate: {expected}" in text
+    assert "pubdate: Jan 01, 2000" in text
     captured = capsys.readouterr()
     assert captured.out.strip().splitlines() == [
+        f"src/doc.md: undefined -> {expected}",
         "1 file checked",
-        "0 files changed",
+        "1 file changed",
     ]

--- a/docs/reference/update-author.md
+++ b/docs/reference/update-author.md
@@ -7,11 +7,11 @@ By default the console script scans `git status --short` for tracked files that
 have been added or changed. When a directory or file is provided, Markdown and
 YAML files under that path—or the specified file itself—are examined instead.
 For each file it locates the associated Markdown and YAML metadata pair using
-`load_metadata_pair` and replaces the `author` field in Markdown frontmatter or
-metadata YAML with the author configured in `cfg/update-author.yml`. Pass
-`--author` or `-a` to
-override this value, which is useful when batch updating book excerpts, quotes,
-or other content.
+`load_metadata_pair` and ensures the `author` field is present in Markdown
+frontmatter or metadata YAML. The field is added when missing and metadata is
+created if none exists. The value is taken from `cfg/update-author.yml`, but
+can be overridden with the `--author` or `-a` option when batch updating book
+excerpts, quotes, or other content.
 
 ```bash
 update-author [-a AUTHOR] [-l LOGFILE] [PATH]

--- a/docs/reference/update-pubdate.md
+++ b/docs/reference/update-pubdate.md
@@ -2,10 +2,12 @@
 
 Update the `pubdate` field in metadata files for documents modified in git.
 
-The console script scans `git status --short` for tracked files that have been added
-or changed. For each path it locates the associated Markdown and YAML
-metadata pair using `load_metadata_pair` and replaces the `pubdate` field in
-Markdown frontmatter or metadata YAML with today's date in the format `%b %d, %Y`.
+The console script scans `git status --short` for tracked files that have been
+added or changed. For each path it locates the associated Markdown and YAML
+metadata pair using `load_metadata_pair` and ensures the `pubdate` field is
+present in Markdown frontmatter or metadata YAML. When the field is missing it
+is added, and metadata is created if none exists, using today's date in the
+format `%b %d, %Y`.
 
 ```python
 from pathlib import Path
@@ -19,8 +21,8 @@ load_metadata_pair(Path("docs/post/index.yml"))
 update-pubdate [-l LOGFILE]
 ```
 
-Each updated file is printed as `<path>: <old> -> <new>` and the same information
-is logged to `LOGFILE`. When omitted, log output is written to
+Each updated file is printed as `<path>: <old> -> <new>` and the same
+information is logged to `LOGFILE`. When omitted, log output is written to
 `log/update-pubdate.txt`.
 
 When finished, the script reports how many files were checked and how many were


### PR DESCRIPTION
## Summary
- allow metadata updater to insert fields into Markdown frontmatter and create frontmatter when missing
- document that update-author and update-pubdate add missing metadata
- expand tests for update-author and update-pubdate to cover new behavior

## Testing
- `pytest app/shell/py/pie/tests/update/test_update_author.py app/shell/py/pie/tests/update/test_update_pubdate.py`

------
https://chatgpt.com/codex/tasks/task_e_689b79f226d8832194a41e43774b46e1