### PR TITLE
Refactor metadata loaders to separate default generation

### DIFF
--- a/app/shell/py/pie/pie/build_index.py
+++ b/app/shell/py/pie/pie/build_index.py
@@ -11,7 +11,12 @@ import os
 from typing import Any, Dict, Optional
 
 from pie.logging import logger, add_log_argument, configure_logging
-from pie.metadata import get_url, read_from_markdown, read_from_yaml
+from pie.metadata import (
+    get_url,
+    read_from_markdown,
+    read_from_yaml,
+    generate_missing_metadata,
+)
 
 
 ## Functions for reading metadata are provided by ``pie.metadata``.
@@ -99,6 +104,7 @@ def build_index(
                 metadata = read_from_yaml(filepath)
 
             if metadata:
+                metadata = generate_missing_metadata(metadata, filepath)
                 validate_and_insert_metadata(metadata, filepath, index)
                 logger.debug("Processed file", filename=filepath)
 

--- a/app/shell/py/pie/pie/process_yaml.py
+++ b/app/shell/py/pie/pie/process_yaml.py
@@ -8,7 +8,7 @@ from typing import Iterable
 
 from pie.logging import logger, add_log_argument, configure_logging
 from pie.utils import write_yaml
-from pie.metadata import read_from_yaml
+from pie.metadata import generate_missing_metadata, read_from_yaml
 
 
 def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
@@ -35,6 +35,8 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     try:
         metadata = read_from_yaml(args.input)
+        if metadata is not None:
+            metadata = generate_missing_metadata(metadata, args.input)
     except Exception as exc:  # pragma: no cover - pass through message
         logger.error("Failed to process YAML", filename=args.input)
         raise SystemExit(1) from exc

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -36,6 +36,8 @@ def test_read_from_markdown_generates_fields(tmp_path):
     os.chdir(tmp_path)
     try:
         data = metadata.read_from_markdown("src/doc.md")
+        assert data is not None
+        data = metadata.generate_missing_metadata(data, "src/doc.md")
     finally:
         os.chdir("/tmp")
     assert data["title"] == "T"
@@ -52,6 +54,8 @@ def test_read_from_yaml_generates_fields(tmp_path):
     os.chdir(tmp_path)
     try:
         data = metadata.read_from_yaml("src/item.yml")
+        assert data is not None
+        data = metadata.generate_missing_metadata(data, "src/item.yml")
     finally:
         os.chdir("/tmp")
     assert data["title"] == "Foo"

--- a/docs/reference/link-metadata.md
+++ b/docs/reference/link-metadata.md
@@ -42,7 +42,8 @@ link:
 
 ## How IDs Are Generated
 
-During indexing, `read_from_yaml` from `pie.metadata` loads the file and assigns an `id` if it is absent:
+During indexing, `read_from_yaml` loads the file and `generate_missing_metadata`
+adds an `id` if it is absent:
 
 ```
 base, _ = os.path.splitext(filepath)

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -19,7 +19,7 @@ This document lists the common metadata keys used by Press and explains how miss
 
 ## Auto‑Generated Values
 
-During indexing, `read_from_yaml` in `pie.metadata` fills in several fields when they are missing:
+During indexing, `generate_missing_metadata` in `pie.metadata` fills in several fields when they are missing:
 
 | Field      | Default value                                  |
 | ---------- | ---------------------------------------------- |
@@ -28,7 +28,7 @@ During indexing, `read_from_yaml` in `pie.metadata` fills in several fields when
 | `url`      | Derived from the source path (e.g. `src/foo.md` → `/foo.html`) |
 
 The `citation` value is used as the anchor text when other pages link to this document using Jinja globals such as `linktitle`.
-The helper that assigns these defaults lives in `read_from_yaml` within `pie.metadata`.
+The helper that assigns these defaults lives in `generate_missing_metadata` within `pie.metadata`.
 
 For bibliographic references the `citation` field may instead be a mapping with
 `author`, `year`, and `page` keys.  This structure is consumed by the `cite`


### PR DESCRIPTION
## Summary
- avoid generating metadata defaults inside `read_from_markdown` and `read_from_yaml`
- apply `generate_missing_metadata` within callers like `build_index`, `process_yaml`, and `load_metadata_pair`
- update documentation and tests for new metadata workflow

## Testing
- `cd app/shell/py/pie && pytest` *(fails: ModuleNotFoundError: No module named 'loguru')*


------
https://chatgpt.com/codex/tasks/task_e_689b93c274288321acc50fb69d6eafa9