### PR TITLE
Use chained glob patterns for metadata scans

### DIFF
--- a/app/shell/py/pie/pie/check/author.py
+++ b/app/shell/py/pie/pie/check/author.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from typing import Iterable
+from itertools import chain
 
 from pie.cli import create_parser
 from pie.logging import logger, configure_logging
@@ -36,11 +37,10 @@ def _iter_metadata(root: Path) -> Iterable[tuple[list[Path], dict | None]]:
     companion Markdown/YAML files are merged.
     """
 
-    exts = {".md", ".yml", ".yaml"}
     processed: set[Path] = set()
 
-    for path in root.rglob("*"):
-        if not path.is_file() or path.suffix.lower() not in exts:
+    for path in chain(root.rglob("*.md"), root.rglob("*.yml"), root.rglob("*.yaml")):
+        if not path.is_file():
             continue
         base = path.with_suffix("")
         if base in processed:

--- a/app/shell/py/pie/pie/update/author.py
+++ b/app/shell/py/pie/pie/update/author.py
@@ -4,6 +4,7 @@ import argparse
 import glob
 from pathlib import Path
 from typing import Iterable, Sequence
+from itertools import chain
 
 import yaml
 
@@ -79,8 +80,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 if not p.exists():
                     continue
                 if p.is_dir():
-                    for child in p.rglob("*"):
-                        if child.suffix in {".md", ".yml", ".yaml"}:
+                    for child in chain(
+                        p.rglob("*.md"), p.rglob("*.yml"), p.rglob("*.yaml")
+                    ):
+                        if child.is_file():
                             changed.append(
                                 child.relative_to(cwd) if child.is_absolute() else child
                             )

--- a/app/shell/py/pie/pie/update/remove_name.py
+++ b/app/shell/py/pie/pie/update/remove_name.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from typing import Iterable, Sequence, Tuple
+from itertools import chain
 
 from pie.cli import create_parser
 from pie.logging import configure_logging
@@ -89,8 +90,8 @@ def remove_name_fields(paths: Iterable[Path]) -> tuple[list[str], int]:
 def walk_files(root: Path) -> Iterable[Path]:
     """Yield metadata files under *root*."""
 
-    for path in root.rglob("*"):
-        if path.suffix.lower() in {".md", ".yml", ".yaml"} and path.is_file():
+    for path in chain(root.rglob("*.md"), root.rglob("*.yml"), root.rglob("*.yaml")):
+        if path.is_file():
             yield path
 
 

--- a/app/shell/py/pie/tests/test_check_author.py
+++ b/app/shell/py/pie/tests/test_check_author.py
@@ -11,6 +11,10 @@ def test_main_reports_missing(tmp_path: Path, monkeypatch) -> None:
     src.mkdir()
     yml = src / "doc.yml"
     yml.write_text("title: Test\n", encoding="utf-8")
+    md = src / "doc.md"
+    md.write_text("---\ntitle: Test\n---\n", encoding="utf-8")
+    yaml_file = src / "other.yaml"
+    yaml_file.write_text("title: Other\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     rc = check_author.main(["-l", str(tmp_path / "log.txt")])
     assert rc == 1
@@ -22,6 +26,10 @@ def test_main_passes_and_logs(tmp_path: Path, monkeypatch) -> None:
     src.mkdir()
     yml = src / "doc.yml"
     yml.write_text("title: Test\nauthor: Jane Doe\n", encoding="utf-8")
+    md = src / "doc.md"
+    md.write_text("---\ntitle: Test\nauthor: Jane Doe\n---\n", encoding="utf-8")
+    yaml_file = src / "other.yaml"
+    yaml_file.write_text("title: Other\nauthor: Jane Doe\n", encoding="utf-8")
     log = tmp_path / "log.txt"
     monkeypatch.chdir(tmp_path)
     rc = check_author.main(["-l", str(log)])

--- a/app/shell/py/pie/tests/update/test_remove_name.py
+++ b/app/shell/py/pie/tests/update/test_remove_name.py
@@ -16,14 +16,19 @@ def test_removes_name_fields(tmp_path: Path, capsys) -> None:
     md = src / "doc.md"
     md.write_text("---\nname: Old\n---\nbody\n", encoding="utf-8")
 
+    yaml_file = src / "doc.yaml"
+    yaml_file.write_text("title: Test\nname: Old\n", encoding="utf-8")
+
     remove_name.main([str(src)])
 
     assert "name:" not in yml.read_text(encoding="utf-8")
     assert "name:" not in md.read_text(encoding="utf-8")
+    assert "name:" not in yaml_file.read_text(encoding="utf-8")
 
     out_lines = capsys.readouterr().out.strip().splitlines()
     assert f"{yml}: Old" in out_lines
     assert f"{md}: Old" in out_lines
-    assert "2 files checked" in out_lines
-    assert "2 files changed" in out_lines
+    assert f"{yaml_file}: Old" in out_lines
+    assert "3 files checked" in out_lines
+    assert "3 files changed" in out_lines
 

--- a/app/shell/py/pie/tests/update/test_update_author.py
+++ b/app/shell/py/pie/tests/update/test_update_author.py
@@ -38,6 +38,9 @@ def test_updates_yaml_from_markdown_change(tmp_path: Path, monkeypatch, capsys) 
     log_text = (tmp_path / "log/update-author.txt").read_text(encoding="utf-8")
     assert "src/doc.md: undefined -> Brian Lee" in log_text
     assert "src/doc.yml: Jane Doe -> Brian Lee" in log_text
+    assert "src/other.yaml: Jane Doe -> Brian Lee" in log_text
+    assert "src/other.yaml: Jane Doe -> Brian Lee" in log_text
+    assert "src/other.yaml: Jane Doe -> Brian Lee" in log_text
 
 
 def test_updates_markdown_frontmatter(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -129,6 +132,8 @@ def test_scans_directory(tmp_path: Path, monkeypatch, capsys) -> None:
     md.write_text("---\ntitle: Test\n---\n", encoding="utf-8")
     yml = src / "doc.yml"
     yml.write_text("title: Test\nauthor: Jane Doe\n", encoding="utf-8")
+    yaml_file = src / "other.yaml"
+    yaml_file.write_text("title: Test\nauthor: Jane Doe\n", encoding="utf-8")
 
     cfg = tmp_path / "cfg"
     cfg.mkdir()
@@ -139,16 +144,19 @@ def test_scans_directory(tmp_path: Path, monkeypatch, capsys) -> None:
     update_author.main(["src"])
     assert "author: Brian Lee" in yml.read_text(encoding="utf-8")
     assert "author: Brian Lee" in md.read_text(encoding="utf-8")
+    assert "author: Brian Lee" in yaml_file.read_text(encoding="utf-8")
     captured = capsys.readouterr()
     lines = captured.out.strip().splitlines()
     assert "src/doc.md: undefined -> Brian Lee" in lines
     assert "src/doc.yml: Jane Doe -> Brian Lee" in lines
-    assert "2 files checked" in lines
-    assert "2 files changed" in lines
-    assert len(lines) == 4
+    assert "src/other.yaml: Jane Doe -> Brian Lee" in lines
+    assert "3 files checked" in lines
+    assert "3 files changed" in lines
+    assert len(lines) == 5
     log_text = (tmp_path / "log/update-author.txt").read_text(encoding="utf-8")
     assert "src/doc.md: undefined -> Brian Lee" in log_text
     assert "src/doc.yml: Jane Doe -> Brian Lee" in log_text
+    assert "src/other.yaml: Jane Doe -> Brian Lee" in log_text
 
 
 def test_scans_file(tmp_path: Path, monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary
- limit metadata scans to markdown and yaml files using chained glob patterns
- remove redundant suffix checks in update utilities
- expand tests to cover `.md`, `.yml`, and `.yaml` inputs

## Testing
- `pytest` *(fails: ImportError while importing tests; 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689bcbca997083219647f41df80504c8