### PR TITLE
feat: add configurable base URL for store-files

### DIFF
--- a/app/shell/py/pie/pie/templates/metadata.yml.jinja
+++ b/app/shell/py/pie/pie/templates/metadata.yml.jinja
@@ -1,0 +1,4 @@
+id: {{ file_id }}
+author: ""
+pubdate: ""
+url: {{ baseurl }}/v2/files/0/{{ file_id }}

--- a/docs/guides/store-files.md
+++ b/docs/guides/store-files.md
@@ -5,16 +5,19 @@
 ## Usage
 
 ```bash
-store-files [-n LIMIT] <path>
+store-files [-n LIMIT] [-c CONFIG] <path>
 ```
 
 - `path` may point to a single file or a directory; directories are processed recursively.
 - `-n LIMIT` optionally restricts how many files are handled in one run.
+- `-c CONFIG` path to a configuration file. Defaults to `cfg/store-files.yml` and is ignored if missing. When a path is explicitly supplied the command exits with an error if the file does not exist.
 
 Each processed file is:
 
 1. Assigned a random identifier.
 2. Moved to `s3/v2/files/0/<id>`.
-3. Given a YAML metadata file at `src/static/files/<id>.yml` containing `id`, `author`, `pubdate`, and `url` fields.
+3. Given a YAML metadata file at `src/static/files/<id>.yml` rendered from the `metadata.yml.jinja` template containing
+   `id`, `author`, `pubdate`, and `url` fields. The `url` is built from `{baseurl}/v2/files/0/{file_id}` where `baseurl` comes
+   from the configuration file (defaulting to an empty string).
 
 Progress information is logged to the console and can be redirected using the standard `--log` option.


### PR DESCRIPTION
## Summary
- allow `store-files` to read optional config file for base URL
- build metadata URLs using a Jinja template
- render metadata YAML via the external `metadata.yml.jinja` template
- document new `--config` flag, templated metadata rendering, and template file

## Testing
- `pip install beautifulsoup4 pyyaml loguru`
- `pytest app/shell/py/pie/tests/test_store_files.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cedbd38dc8321a2d9b484559ab271