### PR TITLE
Add script to run create-post in container

### DIFF
--- a/bin/create-post
+++ b/bin/create-post
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Description:
+#   Run the project's `create-post` command inside the Docker Compose
+#   `shell` service. This executes the command in the container using
+#   the current user's UID so generated files are owned by the invoking
+#   user.
+#
+# Usage:
+#   bin/create-post [ARGS...]
+#
+# Any arguments provided are forwarded directly to the `create-post`
+# command inside the container.
+
+set -euo pipefail
+
+COMPOSE_FILE="docker-compose.yml"
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  COMPOSE_FILE="dist/docker-compose.yml"
+fi
+
+exec docker compose -f "$COMPOSE_FILE" run --rm --build -u "$(id -u)" shell create-post "$@"


### PR DESCRIPTION
## Summary
- Add `bin/create-post` helper to invoke the `create-post` command inside the project's shell Docker container while preserving the current user's UID.

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest app/shell/py/pie/tests`


------
https://chatgpt.com/codex/tasks/task_e_689b95ae0f7c8321a6d69275dfdc3c47