### PR TITLE
test: cover deprecated process yaml command

### DIFF
--- a/app/shell/py/pie/tests/test_process_yaml.py
+++ b/app/shell/py/pie/tests/test_process_yaml.py
@@ -1,0 +1,18 @@
+import pytest
+from pie import process_yaml
+
+
+def test_main_deprecates_and_exits():
+    with pytest.raises(SystemExit) as excinfo:
+        process_yaml.main()
+    assert (
+        "process-yaml is deprecated; YAML metadata is processed automatically."
+        in str(excinfo.value)
+    )
+
+
+def test_module_executes_as_script():
+    import runpy, sys
+    sys.modules.pop("pie.process_yaml", None)
+    with pytest.raises(SystemExit):
+        runpy.run_module("pie.process_yaml", run_name="__main__")


### PR DESCRIPTION
## Summary
- test deprecation warning for process-yaml command
- ensure module run exits with SystemExit

## Testing
- `pytest app/shell/py/pie/tests/test_process_yaml.py --cov=pie.process_yaml -q`

------
https://chatgpt.com/codex/tasks/task_e_68a49a3f2f488321a7603a0be04f505b