### PR TITLE
Add URL underscore checker

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -139,6 +139,8 @@ check:
 	$(Q)check-post-build -c $(CFG_DIR)/check-post-build.yml
 	$(call status,Check for unexpanded Jinja)
 	$(Q)check-unexpanded-jinja $(BUILD_DIR)
+	$(call status,Check for URL underscores)
+	$(Q)check-underscores $(BUILD_DIR)
 
 # Create necessary build directories
 $(BUILD_DIR): | $(BUILD_SUBDIRS)

--- a/app/shell/py/pie/pie/check/underscores.py
+++ b/app/shell/py/pie/pie/check/underscores.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Report URLs containing underscores.
+
+The ``check-underscores`` console script scans HTML files for URLs that
+contain underscores and exits with a non-zero status when any are found.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from bs4 import BeautifulSoup
+
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
+
+DEFAULT_LOG = "log/check-underscores.txt"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = create_parser(
+        "Check HTML files for URLs containing underscores.",
+        log_default=DEFAULT_LOG,
+    )
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="build",
+        help="Root directory to scan for HTML files",
+    )
+    return parser.parse_args(argv)
+
+
+def _iter_urls(path: Path) -> Iterable[str]:
+    """Yield URLs discovered in ``href`` and ``src`` attributes."""
+    with path.open(encoding="utf-8", errors="ignore") as f:
+        soup = BeautifulSoup(f, "html.parser")
+    for attr in ("href", "src"):
+        for tag in soup.find_all(attrs={attr: True}):
+            yield tag[attr]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``check-underscores`` console script."""
+    args = parse_args(argv)
+    Path(args.log).parent.mkdir(parents=True, exist_ok=True)
+    configure_logging(args.verbose, args.log)
+
+    root = Path(args.directory)
+    bad_urls: set[str] = set()
+    for html in root.rglob("*.html"):
+        for url in _iter_urls(html):
+            if "_" in url:
+                logger.error("Underscore in URL", path=str(html), url=url)
+                bad_urls.add(url)
+    if bad_urls:
+        logger.warning("Using dashes instead of underscores in URLs is recommended.")
+        for url in sorted(bad_urls):
+            logger.warning("Fix URL", url=url)
+        return 1
+    logger.info("No URLs with underscores found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -23,6 +23,7 @@ setup(
             'check-page-title=pie.check.page_title:main',
             'check-post-build=pie.check.post_build:main',
             'check-unexpanded-jinja=pie.check.unexpanded_jinja:main',
+            'check-underscores=pie.check.underscores:main',
             'create-post=pie.create.post:main',
             'create-site=pie.create.site:main',
             'emojify=pie.filter.emojify:main',

--- a/app/shell/py/pie/tests/test_check_underscores.py
+++ b/app/shell/py/pie/tests/test_check_underscores.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pie.check import underscores as check_underscores
+
+
+def test_main_pass(tmp_path: Path) -> None:
+    """URL without underscore -> exit code 0."""
+    html = tmp_path / "index.html"
+    html.write_text('<a href="foo-bar.html">link</a>', encoding="utf-8")
+    assert check_underscores.main([str(tmp_path)]) == 0
+
+
+def test_main_fail(tmp_path: Path, capsys) -> None:
+    """URL with underscore -> exit code 1 and report URL."""
+    html = tmp_path / "index.html"
+    html.write_text('<a href="foo_bar.html">link</a>', encoding="utf-8")
+    assert check_underscores.main([str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert "foo_bar.html" in captured.err
+    assert "dashes" in captured.err
+
+
+def test_main_fail_src(tmp_path: Path, capsys) -> None:
+    """Underscore in ``src`` attribute is reported."""
+    html = tmp_path / "index.html"
+    html.write_text('<img src="foo_bar.png" />', encoding="utf-8")
+    assert check_underscores.main([str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert "foo_bar.png" in captured.err

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -14,8 +14,9 @@ concepts and data formats, see the
 - [update-index.md](update-index.md) – keep the index in sync after edits.
 
 ## Validation and testing
-- [check-page-title.md](check-page-title.md) – verify page titles.
 - [checklinks.md](checklinks.md) – scan rendered HTML for broken links.
+- [check-page-title.md](check-page-title.md) – verify page titles.
+- [check-underscores.md](check-underscores.md) – report URLs that contain underscores.
 - [tests.md](tests.md) – run the automated test suite.
 
 ## Services and utilities

--- a/docs/guides/check-underscores.md
+++ b/docs/guides/check-underscores.md
@@ -1,0 +1,15 @@
+# check-underscores
+
+`check-underscores` scans HTML files for URLs that contain underscores. Using
+underscores in URLs is discouraged; dashes are preferred for readability and
+search engine optimisation. The command reports offending URLs and exits with a
+non-zero status when it finds any.
+
+## Usage
+
+```bash
+check-underscores [directory]
+```
+
+If no directory is provided, `build/` is scanned. The script lists each URL
+containing underscores so they can be replaced with dashes.


### PR DESCRIPTION
## Summary
- add `check-underscores` console script to list URLs containing underscores and recommend dashes
- document the new script in the guides and expose it via setup entry points
- run URL underscore check as part of the `check` target
- restore Pandoc PDF options alignment in `build.mk`
- parse HTML with BeautifulSoup instead of regex to discover URLs

## Testing
- `pytest app/shell/py/pie/tests -q`
- `make -f app/shell/mk/build.mk check` *(fails: Missing artifact 'build/static/js/indextree.js' and 'build/static/js/quiz.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a4c737d23c83218a0fe278e40321ce