### PR TITLE
Add SCSS build pipeline with libsass and document styling workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Press is a static-site generator built on Pandoc and Docker, orchestrated with `
 - Automatic metadata indexing and JSON index generation
 - Optional services for API docs, image optimization, and local previews
 
+## Styling
+
+Site styles live under `src/css/` and are compiled with the Python `libsass` library into
+`build/css/`. Edit `src/css/style.css` or add additional files in that
+directory using SCSS syntax to customize the site appearance.
+
 ## Documentation
 
 All project documentation lives under [docs/](docs/). Start with the [guides](docs/guides/README.md) for step-by-step workflows and see the [reference](docs/reference/README.md) for technical details.

--- a/app/shell/Dockerfile
+++ b/app/shell/Dockerfile
@@ -29,6 +29,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
 
 RUN apt install -y --no-install-recommends git
 
+
 RUN rm -rf /var/lib/apt/lists/*
 
 # -------------------------------------------------------------------
@@ -50,7 +51,9 @@ ENV LANG=en_US.UTF-8 \
 # -------------------------------------------------------------------
 # Install library under development.
 COPY ./py/pie /press/py/pie
+# Install libsass for SCSS compilation
 RUN pip install --break-system-packages \
+        libsass \
         -e /press/py/pie \
         -r /press/py/pie/requirements.txt
 

--- a/app/shell/Dockerfile
+++ b/app/shell/Dockerfile
@@ -29,6 +29,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
 
 RUN apt install -y --no-install-recommends git
 
+RUN apt install -y --no-install-recommends pysassc
 
 RUN rm -rf /var/lib/apt/lists/*
 
@@ -51,9 +52,8 @@ ENV LANG=en_US.UTF-8 \
 # -------------------------------------------------------------------
 # Install library under development.
 COPY ./py/pie /press/py/pie
-# Install libsass for SCSS compilation
+
 RUN pip install --break-system-packages \
-        libsass \
         -e /press/py/pie \
         -r /press/py/pie/requirements.txt
 

--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -44,7 +44,7 @@ PANDOC_TEMPLATE := $(SRC_DIR)/pandoc-template.html
 
 # Options for generating HTML output with Pandoc
 PANDOC_OPTS := \
-		--css '/style.css' \
+                --css '/css/style.css' \
 		--standalone \
 		-t html \
 		--toc \
@@ -55,7 +55,7 @@ PANDOC_OPTS := \
 
 # Options for generating PDF output with Pandoc
 PANDOC_OPTS_PDF := \
-                --css "/style.css" \
+                --css "/css/style.css" \
                 --standalone \
                 -t pdf \
                 --toc \
@@ -82,10 +82,10 @@ HTMLS := $(patsubst $(SRC_DIR)/%.md, $(BUILD_DIR)/%.html, $(MARKDOWNS))
 PDFS := $(patsubst $(SRC_DIR)/%.md, $(BUILD_DIR)/%.pdf, $(MARKDOWNS))
 
 # Sort and define build subdirectories based on HTML files
-BUILD_SUBDIRS := $(sort $(dir $(HTMLS))) $(LOG_DIR) $(BUILD_DIR)/static
+BUILD_SUBDIRS := $(sort $(dir $(HTMLS))) $(LOG_DIR) $(BUILD_DIR)/static $(BUILD_DIR)/css
 
-CSS := $(wildcard $(SRC_DIR)/*.css)
-CSS := $(patsubst $(SRC_DIR)/%.css,$(BUILD_DIR)/%.css, $(CSS))
+CSS_SRC := $(wildcard $(SRC_DIR)/css/*.css)
+CSS := $(patsubst $(SRC_DIR)/css/%.css,$(BUILD_DIR)/css/%.css, $(CSS_SRC))
 
 # Nginx permalink redirect configuration
 PERMALINKS_CONF := $(BUILD_DIR)/permalinks.conf
@@ -149,10 +149,10 @@ $(BUILD_SUBDIRS):
 	$(call status,Create directory $@)
 	$(Q)mkdir -p $@
 
-# Copy CSS files to the build directory
-$(BUILD_DIR)/%.css: %.css | $(BUILD_DIR)
-	$(call status,Copy CSS $<)
-	$(Q)cp $< $@
+# Compile SCSS files to the build directory
+$(BUILD_DIR)/css/%.css: $(SRC_DIR)/css/%.css | $(BUILD_DIR)/css
+	$(call status,Compile SCSS $<)
+	$(Q)python -m sass $< $@
 
 # Include and preprocess Markdown files up to three levels deep
 # See docs/guides/preprocess.md for preprocessing details

--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -152,7 +152,7 @@ $(BUILD_SUBDIRS):
 # Compile SCSS files to the build directory
 $(BUILD_DIR)/css/%.css: $(SRC_DIR)/css/%.css | $(BUILD_DIR)/css
 	$(call status,Compile SCSS $<)
-	$(Q)python -m sass $< $@
+	$(Q)pysassc $< $@
 
 # Include and preprocess Markdown files up to three levels deep
 # See docs/guides/preprocess.md for preprocessing details

--- a/app/shell/py/pie/pie/create/site.py
+++ b/app/shell/py/pie/pie/create/site.py
@@ -35,7 +35,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "docker-compose.yml": "docker-compose.yml.jinja",
         "src/index.md": "index.md.jinja",
         "src/index.yml": "index.yml.jinja",
-        "src/style.css": "style.css.jinja",
+        "src/css/style.css": "style.css.jinja",
         "src/pandoc-template.html": "pandoc-template.html.jinja",
         "src/dep.mk": "dep.mk.jinja",
         "src/robots.txt": "robots.txt.jinja",

--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -31,7 +31,7 @@ def test_create_scaffolding(tmp_path: Path) -> None:
 
     assert (target / "redo.mk").exists()
 
-    assert (target / "src/style.css").exists()
+    assert (target / "src/css/style.css").exists()
     assert (target / "src/pandoc-template.html").exists()
 
     shell_dockerfile = target / "app/shell/Dockerfile"

--- a/docs/guides/build-process.md
+++ b/docs/guides/build-process.md
@@ -38,6 +38,17 @@ HTML and assets to `build/`. Logs are stored in `log/`.
 
 If you only need the build step without starting services, run `r all` directly.
 
+## Styling with SCSS
+
+Site styles live under `src/css/` and are compiled with the Python `libsass` library into
+`build/css/`. The default stylesheet is `src/css/style.css` which supports
+full SCSS syntax. Any changes to files in this directory are automatically
+processed during the `r all` build and the output CSS is written to
+`build/css/style.css`.
+
+To add additional stylesheets, create new files in `src/css/` and reference the
+resulting `/css/*.css` paths from your pages or templates.
+
 ## Cleaning up
 
 Use the provided targets to tidy generated files:

--- a/docs/guides/create-site.md
+++ b/docs/guides/create-site.md
@@ -42,6 +42,7 @@ Then visit [http://localhost/examples](http://localhost/examples) to read the bu
 ## Next steps
 
 - **Developing content** – Learn more about the build pipeline and adding assets in [build-process.md](build-process.md) and [store-files.md](store-files.md).
+- **Customizing styles** – Edit `src/css/style.css` using SCSS syntax to style the site; the build compiles it to `build/css/style.css`.
 - **Contributing** – Before submitting changes to Press, review [tests.md](tests.md) and [checklinks.md](checklinks.md) to run tests and link checks.
 
 For additional topics, see the [guides index](README.md).

--- a/docs/guides/quiz-workflow.md
+++ b/docs/guides/quiz-workflow.md
@@ -86,7 +86,7 @@ A page can embed the quiz with:
 
 ## 4. Styling
 
-Both the site CSS (`src/style.css`) and the React bundle’s stylesheet (`app/quiz/src/index.css`) define classes like `.quiz-container`, `.question`, `.choice`, and `.answer` to style quizzes consistently.
+Both the site CSS (`src/css/style.css`) and the React bundle’s stylesheet (`app/quiz/src/index.css`) define classes like `.quiz-container`, `.question`, `.choice`, and `.answer` to style quizzes consistently.
 
 ## Summary
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -79,26 +79,30 @@ h3 {
 /* ==========================================================================
    NAVIGATION
    ========================================================================== */
+nav:not(#TOC) {
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    li {
+      display: inline-block;
+      padding-right: 0.5rem;
+      text-transform: uppercase;
+    }
+  }
+}
 
 nav.site-nav {
   margin-top: var(--space-lg);
-}
 
-nav.site-nav ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-nav.site-nav li {
-  display: inline-block;
-  text-transform: uppercase;
-}
-
-nav.site-nav li:not(:first-child) {
-  margin-left: var(--space-sm);        /* Spacing between nav items */
-  padding-left: var(--space-sm);
-  border-left: var(--border-nav);
+  li {
+    &:not(:first-child) {
+      margin-left: var(--space-sm);        /* Spacing between nav items */
+      padding-left: var(--space-sm);
+      border-left: var(--border-nav);
+    }
+  }
 }
 
 /* ==========================================================================
@@ -106,8 +110,7 @@ nav.site-nav li:not(:first-child) {
    ========================================================================== */
 
 ol,
-ul,
-#TOC > ul {
+ul {
   margin-left: var(--space-lg);
   padding-left: 0;
 }
@@ -116,10 +119,18 @@ ul,
   padding: 0 var(--space-md);
   border: var(--border-toc);
   border-radius: var(--border-radius);
-}
 
-#TOC summary {
-  cursor: pointer;
+  summary {
+    cursor: pointer;
+  }
+
+  /* Direct children of #TOC as decimal; adjust selectors for deeper nesting if needed */
+  > ul,
+  ul {
+    list-style-type: decimal;
+    margin-left: 1.5em; /* optional indentation adjustment */
+    padding-left: 0;
+  }
 }
 
 /* ==========================================================================
@@ -183,24 +194,6 @@ img.thumbnail {
     }
 }
 
-nav:not(#TOC) ul {
-    list-style-type: none;
-    padding-left: 0;
-}
-
-nav:not(#TOC) ul li {
-    display: inline-block;
-    padding-right: 0.5rem;
-    text-transform: uppercase;
-}
-
-/* Direct children of #TOC as decimal; adjust selectors for deeper nesting
-* if needed */
-#TOC > ul, #TOC ul {
-    list-style-type: decimal;
-    margin-left: 1.5em; /* optional indentation adjustment */
-}
-
 .footer {
     padding-top: 1.5rem;
     padding-bottom: 1.5rem;
@@ -220,17 +213,17 @@ a {
 .image-container {
   position: relative;
   display: inline-block;
-}
-
-.magnify-icon {
-  position: absolute;
-  bottom: 10px;
-  right: 10px;
-  background-color: rgba(255, 255, 255, 0.8);
-  border-radius: 50%;
-  padding: 6px;
-  font-size: 20px;
-  cursor: pointer;
+  
+  .magnify-icon {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    background-color: rgba(255, 255, 255, 0.8);
+    border-radius: 50%;
+    padding: 6px;
+    font-size: 20px;
+    cursor: pointer;
+  }
 }
 
 .citation {
@@ -250,78 +243,83 @@ ol + details.answer {
 .quiz-container {
   max-width: 600px;
   margin: 2rem auto;
-}
 
-.question-block {
-  margin-bottom: 2rem;
-}
+  .question-block {
+    margin-bottom: 2rem;
+  }
 
-.question {
-  font-weight: bold;
-  margin-bottom: 0.5rem;
-}
+  .question {
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+  }
 
-.choices {
-  list-style-type: none;
-  padding: 0;
-}
+  .choices {
+    list-style-type: none;
+    padding: 0;
 
-.choice {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  margin-bottom: 0.3rem;
-  cursor: pointer;
-  border-radius: 4px;
-  user-select: none;
-}
+    .choice {
+      padding: 0.5rem;
+      border: 1px solid #ccc;
+      margin-bottom: 0.3rem;
+      cursor: pointer;
+      border-radius: 4px;
+      user-select: none;
 
-.choice:hover {
-  background-color: #f5f5f5;
-}
+      &:hover {
+        background-color: #f5f5f5;
+      }
 
-.choice.selected {
-  background-color: #e0f7fa;
-}
+      &.selected {
+        background-color: #e0f7fa;
+      }
 
-.choice.correct {
-  background-color: #c8f7c5;
-  border-color: #27ae60;
-}
+      &.correct {
+        background-color: #c8f7c5;
+        border-color: #27ae60;
+      }
 
-.choice.incorrect {
-  background-color: #f7c5c5;
-  border-color: #e74c3c;
-}
+      &.incorrect {
+        background-color: #f7c5c5;
+        border-color: #e74c3c;
+      }
+    }
+  }
 
-.explanation {
-  background: #f9f9f9;
-  padding: 0.5rem;
-  margin-top: 0.5rem;
-  border-left: 3px solid #ccc;
-}
+  .explanation {
+    background: #f9f9f9;
+    padding: 0.5rem;
+    margin-top: 0.5rem;
+    border-left: 3px solid #ccc;
+  }
 
-.submit-btn {
-  padding: 0.5rem 1rem;
-  font-size: 1rem;
-  cursor: pointer;
+  .submit-btn {
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    cursor: pointer;
+  }
 }
 
 dt {
   font-weight: bold;
 }
-dd + dt {
-  margin-top: 1em;
-}
-dd + dd {
-  margin-top: 0.5em;
-}
-dd > p {
-  margin-top: 0;
+
+dd {
+  & + dt {
+    margin-top: 1em;
+  }
+
+  & + dd {
+    margin-top: 0.5em;
+  }
+
+  > p {
+    margin-top: 0;
+  }
 }
 ul.examples {
   list-style: none;
 }
 
 pre {
-    overflow: auto;
+  overflow: auto;
 }


### PR DESCRIPTION
## Summary
- Switch shell image to use Python libsass for SCSS compilation
- Compile `src/css` with libsass in build Makefile
- Document libsass-based styling process for contributors
- Refactor stylesheet with nested navigation, TOC, and quiz rules

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flatten_dict')*


------
https://chatgpt.com/codex/tasks/task_e_68a0d0cf196c8321838665960522959d