### PR TITLE
Log generated redirect count

### DIFF
--- a/app/shell/py/pie/pie/nginx_permalinks.py
+++ b/app/shell/py/pie/pie/nginx_permalinks.py
@@ -111,6 +111,8 @@ def main(argv: Sequence[str] | None = None) -> None:
     else:
         print(output, end="")
 
+    logger.info("Generated redirects", count=len(redirects))
+
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     main()


### PR DESCRIPTION
## Summary
- log the number of generated redirects after creating Nginx rules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a74c370a548321b61d54abc8db709e