### PR TITLE
Add canonical link support via permalink metadata

### DIFF
--- a/app/shell/py/pie/tests/test_permalink_canonical.py
+++ b/app/shell/py/pie/tests/test_permalink_canonical.py
@@ -1,0 +1,45 @@
+import subprocess
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+import pytest
+
+
+def run_pandoc(tmp_path: Path, permalink: str | None) -> str:
+    """Render minimal markdown with optional permalink and return HTML."""
+    lines = ["---", "title: Sample"]
+    if permalink:
+        lines.append(f"permalink: {permalink}")
+    lines.append("---\n\nBody")
+    md_path = tmp_path / "doc.md"
+    md_path.write_text("\n".join(lines), encoding="utf-8")
+
+    html_path = tmp_path / "out.html"
+    template = Path(__file__).resolve().parents[5] / "src" / "pandoc-template.html"
+    cmd = [
+        "pandoc",
+        "--standalone",
+        "--template",
+        str(template),
+        str(md_path),
+        "-o",
+        str(html_path),
+    ]
+    subprocess.run(cmd, check=True)
+    return html_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("url", ["https://example.com/a", "/relative/path"])
+def test_permalink_sets_canonical(tmp_path: Path, url: str) -> None:
+    html = run_pandoc(tmp_path, url)
+    soup = BeautifulSoup(html, "html.parser")
+    link = soup.find("link", rel="canonical")
+    assert link is not None
+    assert link.get("href") == url
+
+
+def test_no_permalink_has_no_canonical(tmp_path: Path) -> None:
+    html = run_pandoc(tmp_path, None)
+    soup = BeautifulSoup(html, "html.parser")
+    assert soup.find("link", rel="canonical") is None
+

--- a/src/pandoc-template.html
+++ b/src/pandoc-template.html
@@ -35,6 +35,10 @@
         <meta$if(meta.name)$ name="$meta.name$"$endif$$if(meta.property)$ property="$meta.property$"$endif$ content="$meta.content$" />
         $endfor$
 
+        $if(permalink)$
+        <link rel="canonical" href="$permalink$" />
+        $endif$
+
         <!-- If you supply multiple CSS files via metadata -->
         <!-- The main stylesheet has to be included here because mobile browsers
             don't seem to apply the stylesheet otherwise, and fonts are too


### PR DESCRIPTION
## Summary
- support `permalink` metadata for custom canonical URLs
- render `<link rel="canonical">` when a permalink is provided
- test canonical link rendering for permalink and default cases

## Testing
- `PYTHONPATH=app/shell/py/pie pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4dcd07d883219940a199edc8edf4