### PR TITLE
support per-file pandoc templates via redis metadata

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -45,13 +45,12 @@ PANDOC_TEMPLATE := $(SRC_DIR)/pandoc-template.html
 # Options for generating HTML output with Pandoc
 PANDOC_OPTS := \
                 --css '/css/style.css' \
-		--standalone \
-		-t html \
-		--toc \
-		--toc-depth=2 \
-		--filter pandoc-crossref \
-		--mathjax \
-		--template=$(PANDOC_TEMPLATE) \
+                --standalone \
+                -t html \
+                --toc \
+                --toc-depth=2 \
+                --filter pandoc-crossref \
+                --mathjax \
 
 # Options for generating PDF output with Pandoc
 PANDOC_OPTS_PDF := \
@@ -162,8 +161,8 @@ $(BUILD_DIR)/%.md: %.md | $(BUILD_DIR)
 
 # Generate HTML from processed Markdown using Pandoc
 $(BUILD_DIR)/%.html: $(BUILD_DIR)/%.md $(PANDOC_TEMPLATE) | $(BUILD_DIR)
-	$(call status,Generate HTML $@)
-	$(Q)$(PANDOC_CMD) $(PANDOC_OPTS) -o $@ $<
+    $(call status,Generate HTML $@)
+    $(Q)$(PANDOC_CMD) $(PANDOC_OPTS) --template=$(PANDOC_TEMPLATE) -o $@ $<
 
 # Generate PDF from processed Markdown using Pandoc
 # include-filter usage is documented in docs/guides/include-filter.md

--- a/docs/guides/picasso.md
+++ b/docs/guides/picasso.md
@@ -37,6 +37,20 @@ build/index.html: build/index.md build/index.yml
 Each `.yml` file produces similar targets for preprocessing the metadata and
 rendering the final HTML.
 
+## Custom Pandoc Templates
+
+`picasso` retrieves per-document metadata from Redis. If a document defines
+`pandoc.template`, that template path is added as a dependency and passed to
+Pandoc's `--template` option when rendering. For example:
+
+```yaml
+pandoc:
+  template: src/blog/pandoc-template.html
+```
+
+This allows different pages to use specialized templates while falling back to
+`$(PANDOC_TEMPLATE)` when no custom template is provided.
+
 The command also inspects Markdown files for cross-document links and any
 `include-filter` Python blocks.  Dependencies discovered this way are emitted as
 additional Makefile rules so that updates to referenced files trigger a rebuild


### PR DESCRIPTION
## Summary
- allow specifying a pandoc template per YAML file
- load per-file pandoc templates from Redis metadata
- document Redis metadata lookup for custom templates

## Testing
- `pytest` *(fails: 33 errors during collection)*
- `pytest app/shell/py/pie/tests/test_picasso.py::test_generate_rule_basic -q`
- `pytest app/shell/py/pie/tests/test_picasso.py::test_generate_rule_with_template -q`
- `pytest app/shell/py/pie/tests/test_main_prints_rules -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f475051483219a5321c1a28c5574