### PR TITLE
Handle Jinja link globals in dependency generation

### DIFF
--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -119,6 +119,28 @@ def test_generate_dependencies_link_global(tmp_path):
     assert deps == ["build/index.md: build/quickstart.md"]
 
 
+def test_generate_dependencies_adds_all_referenced_files(tmp_path):
+    """link to id with .md and .yml -> deps include both files."""
+    src = tmp_path / "src"
+    build = tmp_path / "build"
+    src.mkdir()
+
+    quick_md = src / "quickstart.md"
+    quick_md.write_text("---\nid: quickstart\n---\nbody")
+    quick_yml = src / "quickstart.yml"
+    quick_yml.write_text("id: quickstart\n")
+
+    index = src / "index.md"
+    index.write_text('{{"quickstart"|link}}')
+
+    deps = picasso.generate_dependencies(src, build)
+
+    assert sorted(deps) == [
+        "build/index.md: build/quickstart.md",
+        "build/index.md: build/quickstart.yml",
+    ]
+
+
 def test_dependencies_from_include_filter(tmp_path):
     """include('src/inc.md') -> build/index.md: build/inc.md."""
     src = tmp_path / "src"

--- a/docs/guides/picasso.md
+++ b/docs/guides/picasso.md
@@ -60,7 +60,8 @@ The command also inspects Markdown files for cross-document links and any
 `{{link("target-id")}}` are treated the same as filter expressions like
 `{{"target-id"|link}}`. Dependencies discovered this way are emitted as
 additional Makefile rules so that updates to referenced files trigger a rebuild
-of the including document.
+of the including document.  If a referenced document has both Markdown and YAML
+sources, dependencies are added for each existing file.
 
 If these dependencies form a cycle, `picasso` logs a warning and drops the
 minimum number of rules required to break the loop. The build continues with the


### PR DESCRIPTION
## Summary
- detect Jinja `link()` calls when computing picasso dependency rules
- refactor dependency generation with `_build_path` and `_file_dependencies` helpers
- document link global dependency scanning
- add regression tests for link globals and adjust module execution test

## Testing
- `pytest app/shell/py/pie/tests/test_picasso.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3531f854c8321970d90ae9ac58f5a