### PR TITLE
feat: add create-site helper script

### DIFF
--- a/bin/create-site
+++ b/bin/create-site
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Description:
+#   Run the project's `create-site` command inside the Docker Compose
+#   `shell` service. This executes the command in the container using
+#   the current user's UID so generated files are owned by the invoking
+#   user.
+#
+# Usage:
+#   bin/create-site [ARGS...]
+#
+# Any arguments provided are forwarded directly to the `create-site`
+# command inside the container.
+
+set -euo pipefail
+
+COMPOSE_FILE="docker-compose.yml"
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  COMPOSE_FILE="dist/docker-compose.yml"
+fi
+
+exec docker compose -f "$COMPOSE_FILE" run --rm -u "$(id -u)" --entrypoint create-site shell "$@"

--- a/docs/guides/create-site.md
+++ b/docs/guides/create-site.md
@@ -7,7 +7,7 @@ This tutorial shows how to scaffold and run a new Press site.
 Run the helper script with the desired project name:
 
 ```bash
-./bin/bash -c "create-site newsite"
+./bin/create-site newsite
 cd newsite
 git init
 ```


### PR DESCRIPTION
## Summary
- add bin/create-site script for running `create-site` inside the shell container
- update documentation to use the new helper

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a52701c883219c20553b52ad3e68