### PR TITLE
refactor: simplify release script

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -36,14 +36,24 @@ fi
 
 DOCKER_COMPOSE=(docker compose -f "$COMPOSE_FILE")
 
-"${DOCKER_COMPOSE[@]}" down
+MAKE_ARGS=(-f redo.mk VERBOSE="$VERBOSE" SRC_DIR="$SRC_DIR" BUILD_DIR="$BUILD_DIR")
+
+run_make() {
+  make "${MAKE_ARGS[@]}" "$@"
+}
+
+cleanup() {
+  "${DOCKER_COMPOSE[@]}" down
+}
+trap cleanup EXIT
+
+"${DOCKER_COMPOSE[@]}" down >/dev/null 2>&1 || true
 "${DOCKER_COMPOSE[@]}" up -d dragonfly nginx-test
-make -f redo.mk distclean VERBOSE="$VERBOSE" SRC_DIR="$SRC_DIR" BUILD_DIR="$BUILD_DIR"
+run_make distclean
 "${DOCKER_COMPOSE[@]}" build shell
-make -f redo.mk VERBOSE="$VERBOSE" SRC_DIR="$SRC_DIR" BUILD_DIR="$BUILD_DIR"
-make -f redo.mk test VERBOSE="$VERBOSE" SRC_DIR="$SRC_DIR" BUILD_DIR="$BUILD_DIR"
-make -f redo.mk pytest  VERBOSE="$VERBOSE" SRC_DIR="$SRC_DIR" BUILD_DIR="$BUILD_DIR"
+run_make
+run_make test
+run_make pytest
 "${DOCKER_COMPOSE[@]}" build release
-"${DOCKER_COMPOSE[@]}" down
 
 echo "Release Build Successful"


### PR DESCRIPTION
## Summary
- DRY up the release script with a `run_make` helper
- Ensure Docker containers are always stopped by using an `EXIT` trap

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pip install beautifulsoup4`
- `pytest app/shell/py/pie/tests`


------
https://chatgpt.com/codex/tasks/task_e_689e2664cffc832182b4d77435affeb1