### PR TITLE
Log YAML parsing errors with file name

### DIFF
--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -131,8 +131,9 @@ def read_from_yaml(filepath: str) -> Optional[Dict[str, Any]]:
 
     try:
         return read_yaml(filepath)
-    except yaml.YAMLError:
-        logger.warning("Failed to parse YAML file", filename=filepath)
+    except yaml.YAMLError as err:
+        err.add_note(f"file: {filepath}")
+        logger.warning("Failed to parse YAML file {}", filepath)
         raise
 
 # Global connection reused by helper functions.  It is initialised lazily so

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import yaml
 
 from pie import metadata
 
@@ -78,4 +79,17 @@ def test_load_metadata_pair_conflict_shows_path(tmp_path):
         assert "dir/post.yml" in str(record[0].message)
     finally:
         os.chdir("/tmp")
+
+
+def test_read_from_yaml_error_logs_path(tmp_path):
+    """Malformed YAML reports the filename."""
+    bad = tmp_path / "bad.yml"
+    bad.write_text(":\n")
+    os.chdir(tmp_path)
+    try:
+        with pytest.raises(yaml.YAMLError) as excinfo:
+            metadata.read_from_yaml("bad.yml")
+    finally:
+        os.chdir("/tmp")
+    assert "bad.yml" in str(excinfo.value)
 


### PR DESCRIPTION
## Summary
- log malformed YAML file name in pie.metadata
- test that YAML parse errors include the filename

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75eeeea008321bb455f5ee8e3ad13