### PR TITLE
Ignore unexpanded Jinja in code blocks

### DIFF
--- a/app/shell/py/pie/pie/check/unexpanded_jinja.py
+++ b/app/shell/py/pie/pie/check/unexpanded_jinja.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail if HTML files contain unexpanded Jinja template markers."""
+"""Fail if HTML files contain unexpanded Jinja outside ``pre``/``code`` blocks."""
 
 from __future__ import annotations
 
@@ -39,11 +39,15 @@ def check_file(path: Path) -> bool:
         soup = BeautifulSoup(f, "html.parser")
 
     for text in soup.find_all(string=True):
+        if text.find_parent(["pre", "code"]):
+            continue
         if contains_unexpanded_jinja(text):
             logger.error("Found unexpanded Jinja", path=str(path), snippet=text.strip())
             return False
 
     for tag in soup.find_all(True):
+        if tag.name in {"pre", "code"} or tag.find_parent(["pre", "code"]):
+            continue
         for value in tag.attrs.values():
             values = value if isinstance(value, (list, tuple)) else [value]
             for v in values:

--- a/app/shell/py/pie/tests/test_unexpanded_jinja.py
+++ b/app/shell/py/pie/tests/test_unexpanded_jinja.py
@@ -20,6 +20,16 @@ def test_main_detects_jinja_in_html(tmp_path):
     assert rc == 1
 
 
+def test_main_ignores_jinja_in_pre_and_code(tmp_path):
+    """Jinja within ``pre``/``code`` -> exit 0."""
+    build = tmp_path / "build"
+    build.mkdir()
+    html = build / "page.html"
+    html.write_text("<pre>{{ a }}</pre><code>{{ b }}</code>", encoding="utf-8")
+    rc = unexpanded_jinja.main([str(build)])
+    assert rc == 0
+
+
 def test_main_writes_log_file(tmp_path):
     """Clean HTML -> exit 0 and create log."""
     build = tmp_path / "build"


### PR DESCRIPTION
## Summary
- avoid reporting unexpanded Jinja markers when they appear inside `<pre>` or `<code>` elements
- add regression test ensuring Jinja in code blocks is ignored

## Testing
- `pytest app/shell/py/pie/tests/test_unexpanded_jinja.py`

------
https://chatgpt.com/codex/tasks/task_e_689bc5a3a7cc8321ae5c33ed2137fcf0