### PR TITLE
Consolidate JS build directory rule

### DIFF
--- a/app/magicbar/dep.mk
+++ b/app/magicbar/dep.mk
@@ -5,10 +5,6 @@
 # Ensure built JS is available under build/static/
 all: build/static/js/magicbar.js
 
-# Directory for built assets
-build/static/js:
-	mkdir -p $@
-
 # Copy the generated bundle from the app directory into the build tree
 build/static/js/magicbar.js: app/build/static/js/magicbar.js | build/static/js
 	cp $< $@

--- a/app/quiz/dep.mk
+++ b/app/quiz/dep.mk
@@ -7,9 +7,6 @@
 # accompanying JSON files are present under `build/quiz/`.
 all: build/static/js/quiz.js
 
-# Directory for built quiz assets
-build/static/js:
-	mkdir -p $@
 
 # Copy the generated bundle from the app directory into the build tree
 build/static/js/quiz.js: app/build/static/js/quiz.js | build/static/js

--- a/src/dep.mk
+++ b/src/dep.mk
@@ -1,6 +1,11 @@
 ## Aggregate dependency rules for Press. Included by build.mk so
 ## module-specific makefiles can provide asset targets.
 ## See docs/guides/dep-mk.md for details on dependency makefiles.
+ 
+# Directory for built JavaScript assets
+build/static/js:
+	mkdir -p $@
+
 include app/quiz/dep.mk
 include app/indextree/dep.mk
 include app/magicbar/dep.mk


### PR DESCRIPTION
## Summary
- centralize `build/static/js` directory creation in `src/dep.mk`
- remove duplicate directory rules from `magicbar` and `quiz` modules

## Testing
- `make -f src/dep.mk -n`
- `pytest` *(fails: No module named 'loguru', 'yaml', 'redis', 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_689f8d4a7e4c8321a0e8d3d7f7e96357