### PR TITLE
feat: add verbose option to update-author

### DIFF
--- a/app/shell/py/pie/pie/build_index.py
+++ b/app/shell/py/pie/pie/build_index.py
@@ -10,7 +10,7 @@ import json
 import os
 from typing import Any, Dict, Optional
 
-from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, configure_logging
 from pie.metadata import get_url, read_from_markdown, read_from_yaml
 
 
@@ -127,7 +127,7 @@ def main(argv: list[str] | None = None) -> None:
     """Build the index and write JSON output."""
     args = parse_args(argv)
 
-    setup_file_logger(args.log)
+    configure_logging(False, args.log)
 
     index = build_index(args.source_dir)
 

--- a/app/shell/py/pie/pie/check/author.py
+++ b/app/shell/py/pie/pie/check/author.py
@@ -7,7 +7,7 @@ import argparse
 from pathlib import Path
 from typing import Iterable
 
-from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, configure_logging
 from pie.metadata import load_metadata_pair
 
 DEFAULT_LOG = "log/check-author.txt"
@@ -57,7 +57,7 @@ def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``check-author`` console script."""
     args = parse_args(argv)
     Path(args.log).parent.mkdir(parents=True, exist_ok=True)
-    setup_file_logger(args.log)
+    configure_logging(False, args.log)
 
     root = Path(args.directory)
     ok = True

--- a/app/shell/py/pie/pie/check/bad_jinja_output.py
+++ b/app/shell/py/pie/pie/check/bad_jinja_output.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import re
 from bs4 import BeautifulSoup
-from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, configure_logging
 
 def contains_python_dict(text: str) -> bool:
     """Return ``True`` if *text* looks like a Python dictionary literal."""
@@ -29,7 +29,7 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parse_args(argv)
 
-    setup_file_logger(args.log)
+    configure_logging(False, args.log)
 
     with open(args.html_file, "r", encoding="utf-8") as f:
         soup = BeautifulSoup(f, "html.parser")

--- a/app/shell/py/pie/pie/check/post_build.py
+++ b/app/shell/py/pie/pie/check/post_build.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, configure_logging
 from pie.utils import read_yaml
 
 DEFAULT_LOG = "log/check-post-build.txt"
@@ -39,7 +39,7 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parse_args(argv)
     Path(args.log).parent.mkdir(parents=True, exist_ok=True)
-    setup_file_logger(args.log)
+    configure_logging(False, args.log)
 
     required = read_yaml(args.config) or []
 

--- a/app/shell/py/pie/pie/create/site.py
+++ b/app/shell/py/pie/pie/create/site.py
@@ -6,7 +6,7 @@ from typing import Sequence
 
 from jinja2 import Environment
 
-from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, configure_logging
 
 
 __all__ = ["main"]
@@ -25,7 +25,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point for the ``create`` console script."""
     args = parse_args(argv)
-    setup_file_logger(args.log)
+    configure_logging(False, args.log)
 
     root = Path(args.path)
     root.mkdir(parents=True, exist_ok=True)

--- a/app/shell/py/pie/pie/filter/emojify.py
+++ b/app/shell/py/pie/pie/filter/emojify.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 
 import emoji
-from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, configure_logging
 
 def emojify_text(text: str) -> str:
     """Return *text* with ``:emoji:`` codes replaced by Unicode characters."""
@@ -28,7 +28,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> None:
     """Entry point used by the ``emojify`` console script."""
     args = parse_args(argv)
-    setup_file_logger(args.log)
+    configure_logging(False, args.log)
 
     if args.text:
         text = " ".join(args.text)

--- a/app/shell/py/pie/pie/filter/include.py
+++ b/app/shell/py/pie/pie/filter/include.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import IO, Iterable, Callable
 
 import yaml
-from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, configure_logging
 from pie.metadata import get_metadata_by_path
 
 MD_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\.md\)")
@@ -209,7 +209,7 @@ def main(argv: list[str] | None = None) -> None:
 
     args = parse_args(argv)
 
-    setup_file_logger(args.log)
+    configure_logging(False, args.log)
 
     outdir = args.outdir
     infilename = args.infile

--- a/app/shell/py/pie/pie/logging.py
+++ b/app/shell/py/pie/pie/logging.py
@@ -54,3 +54,18 @@ def setup_file_logger(log_path: str | None, *, level: str = "DEBUG") -> None:
 
     if log_path:
         add_file_logger(log_path, level=level)
+
+
+def configure_logging(verbose: bool, log_path: str | None) -> None:
+    """Configure console and file logging based on ``verbose`` flag.
+
+    The existing logger configuration is cleared and a console sink is added
+    at ``DEBUG`` level when ``verbose`` is :data:`True` and ``INFO`` otherwise.
+    File logging is configured via :func:`setup_file_logger` using the same
+    level.
+    """
+
+    level = "DEBUG" if verbose else "INFO"
+    logger.remove()
+    logger.add(sys.stderr, format=LOG_FORMAT, level=level)
+    setup_file_logger(log_path, level=level)

--- a/app/shell/py/pie/pie/process_yaml.py
+++ b/app/shell/py/pie/pie/process_yaml.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 from typing import Iterable
 
-from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, configure_logging
 from pie.utils import write_yaml
 from pie.metadata import read_from_yaml
 
@@ -25,7 +25,7 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
 def main(argv: Iterable[str] | None = None) -> None:
     """Entry point used by the ``process-yaml`` console script."""
     args = parse_args(argv)
-    setup_file_logger(args.log)
+    configure_logging(False, args.log)
 
     try:
         metadata = read_from_yaml(args.input)

--- a/app/shell/py/pie/pie/render/jinja.py
+++ b/app/shell/py/pie/pie/render/jinja.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
-from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, configure_logging
 from pie.utils import read_json, read_utf8, write_utf8, read_yaml as load_yaml_file
 from pie import metadata
 
@@ -371,7 +371,7 @@ def main(argv: list[str] | None = None) -> None:
     global index_json
     args = parse_args(argv)
 
-    setup_file_logger(args.log)
+    configure_logging(False, args.log)
 
     global config
     config = load_config(args.config)

--- a/app/shell/py/pie/pie/render_study_json.py
+++ b/app/shell/py/pie/pie/render_study_json.py
@@ -13,7 +13,7 @@ import json
 from pathlib import Path
 from typing import Any, Iterable, List
 
-from pie.logging import logger, add_log_argument, setup_file_logger
+from pie.logging import logger, add_log_argument, configure_logging
 from pie.utils import read_json
 
 from .render.jinja import create_env
@@ -67,7 +67,7 @@ def main(argv: list[str] | None = None) -> None:
     """Entry point for the ``pie.render_study_json`` module."""
 
     args = parse_args(argv)
-    setup_file_logger(args.log)
+    configure_logging(False, args.log)
 
     index_json = read_json(args.index)
     study_json = read_json(args.study)

--- a/app/shell/py/pie/pie/store_files.py
+++ b/app/shell/py/pie/pie/store_files.py
@@ -7,7 +7,7 @@ import secrets
 from pathlib import Path
 from typing import Iterable, Sequence
 
-from pie.logging import add_log_argument, setup_file_logger, logger
+from pie.logging import add_log_argument, configure_logging, logger
 from pie.utils import write_yaml
 
 __all__ = ["main"]
@@ -78,8 +78,7 @@ def process_file(src: Path, dest_dir: Path, meta_dir: Path) -> str:
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point for the ``store-files`` console script."""
     args = parse_args(argv)
-    if args.log:
-        setup_file_logger(args.log, level="INFO")
+    configure_logging(False, args.log)
 
     base_path = Path(args.path)
     dest_dir = Path("s3") / "v2" / "files" / "0"

--- a/app/shell/py/pie/pie/update/index.py
+++ b/app/shell/py/pie/pie/update/index.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import argparse
 import os
 import json
-import sys
 import time
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -19,12 +18,7 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 
 import redis
-from pie.logging import (
-    LOG_FORMAT,
-    add_log_argument,
-    logger,
-    setup_file_logger,
-)
+from pie.logging import add_log_argument, configure_logging, logger
 from pie.metadata import load_metadata_pair
 
 
@@ -168,10 +162,7 @@ def load_index_from_path(path: Path) -> tuple[dict[str, dict[str, Any]], int]:
 def main(argv: Iterable[str] | None = None) -> None:
     """Entry point for the ``update-index`` console script."""
     args = parse_args(argv)
-    if args.verbose:
-        logger.remove()
-        logger.add(sys.stderr, format=LOG_FORMAT, level="DEBUG")
-    setup_file_logger(args.log)
+    configure_logging(args.verbose, args.log)
 
     start = time.perf_counter()
     path = Path(args.path)

--- a/app/shell/py/pie/pie/update/link_filters.py
+++ b/app/shell/py/pie/pie/update/link_filters.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 from typing import Iterable, Sequence
 
-from pie.logging import add_log_argument, setup_file_logger, logger
+from pie.logging import add_log_argument, configure_logging, logger
 
 FILTERS = [
     "link",
@@ -91,7 +91,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    setup_file_logger(args.log, level="INFO")
+    configure_logging(False, args.log)
     files = list(iter_files(Path(p) for p in args.paths))
     changed = 0
     for fp in files:

--- a/app/shell/py/pie/pie/update/pubdate.py
+++ b/app/shell/py/pie/pie/update/pubdate.py
@@ -4,7 +4,7 @@ import argparse
 from pathlib import Path
 from typing import Iterable, Sequence
 
-from pie.logging import add_log_argument, setup_file_logger
+from pie.logging import add_log_argument, configure_logging
 from .common import get_changed_files, update_files as common_update_files
 from pie.utils import get_pubdate
 
@@ -36,7 +36,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     if args.log:
         Path(args.log).parent.mkdir(parents=True, exist_ok=True)
-    setup_file_logger(args.log, level="INFO")
+    configure_logging(False, args.log)
     today = get_pubdate()
     changed = get_changed_files()
     messages, checked = update_files(changed, today)

--- a/app/shell/py/pie/tests/update/test_update_author.py
+++ b/app/shell/py/pie/tests/update/test_update_author.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sys
 
 from pie.update import author as update_author
 
@@ -171,4 +172,36 @@ def test_overrides_author_argument(tmp_path: Path, monkeypatch, capsys) -> None:
     ]
     log_text = (tmp_path / "log/update-author.txt").read_text(encoding="utf-8")
     assert expected_line in log_text
+
+
+def test_verbose_enables_debug_logging(tmp_path: Path, monkeypatch) -> None:
+    """-v sets the console log level to DEBUG."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "doc.md").write_text("---\ntitle: Test\n---\n", encoding="utf-8")
+    (src / "doc.yml").write_text("title: Test\nauthor: Jane Doe\n", encoding="utf-8")
+
+    cfg = tmp_path / "cfg"
+    cfg.mkdir()
+    (cfg / "update-author.yml").write_text("author: Brian Lee\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+
+    levels: list[str | None] = []
+    original_add = update_author.logger.add
+
+    def fake_add(*args, **kwargs):
+        levels.append(kwargs.get("level"))
+        return original_add(*args, **kwargs)
+
+    monkeypatch.setattr(update_author.logger, "add", fake_add)
+
+    update_author.main(["-v", "src"])
+
+    assert "DEBUG" in levels
+
+    update_author.logger.remove()
+    from pie.logging import LOG_FORMAT
+
+    update_author.logger.add(sys.stderr, format=LOG_FORMAT, level="INFO")
 

--- a/docs/reference/update-author.md
+++ b/docs/reference/update-author.md
@@ -14,12 +14,12 @@ override this value, which is useful when batch updating book excerpts, quotes,
 or other content.
 
 ```bash
-update-author [-a AUTHOR] [-l LOGFILE] [PATH]
+update-author [-a AUTHOR] [-l LOGFILE] [-v] [PATH]
 ```
 
 Each updated file is printed as `<path>: <old> -> <new>` and logged to
 `LOGFILE`.  When not specified, log output is written to
-`log/update-author.txt`.
+`log/update-author.txt`. Pass `-v` to enable debug logging.
 
 After processing, a summary of the number of files checked and modified is
 printed to the console.


### PR DESCRIPTION
## Summary
- support `-v`/`--verbose` flag in `update-author`
- output debug logs and debug print statements when verbose is enabled
- centralize verbose logging configuration in `pie.logging`
- use `configure_logging` across CLI scripts to standardize logging setup

## Testing
- `pytest app/shell/py/pie/tests/update/test_update_author.py -q`
- `pytest app/shell/py/pie/tests/update/test_update_pubdate.py -q`
- `pytest app/shell/py/pie/tests/update/test_update_link_filters.py -q`
- `pytest app/shell/py/pie/tests/update/test_update_index.py -q`
- `pytest app/shell/py/pie/tests/test_build_index.py -q`
- `pytest app/shell/py/pie/tests/test_emojify.py -q`
- `pytest app/shell/py/pie/tests/test_process_yaml.py -q`
- `pytest app/shell/py/pie/tests/test_store_files.py -q`
- `pytest app/shell/py/pie/tests/test_check_author.py -q`
- `pytest app/shell/py/pie/tests/test_check_post_build.py -q`
- `pytest app/shell/py/pie/tests/test_bad_jinja_output.py -q`
- `pytest app/shell/py/pie/tests/test_create.py -q`
- `pytest app/shell/py/pie/tests/test_render_study_json.py -q`
- `pytest app/shell/py/pie/tests/test_render_template.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b7ad26b3483219609af9fffd2adf1