### PR TITLE
feat: add status messages to picasso

### DIFF
--- a/app/shell/py/pie/pie/templates/picasso.rule.mk.jinja
+++ b/app/shell/py/pie/pie/templates/picasso.rule.mk.jinja
@@ -1,0 +1,9 @@
+{preprocessed_yml}: {input_path}
+	$(call status,Preprocess $<)
+	$(Q)mkdir -p $(dir {preprocessed_yml})
+	$(Q)emojify < $< > $@
+	$(Q)render-jinja-template $@ $@
+{output_html}: {preprocessed_md} {preprocessed_yml} {template_dep}
+	$(call status,Generate HTML $@)
+	$(Q)$(PANDOC_CMD) $(PANDOC_OPTS) {template_arg} --metadata-file={preprocessed_yml} -o $@ $<
+	$(Q)check-bad-jinja-output $@

--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -16,10 +16,12 @@ def test_generate_rule_basic(tmp_path, monkeypatch):
     rule = picasso.generate_rule(Path("src/foo/bar.yml")).strip()
     expected = (
         "build/foo/bar.yml: src/foo/bar.yml\n"
+        "\t$(call status,Preprocess $<)\n"
         "\t$(Q)mkdir -p $(dir build/foo/bar.yml)\n"
         "\t$(Q)emojify < $< > $@\n"
         "\t$(Q)render-jinja-template $@ $@\n"
         "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml $(PANDOC_TEMPLATE)\n"
+        "\t$(call status,Generate HTML $@)\n"
         "\t$(Q)$(PANDOC_CMD) $(PANDOC_OPTS) --template=$(PANDOC_TEMPLATE) --metadata-file=build/foo/bar.yml -o $@ $<\n"
         "\t$(Q)check-bad-jinja-output $@"
     )
@@ -43,10 +45,12 @@ def test_generate_rule_with_template(tmp_path, monkeypatch):
     rule = picasso.generate_rule(Path("src/foo/bar.yml")).strip()
     expected = (
         "build/foo/bar.yml: src/foo/bar.yml\n"
+        "\t$(call status,Preprocess $<)\n"
         "\t$(Q)mkdir -p $(dir build/foo/bar.yml)\n"
         "\t$(Q)emojify < $< > $@\n"
         "\t$(Q)render-jinja-template $@ $@\n"
         "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml src/blog/pandoc-template.html\n"
+        "\t$(call status,Generate HTML $@)\n"
         "\t$(Q)$(PANDOC_CMD) $(PANDOC_OPTS) --template=src/blog/pandoc-template.html --metadata-file=build/foo/bar.yml -o $@ $<\n"
         "\t$(Q)check-bad-jinja-output $@"
     )

--- a/docs/guides/picasso.md
+++ b/docs/guides/picasso.md
@@ -28,9 +28,13 @@ For a source file `src/index.yml` the output looks like:
 
 ```make
 build/index.yml: src/index.yml
+    $(call status,Preprocess $<)
+    mkdir -p $(dir build/index.yml)
     emojify < $< > $@
-build/index.html: build/index.md build/index.yml
-    $(PANDOC_CMD) $(PANDOC_OPTS) --metadata-file=build/index.yml -o $@ $<
+    render-jinja-template $@ $@
+build/index.html: build/index.md build/index.yml $(PANDOC_TEMPLATE)
+    $(call status,Generate HTML $@)
+    $(PANDOC_CMD) $(PANDOC_OPTS) --template=$(PANDOC_TEMPLATE) --metadata-file=build/index.yml -o $@ $<
     check-bad-jinja-output $@
 ```
 


### PR DESCRIPTION
## Summary
- emit status messages in picasso-generated Make rules
- externalize rule template for picasso Make recipes

## Testing
- `pytest app/shell/py/pie/tests/test_picasso.py` *(fails: redis.exceptions.ConnectionError: Error -2 connecting to dragonfly:6379. Name or service not known)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis')*


------
https://chatgpt.com/codex/tasks/task_e_68a10190dea08321bdd210b7e62a9100