### PR TITLE
Add MagicBar index generator

### DIFF
--- a/app/magicbar/docs/magicbar-index.md
+++ b/app/magicbar/docs/magicbar-index.md
@@ -1,0 +1,23 @@
+# magicbar-index
+
+`magicbar-index` scans files or directories and builds a JSON navigation list for the MagicBar React component.
+
+## Usage
+
+```bash
+magicbar-index [PATH ...] [-o OUTPUT]
+```
+
+- `PATH` can point to Markdown or YAML files or directories to search recursively.
+- `-o`, `--output` choose the output filename (defaults to `magicbar.json`).
+- `-v`, `-l` enable verbose logging or log file support via `pie`.
+
+Each `.md`, `.yml`, or `.yaml` file should define `title` and `url` metadata. An optional `magicbar.shortcut` value is preserved for quick access.
+
+Example:
+
+```bash
+magicbar-index docs -o src/magicbar/demo.json
+```
+
+This writes a sorted list of entries to `src/magicbar/demo.json` ready to be consumed by the MagicBar component.

--- a/app/magicbar/py/magicbar/magicbar/__init__.py
+++ b/app/magicbar/py/magicbar/magicbar/__init__.py
@@ -1,0 +1,1 @@
+"""MagicBar utilities."""

--- a/app/magicbar/py/magicbar/magicbar/index.py
+++ b/app/magicbar/py/magicbar/magicbar/index.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterator
+
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
+from pie.metadata import load_metadata_pair
+
+SUPPORTED_EXTS = {".md", ".yml", ".yaml"}
+
+def scan_path(path: Path) -> Iterator[dict]:
+    if path.is_dir():
+        seen: set[Path] = set()
+        for child in path.rglob("*"):
+            if "node_modules" in child.parts:
+                continue
+            if child.is_file() and child.suffix in SUPPORTED_EXTS:
+                base = child.with_suffix("")
+                if base in seen:
+                    continue
+                seen.add(base)
+                yield from scan_path(child)
+    else:
+        meta = load_metadata_pair(path)
+        if not meta:
+            return
+        title = meta.get("title")
+        url = meta.get("url")
+        if not title or not url:
+            logger.warning("Missing title or url", path=str(path))
+            return
+        entry = {"title": title, "url": url}
+        section = meta.get("magicbar") or {}
+        shortcut = section.get("shortcut")
+        if shortcut:
+            entry["shortcut"] = shortcut
+        yield entry
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = create_parser("Generate MagicBar index")
+    parser.add_argument("paths", nargs="+", help="Paths to scan")
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="magicbar.json",
+        help="Output JSON filename",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.verbose or args.log:
+        configure_logging(args.verbose, args.log)
+
+    entries = []
+    for p in args.paths:
+        entries.extend(scan_path(Path(p)))
+    entries.sort(key=lambda x: x["title"].lower())
+
+    json_data = json.dumps(entries, indent=2)
+    Path(args.output).write_text(json_data, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/magicbar/py/magicbar/requirements.txt
+++ b/app/magicbar/py/magicbar/requirements.txt
@@ -1,0 +1,2 @@
+loguru
+PyYAML

--- a/app/magicbar/py/magicbar/setup.py
+++ b/app/magicbar/py/magicbar/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="magicbar",
+    version="0.1.0",
+    packages=find_packages(),
+    entry_points={'console_scripts': ['magicbar-index=magicbar.index:main']},
+)

--- a/app/magicbar/py/magicbar/tests/test_index.py
+++ b/app/magicbar/py/magicbar/tests/test_index.py
@@ -1,0 +1,63 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure packages are importable when tests run from the repository root
+TEST_ROOT = Path(__file__).resolve()
+sys.path.insert(0, str(TEST_ROOT.parents[1]))  # magicbar package
+sys.path.insert(0, str(TEST_ROOT.parents[5] / "app/shell/py/pie"))
+from magicbar import index
+
+
+def test_scan_path_collects_metadata(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "alpha.yml").write_text("title: Alpha\nmagicbar:\n  shortcut: a\n", encoding="utf-8")
+    (src / "beta.md").write_text("---\ntitle: Beta\n---\n", encoding="utf-8")
+
+    os.chdir(tmp_path)
+    try:
+        entries = sorted(index.scan_path(Path("src")), key=lambda x: x["title"])
+    finally:
+        os.chdir("/tmp")
+    assert entries == [
+        {"title": "Alpha", "url": "/alpha.html", "shortcut": "a"},
+        {"title": "Beta", "url": "/beta.html"},
+    ]
+
+
+def test_main_writes_default_output(tmp_path, monkeypatch, capsys):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "alpha.yml").write_text("title: Alpha\n", encoding="utf-8")
+
+    os.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["magicbar-index", "src"])
+    try:
+        index.main()
+    finally:
+        os.chdir("/tmp")
+
+    output_path = tmp_path / "magicbar.json"
+    data = json.loads(output_path.read_text())
+    assert data == [{"title": "Alpha", "url": "/alpha.html"}]
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_scan_path_merges_markdown_and_yaml(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "alpha.md").write_text("---\ntitle: FromMD\n---\n", encoding="utf-8")
+    (src / "alpha.yml").write_text(
+        "title: FromYAML\nmagicbar:\n  shortcut: a\n", encoding="utf-8"
+    )
+    os.chdir(tmp_path)
+    try:
+        entries = list(index.scan_path(Path("src")))
+    finally:
+        os.chdir("/tmp")
+    assert entries == [{"title": "FromYAML", "url": "/alpha.html", "shortcut": "a"}]

--- a/app/shell/Dockerfile
+++ b/app/shell/Dockerfile
@@ -48,18 +48,21 @@ ENV LANG=en_US.UTF-8 \
 # Copy Press Python libraries into the image. Users can override by mounting
 # /press/py
 # -------------------------------------------------------------------
-# Install library under development.
-COPY ./py/pie /press/py/pie
+# Install libraries under development.
+COPY ./app/shell/py/pie /press/py/pie
+COPY ./app/magicbar/py/magicbar /press/py/magicbar
 RUN pip install --break-system-packages \
         -e /press/py/pie \
-        -r /press/py/pie/requirements.txt
+        -r /press/py/pie/requirements.txt \
+        -e /press/py/magicbar \
+        -r /press/py/magicbar/requirements.txt
 
 # -------------------------------------------------------------------
 # Custom helper scripts and makefiles
 # -------------------------------------------------------------------
 # Add helper scripts to PATH
-COPY ./bin/ /app/bin
+COPY ./app/shell/bin/ /app/bin
 ENV PATH="/app/bin:${PATH}"
 
 # Copy additional Makefile fragments
-COPY ./mk/ /app/mk
+COPY ./app/shell/mk/ /app/mk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,9 @@ services:
 
   shell:
     image: press-shell
-    build: ./app/shell
+    build:
+      context: .
+      dockerfile: ./app/shell/Dockerfile
     container_name: press-shell
     entrypoint: ["bash"]
     environment:
@@ -78,6 +80,8 @@ services:
       - ./app/shell/bin:/app/bin
       - ./app/shell/py/pie/pie:/press/py/pie/pie
       - ./app/shell/py/pie/tests:/press/py/pie/tests
+      - ./app/magicbar/py/magicbar/magicbar:/press/py/magicbar/magicbar
+      - ./app/magicbar/py/magicbar/tests:/press/py/magicbar/tests
       - ./src/dep.mk:/app/mk/dep.mk
 
   release:

--- a/docs/guides/magicbar.md
+++ b/docs/guides/magicbar.md
@@ -58,3 +58,7 @@ An example dataset and page live in `src/magicbar`. After building the
 `app/magicbar` project, the component script is available at
 `/static/js/magicbar.js` and the demo page loads the data from
 `/magicbar/demo.json`.
+
+For details on generating the JSON dataset, see the
+[MagicBar indexing documentation](../../app/magicbar/docs/magicbar-index.md).
+


### PR DESCRIPTION
## Summary
- add new `magicbar` python package for indexing content
- implement `magicbar-index` console script that scans paths, builds navigation JSON and supports verbose/log options
- add tests for MagicBar index generation
- document `magicbar-index` usage in `app/magicbar/docs`
- link from the MagicBar guide to the new indexing documentation
- switch to `pie.metadata.load_metadata_pair` for metadata loading
- remove redundant `load_metadata` wrapper and call `load_metadata_pair` directly
- install `magicbar` in shell container so its CLI is available during builds

## Testing
- `pytest app/magicbar/py/magicbar/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8f003be8832199b51f42ba5dc0f4