### PR TITLE
Escape metadata fields with YAML dumping

### DIFF
--- a/app/shell/py/pie/pie/update/author.py
+++ b/app/shell/py/pie/pie/update/author.py
@@ -43,6 +43,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Author name to set; overrides value from cfg/update-author.yml",
     )
     parser.add_argument(
+        "--sort-keys",
+        action="store_true",
+        help="Sort keys when writing YAML output",
+    )
+    parser.add_argument(
         "paths",
         nargs="*",
         help=(
@@ -53,14 +58,17 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(list(argv) if argv is not None else None)
 
 
-def update_files(paths: Iterable[Path], author: str) -> tuple[list[str], int]:
+def update_files(
+    paths: Iterable[Path], author: str, sort_keys: bool = False
+) -> tuple[list[str], int]:
     """Update ``author`` in files related to *paths*.
 
     Returns a tuple ``(messages, checked)`` where ``messages`` contains log
     entries for each modified file and ``checked`` is the number of files that
-    were examined.
+    were examined. When ``sort_keys`` is true YAML mappings are serialized with
+    keys in sorted order.
     """
-    return common_update_files(paths, "author", author)
+    return common_update_files(paths, "author", author, sort_keys=sort_keys)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -103,7 +111,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     else:
         changed = get_changed_files()
     logger.debug("Files to check", files=[str(p) for p in changed])
-    messages, checked = update_files(changed, args.author)
+    messages, checked = update_files(changed, args.author, args.sort_keys)
     logger.debug("Update complete", messages=messages, checked=checked)
     for msg in messages:
         print(msg)

--- a/app/shell/py/pie/pie/update/pubdate.py
+++ b/app/shell/py/pie/pie/update/pubdate.py
@@ -19,17 +19,25 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "Update the pubdate field in modified metadata files",
         log_default="log/update-pubdate.txt",
     )
+    parser.add_argument(
+        "--sort-keys",
+        action="store_true",
+        help="Sort keys when writing YAML output",
+    )
     return parser.parse_args(list(argv) if argv is not None else None)
 
 
-def update_files(paths: Iterable[Path], pubdate: str) -> tuple[list[str], int]:
+def update_files(
+    paths: Iterable[Path], pubdate: str, sort_keys: bool = False
+) -> tuple[list[str], int]:
     """Update ``pubdate`` in files related to *paths*.
 
     Returns a tuple ``(messages, checked)`` where ``messages`` contains log
     entries for each modified file and ``checked`` is the number of files that
-    were examined.
+    were examined. When ``sort_keys`` is true YAML mappings are serialized with
+    keys in sorted order.
     """
-    return common_update_files(paths, "pubdate", pubdate)
+    return common_update_files(paths, "pubdate", pubdate, sort_keys=sort_keys)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -40,7 +48,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     configure_logging(args.verbose, args.log)
     today = get_pubdate()
     changed = get_changed_files()
-    messages, checked = update_files(changed, today)
+    messages, checked = update_files(changed, today, args.sort_keys)
     for msg in messages:
         print(msg)
     print(f"{checked} {'file' if checked == 1 else 'files'} checked")

--- a/docs/reference/update-author.md
+++ b/docs/reference/update-author.md
@@ -14,12 +14,13 @@ left untouched. Metadata is created if none exists. The value is taken from
 option when batch updating book excerpts, quotes, or other content.
 
 ```bash
-update-author [-a AUTHOR] [-l LOGFILE] [-v] [PATH ...]
+update-author [-a AUTHOR] [--sort-keys] [-l LOGFILE] [-v] [PATH ...]
 ```
 
 Each updated file is printed as `<path>: <old> -> <new>` and logged to
 `LOGFILE`.  When not specified, log output is written to
-`log/update-author.txt`. Pass `-v` to enable debug logging.
+`log/update-author.txt`. Pass `--sort-keys` to serialize YAML mappings with
+keys in alphabetical order and `-v` to enable debug logging.
 
 After processing, a summary of the number of files checked and modified is
 printed to the console.

--- a/docs/reference/update-pubdate.md
+++ b/docs/reference/update-pubdate.md
@@ -19,12 +19,13 @@ load_metadata_pair(Path("docs/post/index.yml"))
 ```
 
 ```bash
-update-pubdate [-l LOGFILE]
+update-pubdate [--sort-keys] [-l LOGFILE]
 ```
 
 Each updated file is printed as `<path>: <old> -> <new>` and the same
 information is logged to `LOGFILE`. When omitted, log output is written to
-`log/update-pubdate.txt`.
+`log/update-pubdate.txt`. Pass `--sort-keys` to serialize YAML mappings with
+keys in alphabetical order.
 
 When finished, the script reports how many files were checked and how many were
 updated.


### PR DESCRIPTION
## Summary
- Allow `update-author` and `update-pubdate` to sort YAML keys when writing metadata
- Use `yaml.safe_dump` with optional `sort_keys` in common helpers
- Document `--sort-keys` flag and cover sorting behavior with tests

## Testing
- `PYTHONPATH=app/shell/py pytest app/shell/py/pie/tests/update/test_update_author.py app/shell/py/pie/tests/update/test_update_pubdate.py`

------
https://chatgpt.com/codex/tasks/task_e_689e0d8ae6f483219792c10f39200c89