### PR TITLE
Prefer YAML for metadata updates

### DIFF
--- a/app/shell/py/pie/pie/update/common.py
+++ b/app/shell/py/pie/pie/update/common.py
@@ -125,7 +125,12 @@ def update_files(paths: Iterable[Path], field: str, value: str) -> tuple[list[st
         if metadata and "path" in metadata:
             file_paths.update(Path(p) for p in metadata["path"])
 
-        for fp in file_paths:
+        yaml_files = sorted(
+            [fp for fp in file_paths if fp.suffix in {".yml", ".yaml"}]
+        )
+        target_files = yaml_files or sorted(file_paths)
+
+        for fp in target_files:
             if not fp.exists():
                 continue
             checked += 1

--- a/app/shell/py/pie/tests/update/test_common.py
+++ b/app/shell/py/pie/tests/update/test_common.py
@@ -81,8 +81,8 @@ def test_replace_field_updates_markdown_frontmatter(tmp_path: Path) -> None:
     assert "author: New" in md.read_text(encoding="utf-8")
 
 
-def test_update_files_updates_all_related(tmp_path: Path, monkeypatch: object) -> None:
-    """Both Markdown and YAML files are updated for a changed path."""
+def test_update_files_prefers_yaml(tmp_path: Path, monkeypatch: object) -> None:
+    """Only YAML is updated when both Markdown and YAML exist."""
     src = tmp_path / "src"
     src.mkdir()
     md = src / "doc.md"
@@ -92,10 +92,7 @@ def test_update_files_updates_all_related(tmp_path: Path, monkeypatch: object) -
 
     monkeypatch.chdir(tmp_path)
     messages, checked = common.update_files([Path("src/doc.md")], "author", "New")
-    assert checked == 2
-    assert set(messages) == {
-        "src/doc.md: Old -> New",
-        "src/doc.yml: Old -> New",
-    }
-    assert "author: New" in md.read_text(encoding="utf-8")
+    assert checked == 1
+    assert set(messages) == {"src/doc.yml: Old -> New"}
+    assert "author: Old" in md.read_text(encoding="utf-8")
     assert "author: New" in yml.read_text(encoding="utf-8")

--- a/app/shell/py/pie/tests/update/test_update_author.py
+++ b/app/shell/py/pie/tests/update/test_update_author.py
@@ -27,20 +27,16 @@ def test_updates_yaml_from_markdown_change(tmp_path: Path, monkeypatch, capsys) 
 
     update_author.main([])
     assert "author: Brian Lee" in yml.read_text(encoding="utf-8")
-    assert "author: Brian Lee" in md.read_text(encoding="utf-8")
+    assert "author:" not in md.read_text(encoding="utf-8")
     captured = capsys.readouterr()
     lines = captured.out.strip().splitlines()
-    assert "src/doc.md: undefined -> Brian Lee" in lines
     assert "src/doc.yml: Jane Doe -> Brian Lee" in lines
-    assert "2 files checked" in lines
-    assert "2 files changed" in lines
-    assert len(lines) == 4
+    assert "1 file checked" in lines
+    assert "1 file changed" in lines
+    assert len(lines) == 3
+    assert len(lines) == 3
     log_text = (tmp_path / "log/update-author.txt").read_text(encoding="utf-8")
-    assert "src/doc.md: undefined -> Brian Lee" in log_text
     assert "src/doc.yml: Jane Doe -> Brian Lee" in log_text
-    assert "src/other.yaml: Jane Doe -> Brian Lee" in log_text
-    assert "src/other.yaml: Jane Doe -> Brian Lee" in log_text
-    assert "src/other.yaml: Jane Doe -> Brian Lee" in log_text
 
 
 def test_updates_markdown_frontmatter(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -143,18 +139,16 @@ def test_scans_directory(tmp_path: Path, monkeypatch, capsys) -> None:
 
     update_author.main(["src"])
     assert "author: Brian Lee" in yml.read_text(encoding="utf-8")
-    assert "author: Brian Lee" in md.read_text(encoding="utf-8")
     assert "author: Brian Lee" in yaml_file.read_text(encoding="utf-8")
+    assert "author:" not in md.read_text(encoding="utf-8")
     captured = capsys.readouterr()
     lines = captured.out.strip().splitlines()
-    assert "src/doc.md: undefined -> Brian Lee" in lines
     assert "src/doc.yml: Jane Doe -> Brian Lee" in lines
     assert "src/other.yaml: Jane Doe -> Brian Lee" in lines
-    assert "3 files checked" in lines
-    assert "3 files changed" in lines
-    assert len(lines) == 5
+    assert "2 files checked" in lines
+    assert "2 files changed" in lines
+    assert len(lines) == 4
     log_text = (tmp_path / "log/update-author.txt").read_text(encoding="utf-8")
-    assert "src/doc.md: undefined -> Brian Lee" in log_text
     assert "src/doc.yml: Jane Doe -> Brian Lee" in log_text
     assert "src/other.yaml: Jane Doe -> Brian Lee" in log_text
 
@@ -176,16 +170,14 @@ def test_scans_file(tmp_path: Path, monkeypatch, capsys) -> None:
 
     update_author.main(["src/doc.md"])
     assert "author: Brian Lee" in yml.read_text(encoding="utf-8")
-    assert "author: Brian Lee" in md.read_text(encoding="utf-8")
+    assert "author:" not in md.read_text(encoding="utf-8")
     captured = capsys.readouterr()
     lines = captured.out.strip().splitlines()
-    assert "src/doc.md: undefined -> Brian Lee" in lines
     assert "src/doc.yml: Jane Doe -> Brian Lee" in lines
-    assert "2 files checked" in lines
-    assert "2 files changed" in lines
-    assert len(lines) == 4
+    assert "1 file checked" in lines
+    assert "1 file changed" in lines
+    assert len(lines) == 3
     log_text = (tmp_path / "log/update-author.txt").read_text(encoding="utf-8")
-    assert "src/doc.md: undefined -> Brian Lee" in log_text
     assert "src/doc.yml: Jane Doe -> Brian Lee" in log_text
 
 
@@ -207,16 +199,14 @@ def test_overrides_author_argument(tmp_path: Path, monkeypatch, capsys) -> None:
 
     update_author.main(["-a", "Chris R."])
     assert "author: Chris R." in yml.read_text(encoding="utf-8")
-    assert "author: Chris R." in md.read_text(encoding="utf-8")
+    assert "author:" not in md.read_text(encoding="utf-8")
     captured = capsys.readouterr()
     lines = captured.out.strip().splitlines()
-    assert "src/doc.md: undefined -> Chris R." in lines
     assert "src/doc.yml: Jane Doe -> Chris R." in lines
-    assert "2 files checked" in lines
-    assert "2 files changed" in lines
-    assert len(lines) == 4
+    assert "1 file checked" in lines
+    assert "1 file changed" in lines
+    assert len(lines) == 3
     log_text = (tmp_path / "log/update-author.txt").read_text(encoding="utf-8")
-    assert "src/doc.md: undefined -> Chris R." in log_text
     assert "src/doc.yml: Jane Doe -> Chris R." in log_text
 
 
@@ -271,12 +261,15 @@ def test_scans_multiple_paths(tmp_path: Path, monkeypatch, capsys) -> None:
     update_author.main(["src/a", "src/b/doc.md"])
 
     for part in ["a", "b"]:
-        assert "author: Brian Lee" in (src / part / "doc.md").read_text(encoding="utf-8")
         assert "author: Brian Lee" in (src / part / "doc.yml").read_text(encoding="utf-8")
+        assert "author:" not in (src / part / "doc.md").read_text(encoding="utf-8")
 
     lines = capsys.readouterr().out.strip().splitlines()
-    assert "4 files checked" in lines
-    assert "4 files changed" in lines
+    assert f"src/a/doc.yml: Jane Doe -> Brian Lee" in lines
+    assert f"src/b/doc.yml: Jane Doe -> Brian Lee" in lines
+    assert "2 files checked" in lines
+    assert "2 files changed" in lines
+    assert len(lines) == 4
 
 
 def test_accepts_glob_patterns(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -299,12 +292,15 @@ def test_accepts_glob_patterns(tmp_path: Path, monkeypatch, capsys) -> None:
     update_author.main(["src/a*/doc.md"])
 
     for part in ["a1", "a2"]:
-        assert "author: Brian Lee" in (src / part / "doc.md").read_text(encoding="utf-8")
         assert "author: Brian Lee" in (src / part / "doc.yml").read_text(encoding="utf-8")
+        assert "author:" not in (src / part / "doc.md").read_text(encoding="utf-8")
 
     lines = capsys.readouterr().out.strip().splitlines()
-    assert "4 files checked" in lines
-    assert "4 files changed" in lines
+    assert f"src/a1/doc.yml: Jane Doe -> Brian Lee" in lines
+    assert f"src/a2/doc.yml: Jane Doe -> Brian Lee" in lines
+    assert "2 files checked" in lines
+    assert "2 files changed" in lines
+    assert len(lines) == 4
 
 
 def test_verbose_enables_debug_logging(tmp_path: Path, monkeypatch) -> None:

--- a/app/shell/py/pie/tests/update/test_update_pubdate.py
+++ b/app/shell/py/pie/tests/update/test_update_pubdate.py
@@ -24,16 +24,14 @@ def test_updates_yaml_from_markdown_change(tmp_path: Path, monkeypatch, capsys) 
     update_pubdate.main([])
     expected = get_pubdate()
     assert f"pubdate: {expected}" in yml.read_text(encoding="utf-8")
-    assert f"pubdate: {expected}" in md.read_text(encoding="utf-8")
+    assert "pubdate:" not in md.read_text(encoding="utf-8")
     captured = capsys.readouterr()
     lines = captured.out.strip().splitlines()
-    assert f"src/doc.md: undefined -> {expected}" in lines
     assert f"src/doc.yml: Jan 01, 2000 -> {expected}" in lines
-    assert "2 files checked" in lines
-    assert "2 files changed" in lines
-    assert len(lines) == 4
+    assert "1 file checked" in lines
+    assert "1 file changed" in lines
+    assert len(lines) == 3
     log_text = (tmp_path / "log/update-pubdate.txt").read_text(encoding="utf-8")
-    assert f"src/doc.md: undefined -> {expected}" in log_text
     assert f"src/doc.yml: Jan 01, 2000 -> {expected}" in log_text
 
 

--- a/docs/reference/update-author.md
+++ b/docs/reference/update-author.md
@@ -7,11 +7,11 @@ By default the console script scans `git status --short` for tracked files that
 have been added or changed. When directories, files, or glob patterns are
 provided, Markdown and YAML files matching those paths are examined instead.
 For each file it locates the associated Markdown and YAML metadata pair using
-`load_metadata_pair` and ensures the `author` field is present in Markdown
-frontmatter or metadata YAML. The field is added when missing and metadata is
-created if none exists. The value is taken from `cfg/update-author.yml`, but
-can be overridden with the `--author` or `-a` option when batch updating book
-excerpts, quotes, or other content.
+`load_metadata_pair` and ensures the `author` field is present. When a metadata
+YAML file exists, the field is added or updated there and the Markdown file is
+left untouched. Metadata is created if none exists. The value is taken from
+`cfg/update-author.yml`, but can be overridden with the `--author` or `-a`
+option when batch updating book excerpts, quotes, or other content.
 
 ```bash
 update-author [-a AUTHOR] [-l LOGFILE] [-v] [PATH ...]

--- a/docs/reference/update-pubdate.md
+++ b/docs/reference/update-pubdate.md
@@ -5,9 +5,10 @@ Update the `pubdate` field in metadata files for documents modified in git.
 The console script scans `git status --short` for tracked files that have been
 added or changed. For each path it locates the associated Markdown and YAML
 metadata pair using `load_metadata_pair` and ensures the `pubdate` field is
-present in Markdown frontmatter or metadata YAML. When the field is missing it
-is added, and metadata is created if none exists, using today's date in the
-format `%b %d, %Y`.
+present. When a metadata YAML file exists, the field is added or updated there
+and the Markdown file is left untouched. When the field is missing it is added,
+and metadata is created if none exists, using today's date in the format
+`%b %d, %Y`.
 
 ```python
 from pathlib import Path


### PR DESCRIPTION
## Summary
- Prioritize updating YAML metadata when paired with Markdown, leaving Markdown untouched
- Document YAML preference in update-author and update-pubdate guides
- Adjust tests for author and pubdate utilities to expect YAML-only updates

## Testing
- `pytest app/shell/py/pie/tests/update/test_common.py app/shell/py/pie/tests/update/test_update_author.py app/shell/py/pie/tests/update/test_update_pubdate.py`


------
https://chatgpt.com/codex/tasks/task_e_689d03807b608321bc7f0c76053c58cc