### PR TITLE
Allow overriding citation in link helpers

### DIFF
--- a/app/shell/py/pie/tests/test_render_template_extra.py
+++ b/app/shell/py/pie/tests/test_render_template_extra.py
@@ -102,6 +102,24 @@ def test_wrapper_functions():
     assert ">S<" in html and "I" not in html
 
 
+@pytest.mark.parametrize(
+    "func, expected",
+    [
+        (render_template.linktitle, "Custom Citation"),
+        (render_template.link_icon_title, "Custom Citation"),
+        (render_template.linkcap, "Custom citation"),
+        (render_template.linkicon, "custom citation"),
+        (render_template.link, "custom citation"),
+        (render_template.linkshort, "custom citation"),
+    ],
+)
+def test_wrapper_functions_override_citation(func, expected):
+    desc = {"citation": "ignored", "url": "/f", "icon": "I"}
+    html = func(desc, citation="custom citation")
+    assert expected in html
+    assert "ignored" not in html
+
+
 def test_extract_front_matter_invalid_yaml(tmp_path):
     """Bad YAML front matter -> None."""
     md = tmp_path / "f.md"

--- a/docs/reference/link-globals.md
+++ b/docs/reference/link-globals.md
@@ -18,8 +18,9 @@ accepts a few optional parameters to control the output:
 - `use_icon` – when `True` (default) any `icon` field in the metadata is
   prefixed to the link text.  Set to `False` to suppress icons.
 - `anchor` – appends a fragment identifier (`#anchor`) to the URL when provided.
-- `citation` – selects which citation field to render.  The default `"citation"`
-  uses the main citation value; pass `"short"` to use `citation.short`.
+- `citation` – selects which citation field to render or overrides the link text.
+  The default `"citation"` uses the main citation value; pass `"short"` to use
+  `citation.short` or provide a custom string to replace the citation entirely.
 
 When the `citation` field is itself a mapping with `author`, `year`, and an
 optional `page`, the helper formats the text using Chicago style
@@ -37,6 +38,12 @@ renders as:
 
 ```html
 <a href="/humerus.html#deltoid_tuberosity" class="internal-link">Deltoid Tuberosity</a>
+```
+
+You can also override the citation text:
+
+```jinja
+{{ linktitle("opcalc", citation="the calculator") }}
 ```
 
 Bibliographic citations render similarly:

--- a/src/examples/link-globals.md
+++ b/src/examples/link-globals.md
@@ -29,6 +29,16 @@ Output:
 
 {{ linktitle({"citation": "home", "url": "/"}, anchor="#example") }}
 
+## linktitle with custom citation
+
+```jinja
+{% raw %}{{ linktitle("quickstart", citation="custom citation") }}{% endraw %}
+```
+
+Output:
+
+{{ linktitle("quickstart", citation="custom citation") }}
+
 ## linkcap
 
 ```jinja


### PR DESCRIPTION
## Summary
- allow `render_link` and `link*` helpers to override citation text
- document custom citation support and add example
- cover citation overrides in tests
- refactor citation selection into helper for clearer logic

## Testing
- `pytest app/shell/py/pie/tests/test_render_template.py app/shell/py/pie/tests/test_render_template_extra.py`


------
https://chatgpt.com/codex/tasks/task_e_689cd5b3ad5c83218c0838d64b315d3f