### PR TITLE
Use env file for Docker configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and adjust values as needed.
+S3_BUCKET_PATH=s3://press
+S3CFG_PATH=/root/.s3cfg
+OPENAI_API_KEY=
+REDIS_HOST=dragonfly
+REDIS_PORT=6379
+TEST_HOST_URL=http://nginx-test

--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ Press is a static-site generator built on Pandoc and Docker, orchestrated with `
 
 All project documentation lives under [docs/](docs/). Start with the [guides](docs/guides/README.md) for step-by-step workflows and see the [reference](docs/reference/README.md) for technical details.
 
+## Configuration
+
+Environment variables for Docker services are defined in a `.env` file.
+The makefile copies `.env.example` to `.env` if it does not exist; adjust the
+values as needed.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,7 @@ services:
     build: ./app/s3
     container_name: press-sync
     entrypoint: ["/app/bin/sync"]
-    environment:
-      S3_BUCKET_PATH: ${S3_BUCKET_PATH:-s3://press}
-      S3CFG_PATH: ${S3CFG_PATH:-/root/.s3cfg}
+    env_file: .env
     volumes:
       - ../s3:/s3
 
@@ -38,9 +36,7 @@ services:
     build: ./app/s3
     container_name: press-seed
     entrypoint: ["/app/bin/seed"]
-    environment:
-      S3_BUCKET_PATH: ${S3_BUCKET_PATH:-s3://press}
-      S3CFG_PATH: ${S3CFG_PATH:-/root/.s3cfg}
+    env_file: .env
     volumes:
       - ../s3:/s3
 
@@ -66,11 +62,7 @@ services:
     build: ./app/shell
     container_name: press-shell
     entrypoint: ["bash"]
-    environment:
-      OPENAI_API_KEY: "${OPENAI_API_KEY}"
-      REDIS_HOST: dragonfly
-      REDIS_PORT: 6379
-      TEST_HOST_URL: ${TEST_HOST_URL:-http://nginx-test}
+    env_file: .env
     volumes:
       - ./:/data
       - ./app/shell/mk:/app/mk

--- a/docs/guides/redo-mk.md
+++ b/docs/guides/redo-mk.md
@@ -6,6 +6,9 @@ is meant to be invoked with `make -f redo.mk` (often aliased to `r`). By default
 it prints only brief status messages; set `VERBOSE=1` to also show the
 underlying commands.
 
+When invoked, `redo.mk` ensures a `.env` file exists by copying
+`.env.example` if needed.
+
 This repository actually uses three Makefiles that work together:
 
 - **`redo.mk`** – run from the host to start Docker containers and delegate

--- a/docs/guides/sync-service.md
+++ b/docs/guides/sync-service.md
@@ -14,6 +14,9 @@ Use `redo.mk` to build and start the container:
 r sync
 ```
 
-The service mirrors the host `s3/` directory to the bucket specified by `S3_BUCKET_PATH` (default `s3://press`). Credentials come from the file at `S3CFG_PATH` (default `/root/.s3cfg`).
+The service mirrors the host `s3/` directory to the bucket specified by
+`S3_BUCKET_PATH` (default `s3://press`). Credentials come from the file at
+`S3CFG_PATH` (default `/root/.s3cfg`). Configure these values in the
+project's `.env` file.
 
 Files removed locally are deleted from the bucket via `s3cmd --delete-removed --delete-after --acl-public`.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -21,7 +21,11 @@ The top-level Makefile (`redo.mk`) drives all host-side automation. It launches 
 - `nginx` and `nginx-dev` serve generated content.
 - `shell` provides the build environment and exposes tools and tests.
 - `dragonfly` supplies a Redis-compatible store used for tracking document metadata.
-- Auxiliary services `sync`, `seed`, and `webp` handle S3 uploads, database seeding, and WebP image conversion. The `sync` and `seed` containers read the S3 bucket from the `S3_BUCKET_PATH` environment variable (default: `s3://press`) and the S3 configuration file from `S3CFG_PATH` (default: `/root/.s3cfg`).
+- Auxiliary services `sync`, `seed`, and `webp` handle S3 uploads,
+  database seeding, and WebP image conversion. The `sync` and `seed`
+  containers read the S3 bucket from `S3_BUCKET_PATH` (default `s3://press`)
+  and the S3 configuration file from `S3CFG_PATH` (default `/root/.s3cfg`),
+  which are set in the project's `.env` file.
 
 ## Build Pipeline
 The shell container executes `app/shell/mk/build.mk` to transform sources into deliverables:

--- a/redo.mk
+++ b/redo.mk
@@ -8,6 +8,9 @@ override MAKEFLAGS += --warn-undefined-variables  \
 # Export it so sub-makes see the same flags
 export MAKEFLAGS
 
+# Load environment variables from .env if present; create it from .env.example if missing
+-include .env
+
 # Containers started when running `up`/`upd`.
 # See docs/guides/redo-mk.md for details on targets and variables and
 # docs/guides/dep-mk.md for dependency file conventions.
@@ -189,3 +192,8 @@ tags:
 .PHONY: release
 release:
 	$(Q)VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) ./bin/release
+
+.env: .env.example
+	$(call status,Create .env from example)
+	$(Q)cp $< $@
+	$(call status,Review .env and edit to suit your needs)


### PR DESCRIPTION
## Summary
- switch Docker services to load environment variables from `.env`
- add `.env.example` and update documentation to reference it
- ensure `redo.mk` copies `.env.example` to `.env` when missing and reminds users to customize it
- restore single-line table entries in the `redo.mk` guide and keep `release` target recipe tab-indented

## Testing
- `pip install beautifulsoup4 flatten_dict loguru`
- `pytest` *(fails: Interrupted: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d34c3508832198399d4b91e3d0bf