### PR TITLE
Ensure internal links have dedicated CSS class

### DIFF
--- a/app/indextree/src/IndexTree.jsx
+++ b/app/indextree/src/IndexTree.jsx
@@ -114,7 +114,13 @@ export default function IndexTree({ src }) {
             const node = idMap.get(itemId);
             return {
               label: node?.url ? (
-                <a href={node.url} onClick={(e) => e.stopPropagation()}>{label}</a>
+                <a
+                  href={node.url}
+                  className="internal-link"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {label}
+                </a>
               ) : (
                 label
               ),

--- a/app/shell/py/pie/pie/filter/include.py
+++ b/app/shell/py/pie/pie/filter/include.py
@@ -117,7 +117,15 @@ def include_deflist_entry(
             url = get_metadata_by_path(rel, "url")
             if title:
                 if url:
-                    print(f"<dt><a href=\"{url}\">{title}</a></dt>", file=outfile)
+                    cls = (
+                        ""
+                        if url.startswith(("http://", "https://"))
+                        else ' class="internal-link"'
+                    )
+                    print(
+                        f"<dt><a href=\"{url}\"{cls}>{title}</a></dt>",
+                        file=outfile,
+                    )
                 else:
                     print(f"<dt>{title}</dt>", file=outfile)
             print("<dd>", file=outfile)

--- a/app/shell/py/pie/tests/test_include_filter.py
+++ b/app/shell/py/pie/tests/test_include_filter.py
@@ -89,6 +89,30 @@ def test_include_deflist_entry_writes_entries(tmp_path, monkeypatch):
         include_filter.outfile = None
 
 
+def test_include_deflist_entry_adds_internal_class(tmp_path, monkeypatch):
+    """Internal links receive the internal-link class."""
+    c = tmp_path / "c.md"
+    c.write_text("C\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+
+    include_filter.outfile = StringIO()
+
+    def fake_meta(path: str, key: str):
+        data = {"c.md": {"title": "Title C", "url": "/c"}}
+        return data.get(path, {}).get(key)
+
+    with patch("pie.filter.include.get_metadata_by_path", side_effect=fake_meta):
+        include_filter.include_deflist_entry("c.md")
+    try:
+        assert (
+            include_filter.outfile.getvalue()
+            == '<dt><a href="/c" class="internal-link">Title C</a></dt>\n<dd>\nC\n</dd>\n'
+        )
+    finally:
+        include_filter.outfile = None
+
+
 def test_yield_lines_stops_at_code_fence():
     """yield_lines stops when encountering a closing fence."""
     f = StringIO("a\nb\n```\nrest\n")

--- a/src/pandoc-template.html
+++ b/src/pandoc-template.html
@@ -48,7 +48,7 @@
         <!-- site nav -->
         <nav class="site-nav">
             <ul>
-                <li><a href="/">Home</a></li>
+                <li><a href="/" class="internal-link">Home</a></li>
             </ul>
         </nav>
 


### PR DESCRIPTION
## Summary
- Add `internal-link` class to template navigation links
- Apply `internal-link` class when generating internal links in `include` filter
- Use `internal-link` class in the index tree component and test internal link handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4dc94c8308321a1b036e0ef58c3c9