### PR TITLE
feat: support figure captions

### DIFF
--- a/app/shell/py/pie/pie/render/jinja.py
+++ b/app/shell/py/pie/pie/render/jinja.py
@@ -198,6 +198,33 @@ def linkshort(desc, anchor: str | None = None, citation: str | None = None):
         return render_link(desc, use_icon=False, citation="short", anchor=anchor)
     return render_link(desc, use_icon=False, citation=citation, anchor=anchor)
 
+
+def figure(desc):
+    """Return an HTML ``<figure>`` block for ``desc``.
+
+    ``desc`` may be either a metadata dictionary or a string key which will be
+    resolved via :func:`get_cached_metadata`.  The figure uses the ``url`` field
+    for the image ``src`` attribute and the ``title`` as the ``alt`` text.
+    The caption is taken from ``desc['figure']['caption']`` when provided and
+    otherwise falls back to ``title``.  Images are marked with
+    ``loading="lazy"``.
+    """
+
+    if isinstance(desc, str):
+        desc = get_cached_metadata(desc)
+    elif not isinstance(desc, dict):
+        logger.error("Invalid descriptor type", type=str(type(desc)))
+        raise SystemExit(1)
+
+    title = desc.get("title", "")
+    caption = desc.get("figure", {}).get("caption", title)
+    url = desc.get("url")
+
+    return (
+        f'<figure><img src="{url}" alt="{title}" '
+        f'loading="lazy"/><figcaption>{caption}</figcaption></figure>'
+    )
+
 def cite(*names: str) -> str:
     """Return Chicago style citation links for ``names``.
 
@@ -359,6 +386,7 @@ def create_env():
     env.globals["link_icon_title"] = link_icon_title
     env.globals["linkicon"] = linkicon
     env.globals["linkshort"] = linkshort
+    env.globals["figure"] = figure
     env.filters["get_desc"] = get_desc
     env.globals["render_jinja"] = render_jinja
     env.globals["to_alpha_index"] = to_alpha_index

--- a/app/shell/py/pie/tests/test_figure_global.py
+++ b/app/shell/py/pie/tests/test_figure_global.py
@@ -1,0 +1,28 @@
+from pie.render import jinja as render_template
+
+
+def test_figure_prefers_caption_metadata():
+    desc = {
+        "title": "Option Pricing & Greeks Calculator screenshot",
+        "url": "https://koreanbriancom.sfo3.cdn.digitaloceanspaces.com/v2/files/0/VlYZ9h1q",
+        "figure": {"caption": "Option Pricing & Greeks Calculator"},
+    }
+    expected = (
+        "<figure><img src=\"https://koreanbriancom.sfo3.cdn.digitaloceanspaces.com/v2/files/0/VlYZ9h1q\" "
+        "alt=\"Option Pricing & Greeks Calculator screenshot\" loading=\"lazy\"/>"
+        "<figcaption>Option Pricing & Greeks Calculator</figcaption></figure>"
+    )
+    assert render_template.figure(desc) == expected
+
+
+def test_figure_uses_title_when_caption_missing():
+    desc = {
+        "title": "Option Pricing & Greeks Calculator screenshot",
+        "url": "https://koreanbriancom.sfo3.cdn.digitaloceanspaces.com/v2/files/0/VlYZ9h1q",
+    }
+    expected = (
+        "<figure><img src=\"https://koreanbriancom.sfo3.cdn.digitaloceanspaces.com/v2/files/0/VlYZ9h1q\" "
+        "alt=\"Option Pricing & Greeks Calculator screenshot\" loading=\"lazy\"/>"
+        "<figcaption>Option Pricing & Greeks Calculator screenshot</figcaption></figure>"
+    )
+    assert render_template.figure(desc) == expected

--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -17,6 +17,9 @@ for details on the structure of this metadata.
 - `link(desc, anchor=None)` and related helpers `linktitle`, `linkcap`,
   `link_icon_title`, `linkicon`, and `linkshort` – format metadata into HTML
   anchors. See [link-globals.md](link-globals.md) for details.
+- `figure(desc)` – generate a `<figure>` with a lazy-loaded `<img>` and a
+  caption taken from `desc['figure']['caption']` when present, otherwise the
+  entry's `title`.
 
 Example:
 


### PR DESCRIPTION
## Summary
- allow `figure` Jinja helper to use `figure.caption` metadata, defaulting to `title`
- document the new caption resolution behavior
- test caption metadata and title fallback

## Testing
- `pip install -q -r app/shell/py/pie/requirements.txt`
- `pytest app/shell/py/pie/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf1d01aec83219d2212797d142c71