### PR TITLE
Ensure metadata text uses accessible contrast

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -202,7 +202,7 @@ img.thumbnail {
 
 .metablock {
   font-size: 0.8em;
-  color: darkgray;
+  color: var(--color-text);
   margin-top: 0;
 }
 


### PR DESCRIPTION
## Summary
- use main text color for metadata blocks to boost contrast

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4be275648832188ed79b078423655