### PR TITLE
check-underscores: ignore external URLs

### DIFF
--- a/app/shell/py/pie/pie/check/underscores.py
+++ b/app/shell/py/pie/pie/check/underscores.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Report URLs containing underscores.
+"""Report internal URLs containing underscores.
 
-The ``check-underscores`` console script scans HTML files for URLs that
+The ``check-underscores`` console script scans HTML files for internal URLs that
 contain underscores. Some third-party links legitimately use underscores,
 so the command only emits warnings by default. Pass ``--error`` to exit
 with a non-zero status when any underscores are discovered.
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from typing import Iterable
+from urllib.parse import urlparse
 
 from bs4 import BeautifulSoup
 
@@ -60,7 +61,8 @@ def main(argv: list[str] | None = None) -> int:
     bad_urls: set[str] = set()
     for html in root.rglob("*.html"):
         for url in _iter_urls(html):
-            if "_" in url:
+            parsed = urlparse(url)
+            if not parsed.scheme and not parsed.netloc and "_" in url:
                 logger.error("Underscore in URL", path=str(html), url=url)
                 bad_urls.add(url)
     if bad_urls:

--- a/app/shell/py/pie/tests/test_check_underscores.py
+++ b/app/shell/py/pie/tests/test_check_underscores.py
@@ -31,6 +31,17 @@ def test_warn_src(tmp_path: Path, capsys) -> None:
     assert "foo_bar.png" in captured.err
 
 
+def test_ignore_external(tmp_path: Path, capsys) -> None:
+    """External links with underscores are ignored."""
+    html = tmp_path / "index.html"
+    html.write_text(
+        '<a href="https://example.com/foo_bar.html">link</a>', encoding="utf-8"
+    )
+    assert check_underscores.main([str(tmp_path)]) == 0
+    captured = capsys.readouterr()
+    assert "foo_bar.html" not in captured.err
+
+
 def test_error_flag(tmp_path: Path) -> None:
     """`--error` exits with status 1 when underscores are present."""
     html = tmp_path / "index.html"

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -16,7 +16,7 @@ concepts and data formats, see the
 ## Validation and testing
 - [checklinks.md](checklinks.md) – scan rendered HTML for broken links.
 - [check-page-title.md](check-page-title.md) – verify page titles.
-- [check-underscores.md](check-underscores.md) – report URLs that contain underscores.
+- [check-underscores.md](check-underscores.md) – report internal URLs that contain underscores.
 - [tests.md](tests.md) – run the automated test suite.
 
 ## Services and utilities

--- a/docs/guides/check-underscores.md
+++ b/docs/guides/check-underscores.md
@@ -1,10 +1,10 @@
 # check-underscores
 
-`check-underscores` scans HTML files for URLs that contain underscores. Using
-underscores in URLs is discouraged; dashes are preferred for readability and
-search engine optimisation. Some external links legitimately use underscores, so
-the command only prints warnings by default. Pass `--error` to exit with a
-non-zero status when underscores are found.
+`check-underscores` scans HTML files for internal URLs that contain underscores.
+Using underscores in URLs is discouraged; dashes are preferred for readability
+and search engine optimisation. External links are ignored because third-party
+sites often use underscores legitimately. Pass `--error` to exit with a non-zero
+status when underscores are found.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Skip external links when scanning for underscores, limiting `check-underscores` to internal URLs
- Document the new behaviour in the guides
- Test that external links with underscores are ignored

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest app/shell/py/pie/tests/test_check_underscores.py`
- `pytest app/shell/py/pie/tests`

------
https://chatgpt.com/codex/tasks/task_e_68a4d732ffe88321982d8797b3669aaf