### PR TITLE
Include full path in metadata conflict warning

### DIFF
--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -284,7 +284,7 @@ def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
         for k, v in yaml_data.items():
             if k in combined and combined[k] != v:
                 warnings.warn(
-                    f"Conflict for '{k}', using value from {yaml_file.name}",
+                    f"Conflict for '{k}', using value from {yaml_file.resolve().relative_to(Path.cwd())}",
                     UserWarning,
                 )
             combined[k] = v

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -59,3 +59,19 @@ def test_read_from_yaml_generates_fields(tmp_path):
     assert data["citation"] == "foo"
     assert data["id"] == "item"
 
+
+def test_load_metadata_pair_conflict_shows_path(tmp_path):
+    """Conflicting values include path in warning."""
+    md = tmp_path / "dir" / "post.md"
+    md.parent.mkdir(parents=True)
+    md.write_text("---\nurl: /md\n---\n")
+    yml = md.with_suffix(".yml")
+    yml.write_text("url: /yml\n")
+    os.chdir(tmp_path)
+    try:
+        with pytest.warns(UserWarning) as record:
+            metadata.load_metadata_pair(yml)
+        assert "dir/post.yml" in str(record[0].message)
+    finally:
+        os.chdir("/tmp")
+


### PR DESCRIPTION
## Summary
- Show the full file path in metadata conflict warnings for more helpful messages
- Test that load_metadata_pair emits a path-aware warning when metadata values conflict

## Testing
- `pytest` *(fails: No module named 'bs4')*
- `pytest app/shell/py/pie/tests/test_metadata.py::test_load_metadata_pair_conflict_shows_path -q`


------
https://chatgpt.com/codex/tasks/task_e_689b854d8f7483218e8a60ccb9be5b9b