### PR TITLE
feat: support sitemap base url

### DIFF
--- a/app/shell/bin/sitemap
+++ b/app/shell/bin/sitemap
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 # Generate a sitemap.xml file from HTML files in a directory.
-# Usage: sitemap [DIRECTORY]
+# Usage: sitemap [DIRECTORY] [BASE_URL]
 # If DIRECTORY is not provided, defaults to build/.
+# BASE_URL may also be provided through the BASE_URL environment variable.
 set -euo pipefail
 
 BUILD_DIR="${1:-build}"
+BASE_URL="${2:-${BASE_URL:-}}"
+
+if [[ -z "$BASE_URL" ]]; then
+  echo "Usage: sitemap [DIRECTORY] BASE_URL" >&2
+  exit 1
+fi
+
+# Strip trailing slash to avoid // in output.
+BASE_URL="${BASE_URL%/}"
 
 # Find all HTML files relative to BUILD_DIR.
 mapfile -t files < <(find "$BUILD_DIR" -type f -name '*.html' | sed "s|^$BUILD_DIR/||" | sort)
@@ -13,7 +23,7 @@ mapfile -t files < <(find "$BUILD_DIR" -type f -name '*.html' | sed "s|^$BUILD_D
   echo '<?xml version="1.0" encoding="UTF-8"?>'
   echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
   for f in "${files[@]}"; do
-    echo "  <url><loc>/${f}</loc></url>"
+    echo "  <url><loc>${BASE_URL}/${f}</loc></url>"
   done
   echo '</urlset>'
-} > build/sitemap.xml
+} > "$BUILD_DIR/sitemap.xml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       REDIS_HOST: dragonfly
       REDIS_PORT: 6379
       TEST_HOST_URL: ${TEST_HOST_URL:-http://nginx-test}
+      BASE_URL: ${BASE_URL:-http://localhost}
     volumes:
       - ./:/data
       - ./app/shell/mk:/app/mk

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -18,6 +18,7 @@ documents provide context for the task‑oriented
 - [update-pubdate.md](update-pubdate.md) – update the `pubdate` field for modified files.
 - [update-link-filters.md](update-link-filters.md) – convert legacy `link*` filters into globals.
 - [shell.md](shell.md) – run the project's shell service via docker compose.
+- [sitemap.md](sitemap.md) – generate an XML sitemap with absolute URLs.
 - [standalone-bin-scripts.md](standalone-bin-scripts.md) – rationale for self-contained helper scripts.
 
 For step‑by‑step workflows and tutorials, head back to the

--- a/docs/reference/sitemap.md
+++ b/docs/reference/sitemap.md
@@ -1,0 +1,15 @@
+# sitemap
+
+Generate `sitemap.xml` from the HTML files in the build directory.
+
+```bash
+sitemap [DIRECTORY] [BASE_URL]
+```
+
+- `DIRECTORY` – location of the HTML files; defaults to `build`.
+- `BASE_URL` – base URL for absolute links. When omitted, the command reads
+  the `BASE_URL` environment variable.
+
+`docker-compose.yml` exposes `BASE_URL` so the value can be configured in the
+compose environment.
+


### PR DESCRIPTION
## Summary
- generate absolute URLs in sitemap
- allow passing base URL via argument or BASE_URL env
- document sitemap base URL usage

## Testing
- `BASE_URL=http://example.com make -f redo.mk test` *(fails: make: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a759d588d88321bc19782109603d8d