### PR TITLE
Rename gen-markdown-index property to indextree and add upgrade script

### DIFF
--- a/app/shell/py/pie/pie/index_tree.py
+++ b/app/shell/py/pie/pie/index_tree.py
@@ -11,13 +11,13 @@ from pie.logging import logger
 
 def getopt_link(meta: Mapping[str, Any]) -> bool:
     """Return whether the item should be linked."""
-    section = meta.get("gen-markdown-index") or {}
+    section = meta.get("indextree") or {}
     return section.get("link", True)
 
 
 def getopt_show(meta: Mapping[str, Any]) -> bool:
     """Return whether the item should be shown."""
-    section = meta.get("gen-markdown-index") or {}
+    section = meta.get("indextree") or {}
     return section.get("show", True)
 
 

--- a/app/shell/py/pie/pie/update/indextree.py
+++ b/app/shell/py/pie/pie/update/indextree.py
@@ -1,0 +1,108 @@
+"""Rename deprecated 'gen-markdown-index' metadata to 'indextree'."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import yaml
+
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
+
+__all__ = ["main"]
+
+
+def _upgrade_yaml(path: Path) -> bool:
+    """Return ``True`` if *path* was updated."""
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    section = data.pop("gen-markdown-index", None)
+    if section is None:
+        return False
+    data["indextree"] = section
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return True
+
+
+def _upgrade_markdown(path: Path) -> bool:
+    """Return ``True`` if the front matter in *path* was updated."""
+
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    if not lines or not lines[0].startswith("---"):
+        return False
+    try:
+        end = next(i for i, line in enumerate(lines[1:], start=1) if line.startswith("---"))
+    except StopIteration:
+        return False
+    front = yaml.safe_load("".join(lines[1:end])) or {}
+    section = front.pop("gen-markdown-index", None)
+    if section is None:
+        return False
+    front["indextree"] = section
+    new_front = yaml.safe_dump(front, sort_keys=False).splitlines(keepends=True)
+    path.write_text("".join(["---\n", *new_front, *lines[end:]]), encoding="utf-8")
+    return True
+
+
+def upgrade_file(path: Path) -> bool:
+    """Upgrade metadata in *path*."""
+
+    if path.suffix.lower() in {".yml", ".yaml"}:
+        return _upgrade_yaml(path)
+    if path.suffix.lower() == ".md":
+        return _upgrade_markdown(path)
+    return False
+
+
+def walk_files(paths: Iterable[Path]) -> Iterable[Path]:
+    """Yield metadata files under *paths*."""
+
+    for p in paths:
+        if p.is_dir():
+            yield from (
+                child
+                for child in p.rglob("*")
+                if child.is_file() and child.suffix.lower() in {".md", ".yml", ".yaml"}
+            )
+        else:
+            yield p
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = create_parser(
+        "Rename 'gen-markdown-index' metadata keys to 'indextree'",
+        log_default="log/update-indextree.txt",
+    )
+    parser.add_argument("paths", nargs="+", help="Files or directories to scan")
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    configure_logging(args.verbose, args.log)
+    paths = [Path(p) for p in args.paths]
+    changes: list[str] = []
+    checked = 0
+    for fp in walk_files(paths):
+        checked += 1
+        try:
+            changed = upgrade_file(fp)
+        except Exception as exc:  # pragma: no cover - unexpected failures
+            logger.warning("Failed to upgrade file", path=str(fp), error=str(exc))
+            continue
+        if changed:
+            msg = f"{fp}: gen-markdown-index -> indextree"
+            logger.info(msg)
+            changes.append(msg)
+    for msg in changes:
+        print(msg)
+    print(f"{checked} {'file' if checked == 1 else 'files'} checked")
+    print(f"{len(changes)} {'file' if len(changes) == 1 else 'files'} changed")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())
+

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -23,6 +23,7 @@ setup(
             'update-author=pie.update.author:main',
             'update-link-filters=pie.update.link_filters:main',
             'remove-name=pie.update.remove_name:main',
+            'upgrade-indextree=pie.update.indextree:main',
             'picasso=pie.build.picasso:main',
             'render-jinja-template=pie.render.jinja:main',
             'render-study-json=pie.render_study_json:main',

--- a/app/shell/py/pie/tests/test_gen_markdown_index.py
+++ b/app/shell/py/pie/tests/test_gen_markdown_index.py
@@ -11,12 +11,12 @@ def test_show_property(tmp_path, monkeypatch):
     """Nodes with 'show: false' are skipped."""
     (tmp_path / "alpha.yml").write_text("id: alpha\ntitle: Alpha\n")
     (tmp_path / "beta.yml").write_text(
-        "id: beta\ntitle: Beta\n" "gen-markdown-index:\n  show: false\n",
+        "id: beta\ntitle: Beta\n" "indextree:\n  show: false\n",
     )
     hidden = tmp_path / "hidden"
     hidden.mkdir()
     (hidden / "index.yml").write_text(
-        "id: hidden\ntitle: Hidden\n" "gen-markdown-index:\n  show: false\n",
+        "id: hidden\ntitle: Hidden\n" "indextree:\n  show: false\n",
     )
     (hidden / "child.yml").write_text("id: child\ntitle: Child\n")
 
@@ -94,7 +94,7 @@ def test_link_false_and_recursion(tmp_path, monkeypatch):
     meta_alpha = {
         "id": "alpha",
         "title": "Alpha",
-        "gen-markdown-index": {"link": False},
+        "indextree": {"link": False},
     }
     meta_group = {"id": "group", "title": "Group"}
     meta_child = {"id": "child", "title": "Child"}

--- a/app/shell/py/pie/tests/test_indextree_json.py
+++ b/app/shell/py/pie/tests/test_indextree_json.py
@@ -87,19 +87,19 @@ def test_process_dir_honours_show_and_link(tmp_path, monkeypatch):
         fake,
         "src/alpha/beta.yml",
         "beta",
-        {"title": "Beta", "url": "/alpha/beta.html", "gen-markdown-index": {"link": False}},
+        {"title": "Beta", "url": "/alpha/beta.html", "indextree": {"link": False}},
     )
     save_meta(
         fake,
         "src/gamma.yml",
         "gamma",
-        {"title": "Gamma", "url": "/gamma.html", "gen-markdown-index": {"show": False}},
+        {"title": "Gamma", "url": "/gamma.html", "indextree": {"show": False}},
     )
     save_meta(
         fake,
         "src/delta/index.yml",
         "delta",
-        {"title": "Delta", "url": "/delta/index.html", "gen-markdown-index": {"show": False}},
+        {"title": "Delta", "url": "/delta/index.html", "indextree": {"show": False}},
     )
     save_meta(fake, "src/delta/epsilon.yml", "epsilon", {"title": "Epsilon", "url": "/delta/epsilon.html"})
 

--- a/app/shell/py/pie/tests/test_load_from_redis.py
+++ b/app/shell/py/pie/tests/test_load_from_redis.py
@@ -19,7 +19,7 @@ def test_build_from_redis_used(monkeypatch):
             "id": "doc1",
             "title": "Title",
             "url": "URL",
-            "gen-markdown-index": {"link": "1", "show": "0"},
+            "indextree": {"link": "1", "show": "0"},
         }
 
     monkeypatch.setattr(index_tree, "get_metadata_by_path", fake_get_metadata_by_path)
@@ -31,7 +31,7 @@ def test_build_from_redis_used(monkeypatch):
         "id": "doc1",
         "title": "Title",
         "url": "URL",
-        "gen-markdown-index": {"link": "1", "show": "0"},
+        "indextree": {"link": "1", "show": "0"},
     }
     assert calls == ["doc1."]
 

--- a/app/shell/py/pie/tests/update/test_indextree.py
+++ b/app/shell/py/pie/tests/update/test_indextree.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pie.update import indextree
+
+
+def test_renames_metadata_key(tmp_path: Path, capsys) -> None:
+    """The upgrade script renames 'gen-markdown-index' keys."""
+
+    src = tmp_path / "src"
+    src.mkdir()
+
+    yml = src / "doc.yml"
+    yml.write_text("gen-markdown-index:\n  show: false\n", encoding="utf-8")
+
+    md = src / "doc.md"
+    md.write_text("---\ngen-markdown-index:\n  link: false\n---\n", encoding="utf-8")
+
+    indextree.main([str(src)])
+
+    assert "gen-markdown-index" not in yml.read_text(encoding="utf-8")
+    assert "indextree" in yml.read_text(encoding="utf-8")
+
+    assert "gen-markdown-index" not in md.read_text(encoding="utf-8")
+    assert "indextree" in md.read_text(encoding="utf-8")
+
+    out_lines = capsys.readouterr().out.strip().splitlines()
+    assert f"{yml}: gen-markdown-index -> indextree" in out_lines
+    assert f"{md}: gen-markdown-index -> indextree" in out_lines
+    assert "2 files checked" in out_lines
+    assert "2 files changed" in out_lines
+

--- a/docs/guides/gen-markdown-index.md
+++ b/docs/guides/gen-markdown-index.md
@@ -6,4 +6,4 @@
 usage: gen-markdown-index [ROOT_DIR]
 ```
 
-`ROOT_DIR` defaults to the current directory. To exclude an item from the output, set `gen-markdown-index.show` to `false` in its metadata. To omit a link, set `gen-markdown-index.link` to `false`. When a directory is hidden this way, its children are still processed at the same indentation level.
+`ROOT_DIR` defaults to the current directory. To exclude an item from the output, set `indextree.show` to `false` in its metadata. To omit a link, set `indextree.link` to `false`. When a directory is hidden this way, its children are still processed at the same indentation level.

--- a/docs/guides/react-index-tree.md
+++ b/docs/guides/react-index-tree.md
@@ -10,7 +10,7 @@ your project.
 
 The `indextree-json` console script can generate the required JSON by
 scanning a directory of YAML metadata files and producing nodes for each
-file and subdirectory. Entries honour the same `gen-markdown-index`
+file and subdirectory. Entries honour the same `indextree`
 options (`show` and `link`) used by the Markdown index generator. When
 linking is enabled, the `url` property is copied from the metadata
 without modification:

--- a/src/examples/index.yml
+++ b/src/examples/index.yml
@@ -1,6 +1,6 @@
 id: examples
 title: Examples
-gen-markdown-index:
+indextree:
   link: false
 author: Brian Lee
 pubdate: Aug 12, 2025

--- a/src/gen-markdown-index/index.yml
+++ b/src/gen-markdown-index/index.yml
@@ -1,6 +1,6 @@
 title: gen-markdown-index
 id: dist_gen_markdown_index
-gen-markdown-index:
+indextree:
   link: false
   show: true
 author: Brian Lee


### PR DESCRIPTION
## Summary
- switch metadata lookups to new `indextree` key
- add `upgrade-indextree` script to rename old metadata and expose as console command
- document new metadata key and provide regression tests

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest app/shell/py/pie/tests`

------
https://chatgpt.com/codex/tasks/task_e_689bcd2a692c832180932e6934acfe33