### PR TITLE
feat: add store-file helper script

### DIFF
--- a/bin/store-file
+++ b/bin/store-file
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Description:
+#   Run the project's `store-file` command inside the Docker Compose
+#   `shell` service. This executes the command in the container using
+#   the current user's UID so generated files are owned by the invoking
+#   user.
+#
+# Usage:
+#   bin/store-file [ARGS...]
+#
+# Any arguments provided are forwarded directly to the `store-file`
+# command inside the container.
+
+set -euo pipefail
+
+COMPOSE_FILE="docker-compose.yml"
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  COMPOSE_FILE="dist/docker-compose.yml"
+fi
+
+exec docker compose -f "$COMPOSE_FILE" run --rm -u "$(id -u)" --entrypoint store-file shell "$@"


### PR DESCRIPTION
## Summary
- add bin/store-file to run store-file inside the shell service

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_689ca7b2feb08321abdc1d9a72550fdd