### PR TITLE
feat: add permalink redirects for nginx

### DIFF
--- a/app/nginx/default.conf
+++ b/app/nginx/default.conf
@@ -15,4 +15,6 @@ server {
     location / {
         try_files $uri $uri/ =404;
     }
+
+    include /usr/share/nginx/html/permalinks.conf;
 }

--- a/app/nginx/prod.conf
+++ b/app/nginx/prod.conf
@@ -15,4 +15,6 @@ server {
     location / {
         try_files $uri $uri/ =404;
     }
+
+    include /usr/share/nginx/html/permalinks.conf;
 }

--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -106,11 +106,11 @@ all: $(BUILD_DIR)/robots.txt
 all: $(PERMALINKS_CONF)
 
 $(BUILD_DIR)/robots.txt: $(SRC_DIR)/robots.txt
-        cp $< $@
+	cp $< $@
 
 $(PERMALINKS_CONF): $(MARKDOWNS) $(YAMLS) | $(BUILD_DIR) $(LOG_DIR)
 	$(call status,Generate permalink redirects)
-	$(Q)nginx-permalinks $(SRC_DIR) -o $@ -v --log $(LOG_DIR)/nginx-permalinks.txt
+	$(Q)nginx-permalinks $(SRC_DIR) -o $@ --log $(LOG_DIR)/nginx-permalinks.txt
 
 $(BUILD_DIR)/.update-index: $(MARKDOWNS) $(YAMLS)
 	$(call status,Updating Redis Index)

--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -87,6 +87,9 @@ BUILD_SUBDIRS := $(sort $(dir $(HTMLS))) $(LOG_DIR) $(BUILD_DIR)/static
 CSS := $(wildcard $(SRC_DIR)/*.css)
 CSS := $(patsubst $(SRC_DIR)/%.css,$(BUILD_DIR)/%.css, $(CSS))
 
+# Nginx permalink redirect configuration
+PERMALINKS_CONF := $(BUILD_DIR)/permalinks.conf
+
 # Define the default target to build everything
 .PHONY: everything
 everything: | $(BUILD_DIR) $(BUILD_SUBDIRS)
@@ -100,9 +103,14 @@ everything: | $(BUILD_DIR) $(BUILD_SUBDIRS)
 all: $(HTMLS)
 all: $(CSS)
 all: $(BUILD_DIR)/robots.txt
+all: $(PERMALINKS_CONF)
 
 $(BUILD_DIR)/robots.txt: $(SRC_DIR)/robots.txt
-	cp $< $@
+        cp $< $@
+
+$(PERMALINKS_CONF): $(MARKDOWNS) $(YAMLS) | $(BUILD_DIR) $(LOG_DIR)
+	$(call status,Generate permalink redirects)
+	$(Q)nginx-permalinks $(SRC_DIR) -o $@ -v --log $(LOG_DIR)/nginx-permalinks.txt
 
 $(BUILD_DIR)/.update-index: $(MARKDOWNS) $(YAMLS)
 	$(call status,Updating Redis Index)

--- a/app/shell/py/pie/pie/nginx_permalinks.py
+++ b/app/shell/py/pie/pie/nginx_permalinks.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Generate Nginx redirect rules from metadata permalinks."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Iterable, Sequence
+
+from pathlib import Path
+
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
+from pie.metadata import (
+    get_metadata_by_path,
+    build_from_redis,
+    load_metadata_pair,
+)
+
+
+def _load_metadata(filepath: str) -> dict | None:
+    """Load metadata for *filepath* from Redis or fall back to the file pair."""
+    try:
+        doc_id = get_metadata_by_path(filepath, "id")
+        if doc_id:
+            meta = build_from_redis(f"{doc_id}.") or {}
+            if "id" not in meta:
+                meta["id"] = doc_id
+            logger.debug("Loaded metadata from redis", path=filepath, id=doc_id)
+            return meta
+        logger.debug("No doc_id found in redis", path=filepath)
+    except Exception:
+        logger.debug("Redis lookup failed", path=filepath, exc_info=True)
+
+    logger.debug("Falling back to load_metadata_pair", path=filepath)
+    try:
+        return load_metadata_pair(Path(filepath))
+    except Exception:
+        logger.warning("Failed to load metadata", path=filepath, exc_info=True)
+        return None
+
+
+def collect_redirects(source_dir: str) -> list[tuple[str, str]]:
+    """Return ``(permalink, url)`` pairs for metadata under *source_dir*."""
+    redirects: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for root, _, files in os.walk(source_dir):
+        for name in files:
+            base, ext = os.path.splitext(name)
+            ext = ext.lower()
+            if ext not in {".md", ".yml", ".yaml"}:
+                continue
+            filepath = os.path.join(root, name)
+            logger.debug("Processing file", path=filepath)
+            meta = _load_metadata(filepath)
+            if not meta:
+                continue
+            permalink = meta.get("permalink")
+            url = meta.get("url")
+            if permalink and url:
+                if isinstance(permalink, str):
+                    links: Iterable[str] = [permalink]
+                else:
+                    links = permalink
+                for link in links:
+                    pair = (str(link), str(url))
+                    if pair not in seen:
+                        redirects.append(pair)
+                        seen.add(pair)
+                        logger.debug("Added redirect", src=link, dest=url)
+    logger.debug("Collected redirects", count=len(redirects))
+    return redirects
+
+
+def format_redirects(redirects: list[tuple[str, str]]) -> str:
+    """Format redirects as Nginx ``location`` blocks."""
+    lines: list[str] = []
+    for src, dest in redirects:
+        if not src.startswith("/"):
+            src = "/" + src
+        if not dest.startswith("/"):
+            dest = "/" + dest
+        block = f"location = {src} {{\n    return 301 {dest};\n}}"
+        lines.append(block)
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = create_parser(
+        "Generate Nginx redirects from metadata permalinks",
+        log_default="log/nginx-permalinks.txt",
+    )
+    parser.add_argument("source_dir", help="Directory to scan for metadata files")
+    parser.add_argument("-o", "--output", help="Path to write Nginx config")
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Entry point for ``nginx-permalinks`` console script."""
+    args = parse_args(argv)
+    if args.log:
+        os.makedirs(os.path.dirname(args.log), exist_ok=True)
+    configure_logging(args.verbose, args.log)
+    redirects = collect_redirects(args.source_dir)
+    output = format_redirects(redirects)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(output)
+        logger.info("Redirects written", path=args.output)
+    else:
+        print(output, end="")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -39,6 +39,7 @@ setup(
             'create-site=pie.create.site:main',
             'emojify=pie.filter.emojify:main',
             'store-files=pie.store_files:main',
+            'nginx-permalinks=pie.nginx_permalinks:main',
         ],
     },
 )

--- a/app/shell/py/pie/tests/test_nginx_permalinks.py
+++ b/app/shell/py/pie/tests/test_nginx_permalinks.py
@@ -1,0 +1,48 @@
+import json
+import os
+
+import fakeredis
+from pie import metadata, nginx_permalinks
+
+
+def test_generates_redirects_from_redis(tmp_path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "doc.md").touch()
+
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
+    fake.set("src/doc.md", "doc")
+    fake.set("doc.id", "doc")
+    fake.set("doc.url", json.dumps("/doc.html"))
+    fake.set("doc.permalink", json.dumps("/old.html"))
+
+    out = tmp_path / "permalinks.conf"
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        nginx_permalinks.main(["src", "-o", str(out), "-v"])
+    finally:
+        os.chdir(cwd)
+
+    assert out.read_text() == "location = /old.html {\n    return 301 /doc.html;\n}\n"
+
+
+def test_fallbacks_to_load_metadata_pair(tmp_path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    md = src / "doc.md"
+    md.write_text("---\npermalink: /old.html\n---\n")
+
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
+
+    out = tmp_path / "permalinks.conf"
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        nginx_permalinks.main(["src", "-o", str(out), "-v"])
+    finally:
+        os.chdir(cwd)
+
+    assert out.read_text() == "location = /old.html {\n    return 301 /doc.html;\n}\n"

--- a/docs/guides/nginx.md
+++ b/docs/guides/nginx.md
@@ -5,6 +5,11 @@ It starts from `nginx:alpine-slim` and copies the generated `build/` directory
 into Nginx's default web root. Both the `nginx` and `nginx-dev` services in
 `docker-compose.yml` use this image.
 
+The build process also creates a `permalinks.conf` file in the `build/` directory.
+Nginx includes this file to redirect legacy URLs specified by a page's
+`permalink` metadata to its canonical `url`. Debug logs from this step are
+written to `log/nginx-permalinks.txt`.
+
 ```Dockerfile
 FROM nginx:alpine-slim
 COPY ./build /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- generate Nginx redirect rules from `permalink` metadata
- include generated `permalinks.conf` in Nginx config and build pipeline
- document permalink redirects and add tests
- load metadata from Redis with file fallback and log debug output

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pip install beautifulsoup4`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f9034ef048321a18cce0fbdc84cd2