### PR TITLE
docs: add sync service guide

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -23,6 +23,7 @@ concepts and data formats, see the
 - [pdoc-service.md](pdoc-service.md) – generate API documentation.
 - [react-index-tree.md](react-index-tree.md) – browse index data interactively.
 - [store-files.md](store-files.md) – move files into S3 staging and create metadata.
+- [sync-service.md](sync-service.md) – upload site files to S3 using the sync container.
 - [webp-service.md](webp-service.md) – convert images to WebP using the helper
   container.
 

--- a/docs/guides/sync-service.md
+++ b/docs/guides/sync-service.md
@@ -1,0 +1,19 @@
+# sync service
+
+The `sync` service uploads site files to an S3 bucket using [`s3cmd`](https://s3tools.org/s3cmd). It uses the image under `app/s3` and runs `/app/bin/sync` in a loop.
+
+## Directories
+
+- `../s3` – host directory whose contents are uploaded.
+
+## Running the service
+
+Use `redo.mk` to build and start the container:
+
+```bash
+r sync
+```
+
+The service mirrors the host `s3/` directory to the bucket specified by `S3_BUCKET_PATH` (default `s3://press`). Credentials come from the file at `S3CFG_PATH` (default `/root/.s3cfg`).
+
+Files removed locally are deleted from the bucket via `s3cmd --delete-removed --delete-after --acl-public`.


### PR DESCRIPTION
## Summary
- document sync service for uploading site files to S3
- link the new guide in the guides index

## Testing
- `pip install beautifulsoup4`
- `pip install loguru PyYAML redis fakeredis`
- `pip install flatten-dict emoji`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cb8d69c508321966d0bfb44e51508