### PR TITLE
Rename pubdate CSS class to metablock

### DIFF
--- a/src/pandoc-template.html
+++ b/src/pandoc-template.html
@@ -54,7 +54,7 @@
 
         <h1>$title$</h1>
 
-        <p class="pubdate">
+        <p class="metablock">
         $if(author)$
           $author$<br/>
         $endif$

--- a/src/style.css
+++ b/src/style.css
@@ -62,7 +62,7 @@ body {
 }
 
 h1 {
-  margin-bottom: 0.1em; /* Keeps pubdate close */
+  margin-bottom: 0.1em; /* Keeps metablock close */
 }
 
 h2 {
@@ -207,7 +207,7 @@ nav:not(#TOC) ul li {
     text-align: center;
 }
 
-.pubdate {
+.metablock {
   font-size: 0.8em;
   color: darkgray;
   margin-top: 0;


### PR DESCRIPTION
## Summary
- rename pubdate block to metablock in the Pandoc template
- update stylesheet to style .metablock and adjust comment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a09f75fa608321837ec4b6c6bdd6c6