### PR TITLE
Add sitemap generation step and robots.txt reference

### DIFF
--- a/app/shell/bin/sitemap
+++ b/app/shell/bin/sitemap
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Generate a sitemap.xml file from HTML files in a directory.
+# Usage: sitemap [DIRECTORY]
+# If DIRECTORY is not provided, defaults to build/.
+set -euo pipefail
+
+SRC_DIR="${1:-build}"
+
+# Find all HTML files relative to SRC_DIR.
+mapfile -t files < <(find "$SRC_DIR" -type f -name '*.html' | sed "s|^$SRC_DIR/||" | sort)
+
+{
+  echo '<?xml version="1.0" encoding="UTF-8"?>'
+  echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+  for f in "${files[@]}"; do
+    echo "  <url><loc>/${f}</loc></url>"
+  done
+  echo '</urlset>'
+} > build/sitemap.xml

--- a/app/shell/bin/sitemap
+++ b/app/shell/bin/sitemap
@@ -4,10 +4,10 @@
 # If DIRECTORY is not provided, defaults to build/.
 set -euo pipefail
 
-SRC_DIR="${1:-build}"
+BUILD_DIR="${1:-build}"
 
-# Find all HTML files relative to SRC_DIR.
-mapfile -t files < <(find "$SRC_DIR" -type f -name '*.html' | sed "s|^$SRC_DIR/||" | sort)
+# Find all HTML files relative to BUILD_DIR.
+mapfile -t files < <(find "$BUILD_DIR" -type f -name '*.html' | sed "s|^$BUILD_DIR/||" | sort)
 
 {
   echo '<?xml version="1.0" encoding="UTF-8"?>'

--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -102,10 +102,15 @@ everything: | $(BUILD_DIR) $(BUILD_SUBDIRS)
 all: $(HTMLS)
 all: $(CSS)
 all: $(BUILD_DIR)/robots.txt
+all: $(BUILD_DIR)/sitemap.xml
 all: $(PERMALINKS_CONF)
 
 $(BUILD_DIR)/robots.txt: $(SRC_DIR)/robots.txt
 	cp $< $@
+
+$(BUILD_DIR)/sitemap.xml: $(HTMLS)
+	$(call status,Generate sitemap)
+	$(Q)sitemap $(BUILD_DIR)
 
 $(PERMALINKS_CONF): $(MARKDOWNS) $(YAMLS) | $(BUILD_DIR) $(LOG_DIR)
 	$(call status,Generate permalink redirects)

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: /sitemap.xml


### PR DESCRIPTION
## Summary
- generate `build/sitemap.xml` from built HTML files via `sitemap`
- invoke sitemap generation from `app/shell/mk/build.mk` using PATH utility
- reference the sitemap in `src/robots.txt`

## Testing
- `make -f redo.mk all` *(fails: docker: No such file or directory)*
- `pytest app/shell/py/pie/tests` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dcaae73483218655fbb1f9f56c71