### PR TITLE
docs: document upgrade script

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -26,6 +26,8 @@ concepts and data formats, see the
 - [sync-service.md](sync-service.md) – upload site files to S3 using the sync container.
 - [webp-service.md](webp-service.md) – convert images to WebP using the helper
   container.
+- [upgrade.md](upgrade.md) – rebuild containers and run tests
+  after pulling changes.
 
 Refer to the individual files for additional guides not listed here.
 

--- a/docs/guides/upgrade.md
+++ b/docs/guides/upgrade.md
@@ -1,0 +1,24 @@
+# upgrade helper
+
+`bin/upgrade` rebuilds the development environment after pulling new changes. It stops running containers, rebuilds images and dependencies, and runs the full test suite to ensure the project is ready.
+
+## Usage
+
+```bash
+./bin/upgrade
+```
+
+The script performs the following steps:
+
+1. Stops existing Docker services.
+2. Cleans the workspace with `distclean` and rebuilds the shell image.
+3. Runs `make`, `make test`, and `pytest` to validate the build.
+4. Restarts `nginx-test` and other required containers.
+
+### Environment variables
+
+- `VERBOSE` – set to `1` for verbose `make` output. Defaults to `0`.
+- `SRC_DIR` – source directory for `make`. Defaults to `src`.
+- `BUILD_DIR` – build output directory for `make`. Defaults to `build`.
+
+Run this script after `git pull` to keep your development environment in sync with repository changes.


### PR DESCRIPTION
## Summary
- document `bin/upgrade` helper for rebuilding and testing after pulling changes
- link upgrade guide from services and utilities list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a499ddaffc8321b3d752a4d470e799