### PR TITLE
Support responsive images in figure macro

### DIFF
--- a/app/shell/py/pie/tests/test_figure_global.py
+++ b/app/shell/py/pie/tests/test_figure_global.py
@@ -26,3 +26,23 @@ def test_figure_uses_title_when_caption_missing():
         "<figcaption>Option Pricing & Greeks Calculator screenshot</figcaption></figure>"
     )
     assert render_template.figure(desc) == expected
+
+
+def test_figure_generates_srcset_from_widths():
+    desc = {
+        "title": "Responsive image",
+        "url": "/img/sample-400.jpg",
+        "figure": {
+            "caption": "Responsive",
+            "pattern": "/img/sample-{width}.jpg",
+            "widths": [400, 800],
+            "sizes": "(max-width: 800px) 100vw, 800px",
+        },
+    }
+    expected = (
+        "<figure><img src=\"/img/sample-400.jpg\" "
+        "srcset=\"/img/sample-400.jpg 400w, /img/sample-800.jpg 800w\" "
+        "sizes=\"(max-width: 800px) 100vw, 800px\" alt=\"Responsive image\" "
+        "loading=\"lazy\"/><figcaption>Responsive</figcaption></figure>"
+    )
+    assert render_template.figure(desc) == expected

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -28,3 +28,6 @@ concepts and data formats, see the
   container.
 
 Refer to the individual files for additional guides not listed here.
+
+## Content features
+- [responsive-images.md](responsive-images.md) – render responsive images with the figure helper.

--- a/docs/guides/responsive-images.md
+++ b/docs/guides/responsive-images.md
@@ -1,0 +1,39 @@
+# Responsive Images
+
+The `figure` Jinja helper can generate responsive `<img>` tags. Provide either a
+URL pattern with a `{w}` placeholder or explicit width-to-URL mappings. The
+helper emits a `srcset` and `sizes` attribute along with a fallback `src` for
+older browsers.
+
+## Pattern-based widths
+
+```jinja
+{{ figure({
+    "url": "/img/chart@{w}.png",
+    "widths": [320, 640, 960],
+    "sizes": "(max-width: 960px) 100vw, 960px",
+    "alt": "An example chart"
+}) }}
+```
+
+## Explicit URLs
+
+```jinja
+{{ figure({
+    "srcset": {
+        "320": "/img/chart-320.png",
+        "640": "/img/chart-640.png"
+    },
+    "sizes": "(max-width: 640px) 100vw, 640px",
+    "alt": "An example chart"
+}) }}
+```
+
+Both approaches output responsive markup similar to:
+
+```html
+<img src="/img/chart-320.png" srcset="/img/chart-320.png 320w, /img/chart-640.png 640w" sizes="(max-width: 640px) 100vw, 640px" alt="An example chart">
+```
+
+The browser picks the appropriate image size based on device width, reducing
+bandwidth while preserving quality.

--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -17,9 +17,11 @@ for details on the structure of this metadata.
 - `link(desc, anchor=None)` and related helpers `linktitle`, `linkcap`,
   `link_icon_title`, `linkicon`, and `linkshort` – format metadata into HTML
   anchors. See [link-globals.md](link-globals.md) for details.
-- `figure(desc)` – generate a `<figure>` with a lazy-loaded `<img>` and a
-  caption taken from `desc['figure']['caption']` when present, otherwise the
-  entry's `title`.
+- `figure(desc)` – generate a `<figure>` with a lazy-loaded `<img>`. The image
+  uses `desc['url']` as a fallback `src` while optional responsive sources may
+  be supplied via `desc['figure']['urls']` or a `widths`/`pattern` pair to
+  populate `srcset` and `sizes`. The caption defaults to
+  `desc['figure']['caption']` when present, otherwise the entry's `title`.
 
 Example:
 

--- a/src/examples/responsive-images.md
+++ b/src/examples/responsive-images.md
@@ -1,0 +1,26 @@
+---
+title: Responsive Images
+author: Brian Lee
+id: responsive-images
+citation: responsive-images
+---
+
+This example shows how to build a responsive image using the `figure` Jinja macro.
+
+```jinja
+{{ figure({
+    "url": "https://via.placeholder.com/{w}",
+    "widths": [320, 640],
+    "sizes": "(max-width: 640px) 100vw, 640px",
+    "alt": "Placeholder"
+}) }}
+```
+
+renders as:
+
+{{ figure({
+    "url": "https://via.placeholder.com/{w}",
+    "widths": [320, 640],
+    "sizes": "(max-width: 640px) 100vw, 640px",
+    "alt": "Placeholder"
+}) }}

--- a/src/index.md
+++ b/src/index.md
@@ -3,6 +3,7 @@ Welcome to the demo site for **Press**. Use the links below to explore key featu
 - [Quickstart](quickstart.md)
 - [Jinja Examples](examples/jinja.md)
 - [Link Global Examples](examples/link-globals.md)
+- [Responsive Image Examples](examples/responsive-images.md)
 - [Chicago Citation Examples](examples/chicago-citations.md)
 - [Index Tree Demo](examples/indextree/index.md)
 - [Quiz Demo](quiz/index.md)


### PR DESCRIPTION
## Summary
- allow `figure()` helper to build responsive `<img>` tags with `srcset` and `sizes`
- document new `figure` metadata fields for responsive images
- add demo page and user guide for responsive figures
- remove placeholder opcalc metadata examples

## Testing
- `pip install beautifulsoup4`
- `pip install loguru PyYAML redis fakeredis`
- `pip install flatten_dict emoji`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f956d4c648321a08d3caad602d4b9