### PR TITLE
refactor: centralize CLI parser creation

### DIFF
--- a/app/shell/py/pie/pie/build_index.py
+++ b/app/shell/py/pie/pie/build_index.py
@@ -10,7 +10,8 @@ import json
 import os
 from typing import Any, Dict, Optional
 
-from pie.logging import logger, add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
 from pie.metadata import get_url, read_from_markdown, read_from_yaml
 
 
@@ -107,9 +108,7 @@ def build_index(
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Build a JSON index from Markdown/YAML files' metadata."
-    )
+    parser = create_parser("Build a JSON index from Markdown/YAML files' metadata.")
     parser.add_argument(
         "source_dir",
         help="Root directory to scan for `.md`, `.yml`, and `.yaml` files",
@@ -118,13 +117,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "-o",
         "--output",
         help="Path to write the JSON index (defaults to stdout)",
-    )
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
     )
     return parser.parse_args(argv)
 

--- a/app/shell/py/pie/pie/check/author.py
+++ b/app/shell/py/pie/pie/check/author.py
@@ -7,7 +7,8 @@ import argparse
 from pathlib import Path
 from typing import Iterable
 
-from pie.logging import logger, add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
 from pie.metadata import load_metadata_pair
 
 DEFAULT_LOG = "log/check-author.txt"
@@ -15,21 +16,15 @@ DEFAULT_LOG = "log/check-author.txt"
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Check that metadata files include an author field.",
+    parser = create_parser(
+        "Check that metadata files include an author field.",
+        log_default=DEFAULT_LOG,
     )
     parser.add_argument(
         "directory",
         nargs="?",
         default="src",
         help="Root directory to scan for metadata files",
-    )
-    add_log_argument(parser, default=DEFAULT_LOG)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
     )
     return parser.parse_args(argv)
 

--- a/app/shell/py/pie/pie/check/bad_jinja_output.py
+++ b/app/shell/py/pie/pie/check/bad_jinja_output.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import argparse
 import re
 from bs4 import BeautifulSoup
-from pie.logging import logger, add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
 
 def contains_python_dict(text: str) -> bool:
     """Return ``True`` if *text* looks like a Python dictionary literal."""
@@ -16,17 +17,8 @@ def contains_python_dict(text: str) -> bool:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Return parsed command line arguments."""
 
-    parser = argparse.ArgumentParser(
-        description="Check for Python dictionaries in HTML text nodes",
-    )
+    parser = create_parser("Check for Python dictionaries in HTML text nodes")
     parser.add_argument("html_file", help="Path to the HTML file to inspect")
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
-    )
     return parser.parse_args(argv)
 
 

--- a/app/shell/py/pie/pie/check/page_title.py
+++ b/app/shell/py/pie/pie/check/page_title.py
@@ -14,7 +14,8 @@ import sys
 from pathlib import Path
 
 from bs4 import BeautifulSoup
-from pie.logging import add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import configure_logging
 from pie.utils import read_yaml
 
 
@@ -44,8 +45,8 @@ def check_file(path: Path) -> bool:
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Verify that HTML files contain non-empty <h1> tags.",
+    parser = create_parser(
+        "Verify that HTML files contain non-empty <h1> tags."
     )
     parser.add_argument(
         "directory",
@@ -57,13 +58,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "-x",
         "--exclude",
         help="YAML file listing HTML files to skip",
-    )
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
     )
     return parser.parse_args(argv)
 

--- a/app/shell/py/pie/pie/check/post_build.py
+++ b/app/shell/py/pie/pie/check/post_build.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from pie.logging import logger, add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
 from pie.utils import read_yaml
 
 DEFAULT_LOG = "log/check-post-build.txt"
@@ -15,8 +16,9 @@ DEFAULT_CFG = "cfg/check-post-build.yml"
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Return parsed command line arguments."""
 
-    parser = argparse.ArgumentParser(
-        description="Verify that expected build artifacts exist.",
+    parser = create_parser(
+        "Verify that expected build artifacts exist.",
+        log_default=DEFAULT_LOG,
     )
     parser.add_argument(
         "directory",
@@ -29,13 +31,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--config",
         default=DEFAULT_CFG,
         help="YAML file listing required paths",
-    )
-    add_log_argument(parser, default=DEFAULT_LOG)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
     )
     return parser.parse_args(argv)
 

--- a/app/shell/py/pie/pie/cli.py
+++ b/app/shell/py/pie/pie/cli.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import argparse
+
+from pie.logging import add_log_argument
+
+__all__ = ["create_parser"]
+
+
+def create_parser(description: str, *, log_default: str | None = None) -> argparse.ArgumentParser:
+    """Return an :class:`argparse.ArgumentParser` with standard options.
+
+    The parser includes ``--log`` and ``--verbose`` arguments used throughout
+    the ``pie`` command line tools.
+
+    Parameters
+    ----------
+    description:
+        Description for the parser.
+    log_default:
+        Optional default path for the ``--log`` argument.
+    """
+
+    parser = argparse.ArgumentParser(description=description)
+    add_log_argument(parser, default=log_default)
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    return parser

--- a/app/shell/py/pie/pie/create/post.py
+++ b/app/shell/py/pie/pie/create/post.py
@@ -4,7 +4,8 @@ import argparse
 from pathlib import Path
 from typing import Sequence
 
-from pie.logging import add_log_argument, configure_logging, logger
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
 from pie.utils import get_pubdate, write_yaml
 
 
@@ -13,17 +14,8 @@ __all__ = ["main"]
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Create a new post with Markdown and YAML files",
-    )
+    parser = create_parser("Create a new post with Markdown and YAML files")
     parser.add_argument("path", help="Base path for the new post without extension")
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
-    )
     return parser.parse_args(list(argv) if argv is not None else None)
 
 

--- a/app/shell/py/pie/pie/create/site.py
+++ b/app/shell/py/pie/pie/create/site.py
@@ -6,7 +6,8 @@ from typing import Sequence
 
 from jinja2 import Environment
 
-from pie.logging import logger, add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
 
 
 __all__ = ["main"]
@@ -14,17 +15,8 @@ __all__ = ["main"]
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Create scaffolding for a Press project",
-    )
+    parser = create_parser("Create scaffolding for a Press project")
     parser.add_argument("path", help="Target directory for the project")
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
-    )
     return parser.parse_args(list(argv) if argv is not None else None)
 
 

--- a/app/shell/py/pie/pie/filter/emojify.py
+++ b/app/shell/py/pie/pie/filter/emojify.py
@@ -4,7 +4,8 @@ import argparse
 import sys
 
 import emoji
-from pie.logging import logger, add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
 
 def emojify_text(text: str) -> str:
     """Return *text* with ``:emoji:`` codes replaced by Unicode characters."""
@@ -13,20 +14,11 @@ def emojify_text(text: str) -> str:
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Replace :emoji: codes with Unicode characters",
-    )
+    parser = create_parser("Replace :emoji: codes with Unicode characters")
     parser.add_argument(
         "text",
         nargs="*",
         help="Text to emojify. Reads from stdin when omitted.",
-    )
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
     )
     return parser.parse_args(list(argv) if argv is not None else None)
 

--- a/app/shell/py/pie/pie/filter/include.py
+++ b/app/shell/py/pie/pie/filter/include.py
@@ -21,7 +21,8 @@ from pathlib import Path
 from typing import IO, Iterable, Callable
 
 import yaml
-from pie.logging import logger, add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
 from pie.metadata import get_metadata_by_path
 
 MD_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\.md\)")
@@ -186,19 +187,10 @@ def md_to_html_links(line: str) -> str:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
 
-    parser = argparse.ArgumentParser(
-        description="Expand Python directives inside a Markdown file",
-    )
+    parser = create_parser("Expand Python directives inside a Markdown file")
     parser.add_argument("outdir", help="Output directory for diagrams")
     parser.add_argument("infile", help="Input Markdown file")
     parser.add_argument("outfile", help="Output Markdown file")
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
-    )
     return parser.parse_args(argv)
 
 

--- a/app/shell/py/pie/pie/gen_markdown_index.py
+++ b/app/shell/py/pie/pie/gen_markdown_index.py
@@ -11,7 +11,8 @@ import warnings
 from pathlib import Path
 from typing import Iterator
 
-from pie.logging import add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import configure_logging
 from pie.index_tree import walk, getopt_link, getopt_show
 
 warnings.warn(
@@ -42,15 +43,8 @@ def generate(directory: Path, level: int = 0) -> Iterator[str]:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Generate a Markdown index")
+    parser = create_parser("Generate a Markdown index")
     parser.add_argument("root_dir", nargs="?", default=".", help="Root directory to scan")
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
-    )
     return parser.parse_args(argv)
 
 

--- a/app/shell/py/pie/pie/indextree_json.py
+++ b/app/shell/py/pie/pie/indextree_json.py
@@ -4,7 +4,8 @@ import argparse
 import json
 from pathlib import Path
 
-from pie.logging import logger, add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
 
 from pie.index_tree import walk, getopt_link, getopt_show
 
@@ -40,18 +41,9 @@ def process_dir(directory: Path):
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Generate JSON index from metadata tree",
-    )
+    parser = create_parser("Generate JSON index from metadata tree")
     parser.add_argument("root", nargs="?", default=".", help="Directory to scan")
     parser.add_argument("output", nargs="?", help="Write JSON to file")
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
-    )
     return parser.parse_args(argv)
 
 

--- a/app/shell/py/pie/pie/process_yaml.py
+++ b/app/shell/py/pie/pie/process_yaml.py
@@ -6,25 +6,17 @@ import argparse
 import sys
 from typing import Iterable
 
-from pie.logging import logger, add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
 from pie.utils import write_yaml
 from pie.metadata import read_from_yaml
 
 
 def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Generate missing metadata fields for a YAML file",
-    )
+    parser = create_parser("Generate missing metadata fields for a YAML file")
     parser.add_argument("input", help="Source YAML file")
     parser.add_argument("output", help="Destination file to write")
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
-    )
     return parser.parse_args(list(argv) if argv is not None else None)
 
 

--- a/app/shell/py/pie/pie/render/jinja.py
+++ b/app/shell/py/pie/pie/render/jinja.py
@@ -17,7 +17,8 @@ from pathlib import Path
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
-from pie.logging import logger, add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
 from pie.utils import read_json, read_utf8, write_utf8, read_yaml as load_yaml_file
 from pie import metadata
 
@@ -346,8 +347,8 @@ env = create_env()
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
 
-    parser = argparse.ArgumentParser(
-        description="Render a template using metadata from Redis and an optional index file",
+    parser = create_parser(
+        "Render a template using metadata from Redis and an optional index file"
     )
     parser.add_argument("template", help="Template file to render")
     parser.add_argument("output", help="File to write rendered template to")
@@ -356,18 +357,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--index",
         help="Optional path to index.json",
     )
-    add_log_argument(parser)
     parser.add_argument(
         "-c",
         "--config",
         default=str(DEFAULT_CONFIG),
         help="Path to YAML configuration file",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
     )
     return parser.parse_args(argv)
 

--- a/app/shell/py/pie/pie/render_study_json.py
+++ b/app/shell/py/pie/pie/render_study_json.py
@@ -13,7 +13,8 @@ import json
 from pathlib import Path
 from typing import Any, Iterable, List
 
-from pie.logging import logger, add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
 from pie.utils import read_json
 
 from .render.jinja import create_env
@@ -49,8 +50,8 @@ def render_study(index: dict[str, Any], questions: Iterable[dict[str, Any]]) -> 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
 
-    parser = argparse.ArgumentParser(
-        description="Render a study JSON file by expanding Jinja templates",
+    parser = create_parser(
+        "Render a study JSON file by expanding Jinja templates"
     )
     parser.add_argument("index", help="Path to the index JSON providing variables")
     parser.add_argument("study", help="Path to the source study JSON file")
@@ -58,13 +59,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "-o",
         "--output",
         help="Optional file to write the rendered JSON (defaults to stdout)",
-    )
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
     )
     return parser.parse_args(argv)
 

--- a/app/shell/py/pie/pie/store_files.py
+++ b/app/shell/py/pie/pie/store_files.py
@@ -7,7 +7,8 @@ import secrets
 from pathlib import Path
 from typing import Iterable, Sequence
 
-from pie.logging import add_log_argument, configure_logging, logger
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
 from pie.utils import write_yaml
 
 __all__ = ["main"]
@@ -31,22 +32,13 @@ def iter_files(path: Path) -> Iterable[Path]:
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Move files to s3/v2 and create metadata entries",
-    )
+    parser = create_parser("Move files to s3/v2 and create metadata entries")
     parser.add_argument("path", help="Path to file or directory to process")
     parser.add_argument(
         "-n",
         dest="limit",
         type=int,
         help="Limit number of files processed",
-    )
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
     )
     return parser.parse_args(list(argv) if argv is not None else None)
 

--- a/app/shell/py/pie/pie/update/author.py
+++ b/app/shell/py/pie/pie/update/author.py
@@ -7,7 +7,8 @@ from typing import Iterable, Sequence
 
 import yaml
 
-from pie.logging import add_log_argument, configure_logging, logger
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
 from .common import get_changed_files, update_files as common_update_files
 
 __all__ = ["main"]
@@ -30,8 +31,9 @@ def load_default_author(cfg_path: Path | None = None) -> str:
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
     default_author = load_default_author()
-    parser = argparse.ArgumentParser(
-        description="Update the author field in modified metadata files",
+    parser = create_parser(
+        "Update the author field in modified metadata files",
+        log_default="log/update-author.txt",
     )
     parser.add_argument(
         "-a",
@@ -46,13 +48,6 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "Directories, files, or glob patterns to scan; if omitted, changed files"
             " are read from git"
         ),
-    )
-    add_log_argument(parser, default="log/update-author.txt")
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
     )
     return parser.parse_args(list(argv) if argv is not None else None)
 

--- a/app/shell/py/pie/pie/update/index.py
+++ b/app/shell/py/pie/pie/update/index.py
@@ -18,7 +18,8 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 
 import redis
-from pie.logging import add_log_argument, configure_logging, logger
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
 from pie.metadata import load_metadata_pair
 
 
@@ -61,14 +62,13 @@ def flatten_index(index: Mapping[str, Mapping[str, Any]]) -> Iterable[tuple[str,
 
 def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Insert index values into a DragonflyDB/Redis instance",
+    parser = create_parser(
+        "Insert index values into a DragonflyDB/Redis instance"
     )
     parser.add_argument(
         "path",
         help="Path to index.json, a metadata file, or a directory containing YAML",
     )
-    add_log_argument(parser)
     parser.add_argument(
         "--host",
         default=os.getenv("REDIS_HOST", "dragonfly"),
@@ -79,12 +79,6 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
         type=int,
         default=int(os.getenv("REDIS_PORT", "6379")),
         help="Redis port (default: env REDIS_PORT or 6379)",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
     )
     return parser.parse_args(list(argv) if argv is not None else None)
 

--- a/app/shell/py/pie/pie/update/link_filters.py
+++ b/app/shell/py/pie/pie/update/link_filters.py
@@ -5,7 +5,8 @@ import re
 from pathlib import Path
 from typing import Iterable, Sequence
 
-from pie.logging import add_log_argument, configure_logging, logger
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
 
 FILTERS = [
     "link",
@@ -81,17 +82,11 @@ def process_file(path: Path) -> bool:
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
 
-    parser = argparse.ArgumentParser(
-        description="Best-effort rewrite of legacy link* filters to globals",
+    parser = create_parser(
+        "Best-effort rewrite of legacy link* filters to globals",
+        log_default="log/update-link-filters.txt",
     )
     parser.add_argument("paths", nargs="+", help="Files or directories to rewrite")
-    add_log_argument(parser, default="log/update-link-filters.txt")
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
-    )
     return parser.parse_args(list(argv) if argv is not None else None)
 
 

--- a/app/shell/py/pie/pie/update/pubdate.py
+++ b/app/shell/py/pie/pie/update/pubdate.py
@@ -4,7 +4,8 @@ import argparse
 from pathlib import Path
 from typing import Iterable, Sequence
 
-from pie.logging import add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import configure_logging
 from .common import get_changed_files, update_files as common_update_files
 from pie.utils import get_pubdate
 
@@ -14,15 +15,9 @@ __all__ = ["main"]
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Update the pubdate field in modified metadata files",
-    )
-    add_log_argument(parser, default="log/update-pubdate.txt")
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
+    parser = create_parser(
+        "Update the pubdate field in modified metadata files",
+        log_default="log/update-pubdate.txt",
     )
     return parser.parse_args(list(argv) if argv is not None else None)
 

--- a/app/shell/py/pie/pie/update/remove_name.py
+++ b/app/shell/py/pie/pie/update/remove_name.py
@@ -12,7 +12,8 @@ import argparse
 from pathlib import Path
 from typing import Iterable, Sequence, Tuple
 
-from pie.logging import add_log_argument, configure_logging
+from pie.cli import create_parser
+from pie.logging import configure_logging
 
 __all__ = ["main", "remove_name_fields"]
 
@@ -94,19 +95,10 @@ def walk_files(root: Path) -> Iterable[Path]:
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Remove deprecated 'name' fields from metadata files",
-    )
+    parser = create_parser("Remove deprecated 'name' fields from metadata files")
     parser.add_argument(
         "root",
         help="Root directory to scan",
-    )
-    add_log_argument(parser)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
     )
     return parser.parse_args(list(argv) if argv is not None else None)
 


### PR DESCRIPTION
## Summary
- add `pie.cli.create_parser` for shared `--log`/`--verbose` options
- refactor command modules to use the centralized parser helper

## Testing
- `pip install beautifulsoup4 loguru pyyaml emoji redis fakeredis flatten-dict`
- `PYTHONPATH=app/shell/py/pie pytest -q app/shell/py/pie/tests`

------
https://chatgpt.com/codex/tasks/task_e_689b920acce88321823bca73501b3309