### PR TITLE
feat: add verbose option to update-author

### DIFF
--- a/app/shell/py/pie/pie/logging.py
+++ b/app/shell/py/pie/pie/logging.py
@@ -54,3 +54,18 @@ def setup_file_logger(log_path: str | None, *, level: str = "DEBUG") -> None:
 
     if log_path:
         add_file_logger(log_path, level=level)
+
+
+def configure_logging(verbose: bool, log_path: str | None) -> None:
+    """Configure console and file logging based on ``verbose`` flag.
+
+    The existing logger configuration is cleared and a console sink is added
+    at ``DEBUG`` level when ``verbose`` is :data:`True` and ``INFO`` otherwise.
+    File logging is configured via :func:`setup_file_logger` using the same
+    level.
+    """
+
+    level = "DEBUG" if verbose else "INFO"
+    logger.remove()
+    logger.add(sys.stderr, format=LOG_FORMAT, level=level)
+    setup_file_logger(log_path, level=level)

--- a/app/shell/py/pie/tests/update/test_update_author.py
+++ b/app/shell/py/pie/tests/update/test_update_author.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sys
 
 from pie.update import author as update_author
 
@@ -171,4 +172,36 @@ def test_overrides_author_argument(tmp_path: Path, monkeypatch, capsys) -> None:
     ]
     log_text = (tmp_path / "log/update-author.txt").read_text(encoding="utf-8")
     assert expected_line in log_text
+
+
+def test_verbose_enables_debug_logging(tmp_path: Path, monkeypatch) -> None:
+    """-v sets the console log level to DEBUG."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "doc.md").write_text("---\ntitle: Test\n---\n", encoding="utf-8")
+    (src / "doc.yml").write_text("title: Test\nauthor: Jane Doe\n", encoding="utf-8")
+
+    cfg = tmp_path / "cfg"
+    cfg.mkdir()
+    (cfg / "update-author.yml").write_text("author: Brian Lee\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+
+    levels: list[str | None] = []
+    original_add = update_author.logger.add
+
+    def fake_add(*args, **kwargs):
+        levels.append(kwargs.get("level"))
+        return original_add(*args, **kwargs)
+
+    monkeypatch.setattr(update_author.logger, "add", fake_add)
+
+    update_author.main(["-v", "src"])
+
+    assert "DEBUG" in levels
+
+    update_author.logger.remove()
+    from pie.logging import LOG_FORMAT
+
+    update_author.logger.add(sys.stderr, format=LOG_FORMAT, level="INFO")
 

--- a/docs/reference/update-author.md
+++ b/docs/reference/update-author.md
@@ -14,12 +14,12 @@ override this value, which is useful when batch updating book excerpts, quotes,
 or other content.
 
 ```bash
-update-author [-a AUTHOR] [-l LOGFILE] [PATH]
+update-author [-a AUTHOR] [-l LOGFILE] [-v] [PATH]
 ```
 
 Each updated file is printed as `<path>: <old> -> <new>` and logged to
 `LOGFILE`.  When not specified, log output is written to
-`log/update-author.txt`.
+`log/update-author.txt`. Pass `-v` to enable debug logging.
 
 After processing, a summary of the number of files checked and modified is
 printed to the console.


### PR DESCRIPTION
## Summary
- support `-v`/`--verbose` flag in `update-author`
- output debug logs and debug print statements when verbose is enabled
- centralize verbose logging configuration in `pie.logging`

## Testing
- `pytest app/shell/py/pie/tests/update/test_update_author.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b7ad26b3483219609af9fffd2adf1