### PR TITLE
Resolve file paths before processing in store-files

### DIFF
--- a/app/shell/py/pie/pie/store_files.py
+++ b/app/shell/py/pie/pie/store_files.py
@@ -32,9 +32,14 @@ def generate_id(size: int = 8) -> str:
 
 
 def iter_files(path: Path) -> Iterable[Path]:
-    """Yield files under *path* recursively."""
+    """Yield files under *path* recursively.
+
+    All returned paths are fully resolved so that relative components and
+    symlinks are normalised before being processed by callers.
+    """
+    path = path.resolve()
     if path.is_dir():
-        yield from (p for p in path.rglob("*") if p.is_file())
+        yield from (p.resolve() for p in path.rglob("*") if p.is_file())
     elif path.is_file():
         yield path
 
@@ -108,7 +113,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     meta_dir = Path("src") / "static" / "files"
 
     count = 0
-    for base in (Path(p) for p in args.paths):
+    for base in (Path(p).resolve() for p in args.paths):
         for src in iter_files(base):
             process_file(src, dest_dir, meta_dir, baseurl=baseurl)
             count += 1

--- a/app/shell/py/pie/tests/test_store_files.py
+++ b/app/shell/py/pie/tests/test_store_files.py
@@ -27,6 +27,18 @@ def test_iter_files_returns_all_files(tmp_path: Path) -> None:
     assert list(store_files.iter_files(single)) == [single]
 
 
+def test_iter_files_resolves_paths(tmp_path: Path, monkeypatch) -> None:
+    base = tmp_path / "base"
+    base.mkdir()
+    target = base / "file.txt"
+    target.write_text("data")
+
+    monkeypatch.chdir(tmp_path)
+    rel = Path("base/../base")
+    files = list(store_files.iter_files(rel))
+    assert files == [target]
+
+
 def test_process_file_moves_and_creates_metadata(tmp_path: Path, monkeypatch) -> None:
     src = tmp_path / "file.txt"
     src.write_text("data")

--- a/docs/guides/store-files.md
+++ b/docs/guides/store-files.md
@@ -9,6 +9,7 @@ store-files [-n LIMIT] [-c CONFIG] <path>...
 ```
 
 - Each `path` may point to a single file or a directory; directories are processed recursively. Multiple paths may be supplied.
+- All paths are resolved to their absolute locations before any files are processed.
 - `-n LIMIT` optionally restricts how many files are handled in one run.
 - `-c CONFIG` path to a configuration file. Defaults to `cfg/store-files.yml` and is ignored if missing. When a path is explicitly supplied the command exits with an error if the file does not exist.
 


### PR DESCRIPTION
## Summary
- normalise input paths in `store-files` before iterating over files
- document path resolution behaviour for `store-files`
- add test covering path resolution

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'redis' and other missing dependencies)*
- `pytest app/shell/py/pie/tests/test_store_files.py -k test_iter_files_resolves_paths -q`

------
https://chatgpt.com/codex/tasks/task_e_689e2f97fc50832186093b3bb7be8c1f