### PR TITLE
Constrain pie logging field widths

### DIFF
--- a/app/shell/py/pie/pie/logging.py
+++ b/app/shell/py/pie/pie/logging.py
@@ -16,7 +16,7 @@ from loguru import logger
 logger.remove()
 
 LOG_FORMAT = (
-    "{time:HH:mm:ss} {module:>25}:{function:<25}:{line:<4} {level:.4s} {message} {extra}"
+    "{time:HH:mm:ss} {module:>10.10}:{function:<15.15}:{line:<4} {level:.1s} {message} {extra}"
 )
 
 # Configure the console sink that all tests and scripts rely on.


### PR DESCRIPTION
## Summary
- shorten module name output to 10 characters
- truncate function names to 15 characters
- limit log level output to a single character

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b85160dec83218d70fae83e5ef424