### PR TITLE
Remove dist docker-compose references

### DIFF
--- a/app/shell/py/pie/pie/create/templates/redo.mk.jinja
+++ b/app/shell/py/pie/pie/create/templates/redo.mk.jinja
@@ -18,7 +18,7 @@ BUILD_DIR := build
 
 VPATH := $(SRC_DIR)
 
-COMPOSE_FILE := $(if $(wildcard docker-compose.yml),docker-compose.yml,dist/docker-compose.yml)
+COMPOSE_FILE := docker-compose.yml
 DOCKER_COMPOSE := docker compose -f $(COMPOSE_FILE)
 
 MAKE_CMD := $(DOCKER_COMPOSE) run --rm --entrypoint make -u $(shell id -u) -T shell

--- a/bin/create-post
+++ b/bin/create-post
@@ -15,8 +15,5 @@
 set -euo pipefail
 
 COMPOSE_FILE="docker-compose.yml"
-if [[ ! -f "$COMPOSE_FILE" ]]; then
-  COMPOSE_FILE="dist/docker-compose.yml"
-fi
 
 exec docker compose -f "$COMPOSE_FILE" run --rm -u "$(id -u)" --entrypoint create-post shell "$@"

--- a/bin/create-site
+++ b/bin/create-site
@@ -15,8 +15,5 @@
 set -euo pipefail
 
 COMPOSE_FILE="docker-compose.yml"
-if [[ ! -f "$COMPOSE_FILE" ]]; then
-  COMPOSE_FILE="dist/docker-compose.yml"
-fi
 
 exec docker compose -f "$COMPOSE_FILE" run --rm -u "$(id -u)" --entrypoint create-site shell "$@"

--- a/bin/release
+++ b/bin/release
@@ -28,11 +28,7 @@ VERBOSE="${VERBOSE:-0}"
 SRC_DIR="${SRC_DIR:-src}"
 BUILD_DIR="${BUILD_DIR:-build}"
 
-if [ -f docker-compose.yml ]; then
-  COMPOSE_FILE="docker-compose.yml"
-else
-  COMPOSE_FILE="dist/docker-compose.yml"
-fi
+COMPOSE_FILE="docker-compose.yml"
 
 DOCKER_COMPOSE=(docker compose -f "$COMPOSE_FILE")
 

--- a/bin/shell
+++ b/bin/shell
@@ -53,8 +53,5 @@ while [[ $# -gt 0 ]]; do
 done
 
 COMPOSE_FILE="docker-compose.yml"
-if [[ ! -f "$COMPOSE_FILE" ]]; then
-  COMPOSE_FILE="dist/docker-compose.yml"
-fi
 
 exec docker compose -f "$COMPOSE_FILE" run --rm --build "${uid_flag[@]}" shell "$@"

--- a/bin/store-files
+++ b/bin/store-files
@@ -15,8 +15,5 @@
 set -euo pipefail
 
 COMPOSE_FILE="docker-compose.yml"
-if [[ ! -f "$COMPOSE_FILE" ]]; then
-  COMPOSE_FILE="dist/docker-compose.yml"
-fi
 
 exec docker compose -f "$COMPOSE_FILE" run --rm -u "$(id -u)" --entrypoint store-files shell "$@"

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -9,11 +9,7 @@ VERBOSE="${VERBOSE:-0}"
 SRC_DIR="${SRC_DIR:-src}"
 BUILD_DIR="${BUILD_DIR:-build}"
 
-if [ -f docker-compose.yml ]; then
-  COMPOSE_FILE="docker-compose.yml"
-else
-  COMPOSE_FILE="dist/docker-compose.yml"
-fi
+COMPOSE_FILE="docker-compose.yml"
 
 DOCKER_COMPOSE=(docker compose -f "$COMPOSE_FILE")
 

--- a/redo.mk
+++ b/redo.mk
@@ -18,7 +18,7 @@ BUILD_DIR := build
 
 VPATH := $(SRC_DIR)
 
-COMPOSE_FILE := $(if $(wildcard docker-compose.yml),docker-compose.yml,dist/docker-compose.yml)
+COMPOSE_FILE := docker-compose.yml
 DOCKER_COMPOSE := docker compose -f $(COMPOSE_FILE)
 
 COMPOSE_RUN := $(DOCKER_COMPOSE) run --build --rm -T


### PR DESCRIPTION
## Summary
- simplify compose file configuration to only use `docker-compose.yml`
- drop `dist/docker-compose.yml` fallback from helper scripts

## Testing
- `pytest app/shell/py/pie/tests`

------
https://chatgpt.com/codex/tasks/task_e_68a4aeece08c8321bd323bc91153a7bb