### PR TITLE
docs: expand create-site guide

### DIFF
--- a/docs/guides/create-site.md
+++ b/docs/guides/create-site.md
@@ -25,3 +25,23 @@ r up
 ```
 
 The first `r` builds the site, while `r up` launches the development containers. Once complete, visit [http://localhost](http://localhost) to view the site.
+
+## Explore built-in examples
+
+Press ships with sample content in `src/examples` that demonstrates features like templating and metadata.
+Build the repository and start the server to browse them:
+
+```bash
+# From the Press repository
+r
+r up
+```
+
+Then visit [http://localhost/examples](http://localhost/examples) to read the built-in examples.
+
+## Next steps
+
+- **Developing content** – Learn more about the build pipeline and adding assets in [build-process.md](build-process.md) and [store-files.md](store-files.md).
+- **Contributing** – Before submitting changes to Press, review [tests.md](tests.md) and [checklinks.md](checklinks.md) to run tests and link checks.
+
+For additional topics, see the [guides index](README.md).


### PR DESCRIPTION
## Summary
- direct readers to Press's built-in examples
- outline docs to consult for content development and contributing

## Testing
- `pip install bs4`
- `pytest` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_689e0eafbdbc832190ad041e881c09de