### PR TITLE
refactor: rename read_from_markdown

### DIFF
--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -108,7 +108,7 @@ def generate_missing_metadata(metadata: dict[str, Any], filepath: str) -> dict[s
     return metadata
 
 
-def read_from_markdown(filepath: str) -> Optional[Dict[str, Any]]:
+def _read_from_markdown(filepath: str) -> Optional[Dict[str, Any]]:
     """Load metadata from a Markdown file without adding defaults.
 
     ``generate_missing_metadata`` should be called by the caller if default
@@ -285,7 +285,7 @@ def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
 
     md_data = None
     if md_path.exists():
-        md_data = read_from_markdown(str(md_path))
+        md_data = _read_from_markdown(str(md_path))
 
     yaml_data = None
     yaml_file: Path | None = None

--- a/app/shell/py/pie/tests/test_build_index.py
+++ b/app/shell/py/pie/tests/test_build_index.py
@@ -1,15 +1,28 @@
-import os
 import json
+import os
 from pathlib import Path
+
 import pytest
+
 from pie import build_index
 
 
 def test_validate_and_insert_duplicate(tmp_path):
     """Duplicate id triggers KeyError."""
-    index = {"a": {"id": "a"}}
-    with pytest.raises(KeyError):
-        build_index.validate_and_insert_metadata({"id": "a"}, "file", index)
+    src = tmp_path / "src"
+    src.mkdir()
+    first = src / "first.yml"
+    first.write_text("id: a")
+    second = src / "second.yml"
+    second.write_text("id: a")
+    index: dict[str, dict[str, str]] = {}
+    os.chdir(tmp_path)
+    try:
+        build_index.validate_and_insert_metadata("src/first.yml", index)
+        with pytest.raises(KeyError):
+            build_index.validate_and_insert_metadata("src/second.yml", index)
+    finally:
+        os.chdir("/tmp")
 
 
 def test_build_index_handles_multiple_extensions(tmp_path):

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -28,14 +28,14 @@ def test_get_url_invalid_raises(tmp_path):
         os.chdir("/tmp")
 
 
-def test_read_from_markdown_generates_fields(tmp_path):
+def test__read_from_markdown_generates_fields(tmp_path):
     """Frontmatter {'title': 'T'} -> url/id/citation added."""
     md = tmp_path / "src" / "doc.md"
     md.parent.mkdir(parents=True)
     md.write_text("---\n{\"title\": \"T\"}\n---\nbody")
     os.chdir(tmp_path)
     try:
-        data = metadata.read_from_markdown("src/doc.md")
+        data = metadata._read_from_markdown("src/doc.md")
         assert data is not None
         data = metadata.generate_missing_metadata(data, "src/doc.md")
     finally:


### PR DESCRIPTION
## Summary
- rename metadata helper to _read_from_markdown
- update build_index and tests to use the private helper
- load metadata pairs in validate_and_insert_metadata

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f954caa0483219618544e2f529ed2