### PR TITLE
docs: explain nginx-test usage

### DIFF
--- a/docs/guides/nginx.md
+++ b/docs/guides/nginx.md
@@ -29,3 +29,15 @@ For production, build the image and run the `nginx` service.
 
 You can also run `r docker` to build and push the image to your configured
 registry. See [DigitalOcean Setup](digitalocean.md) for an example.
+
+### `nginx-test` for isolated testing
+
+`docker-compose.yml` also defines an `nginx-test` service that uses the same
+image without publishing any ports to the host. The test suite reaches this
+container at `http://nginx-test`, providing a private Nginx instance for link
+checks and other HTTP tests. Running a dedicated server prevents conflicts with
+other applications that might need port&nbsp;80, making testing easier and more
+robust.
+The base URL comes from the `TEST_HOST_URL` environment variable, which defaults
+to `http://nginx-test` but can be overridden to target a different host during
+tests.

--- a/docs/guides/tests.md
+++ b/docs/guides/tests.md
@@ -11,6 +11,16 @@ r pytest
 This command invokes `pytest` within the container so the tests run in the same
 environment used for development and CI.
 
+The suite relies on the `nginx-test` service defined in `docker-compose.yml`.
+This container runs a private Nginx instance without exposing port 80, allowing
+HTTP checks to run without disturbing other services that might need the default
+web port.
+
+Link checks use the `TEST_HOST_URL` environment variable to decide which host to
+scan. `docker-compose` sets it to `http://nginx-test` so the tests talk to the
+private Nginx container, but you can override it to point at another server
+(for example, `TEST_HOST_URL=http://localhost:8080 r pytest`).
+
 To check test coverage for the `pie` package and generate an HTML report, run:
 
 ```bash


### PR DESCRIPTION
## Summary
- document nginx-test service and how it isolates Nginx for testing
- clarify that the test suite uses nginx-test to avoid port 80 conflicts
- note TEST_HOST_URL for directing link checks to the private Nginx container or another host

## Testing
- `pip install beautifulsoup4 loguru pyyaml redis fakeredis flatten-dict emoji`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0d2173168832180e60bb898908051