### PR TITLE
Add unexpanded Jinja HTML check

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -126,6 +126,8 @@ test: $(BUILD_DIR)/.minify | $(LOG_DIR)
 	$(Q)check-page-title -x $(CFG_DIR)/check-page-title-exclude.yml $(BUILD_DIR)
 	$(call status,Check post-build artifacts)
 	$(Q)check-post-build -c $(CFG_DIR)/check-post-build.yml
+	$(call status,Check for unexpanded Jinja)
+	$(Q)check-unexpanded-jinja $(BUILD_DIR)
 
 # Create necessary build directories
 $(BUILD_DIR): | $(BUILD_SUBDIRS)

--- a/app/shell/py/pie/pie/check/unexpanded_jinja.py
+++ b/app/shell/py/pie/pie/check/unexpanded_jinja.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Fail if HTML files contain unexpanded Jinja template markers."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from bs4 import BeautifulSoup
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
+
+DEFAULT_LOG = "log/check-unexpanded-jinja.txt"
+
+
+def contains_unexpanded_jinja(text: str) -> bool:
+    """Return ``True`` when *text* includes Jinja markers."""
+    return "{{" in text or "{%" in text
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Return parsed command line arguments."""
+
+    parser = create_parser(
+        "Check for unexpanded Jinja code in HTML files.",
+        log_default=DEFAULT_LOG,
+    )
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="build",
+        help="Root directory containing HTML files",
+    )
+    return parser.parse_args(argv)
+
+
+def check_file(path: Path) -> bool:
+    """Return ``True`` if *path* is free of unexpanded Jinja."""
+    with open(path, "r", encoding="utf-8") as f:
+        soup = BeautifulSoup(f, "html.parser")
+
+    for text in soup.find_all(string=True):
+        if contains_unexpanded_jinja(text):
+            logger.error("Found unexpanded Jinja", path=str(path), snippet=text.strip())
+            return False
+
+    for tag in soup.find_all(True):
+        for value in tag.attrs.values():
+            values = value if isinstance(value, (list, tuple)) else [value]
+            for v in values:
+                if isinstance(v, str) and contains_unexpanded_jinja(v):
+                    logger.error("Found unexpanded Jinja", path=str(path), snippet=v.strip())
+                    return False
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Return ``0`` if HTML files are clean, ``1`` otherwise."""
+
+    args = parse_args(argv)
+    Path(args.log).parent.mkdir(parents=True, exist_ok=True)
+    configure_logging(args.verbose, args.log)
+
+    base = Path(args.directory)
+    html_files = list(base.rglob("*.html"))
+
+    ok = True
+    for html_file in html_files:
+        if not check_file(html_file):
+            ok = False
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -30,6 +30,7 @@ setup(
             'process-yaml=pie.process_yaml:main',
             'check-author=pie.check.author:main',
             'check-bad-jinja-output=pie.check.bad_jinja_output:main',
+            'check-unexpanded-jinja=pie.check.unexpanded_jinja:main',
             'indextree-json=pie.indextree_json:main',
             'gen-markdown-index=pie.gen_markdown_index:main',
             'check-page-title=pie.check.page_title:main',

--- a/app/shell/py/pie/tests/test_unexpanded_jinja.py
+++ b/app/shell/py/pie/tests/test_unexpanded_jinja.py
@@ -1,0 +1,39 @@
+import pytest
+
+from pie.check import unexpanded_jinja
+
+
+def test_contains_unexpanded_jinja_identifies_and_ignores():
+    """"{{a}}" -> True; "no jinja" -> False."""
+    assert unexpanded_jinja.contains_unexpanded_jinja("{{a}}")
+    assert unexpanded_jinja.contains_unexpanded_jinja("{% if %}")
+    assert not unexpanded_jinja.contains_unexpanded_jinja("no jinja")
+
+
+def test_main_detects_jinja_in_html(tmp_path):
+    """HTML with Jinja -> exit 1."""
+    build = tmp_path / "build"
+    build.mkdir()
+    html = build / "page.html"
+    html.write_text("<p>{{ a }}</p>", encoding="utf-8")
+    rc = unexpanded_jinja.main([str(build)])
+    assert rc == 1
+
+
+def test_main_writes_log_file(tmp_path):
+    """Clean HTML -> exit 0 and create log."""
+    build = tmp_path / "build"
+    build.mkdir()
+    html = build / "page.html"
+    html.write_text("<p>clean</p>", encoding="utf-8")
+    log = tmp_path / "det.log"
+    rc = unexpanded_jinja.main([str(build), "--log", str(log)])
+    assert rc == 0
+    assert log.exists()
+
+
+def test_parse_args_parses_options():
+    """parse_args returns directory and log paths."""
+    args = unexpanded_jinja.parse_args(["out", "--log", "log.txt"])
+    assert args.directory == "out"
+    assert args.log == "log.txt"


### PR DESCRIPTION
## Summary
- add `check-unexpanded-jinja` console script to scan HTML for leftover Jinja tags
- include entry point in setup
- test checking directories and logging
- run Jinja check as part of the `test` target in `build.mk`

## Testing
- `pip install beautifulsoup4`
- `pip install -r app/shell/py/pie/requirements.txt`
- `pip install -e app/shell/py/pie`
- `pytest app/shell/py/pie/tests -q`
- `make -f app/shell/mk/build.mk test` *(fails: minify not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ba0c0521083219a5ee7d4a20fd0ed