### PR TITLE
Switch distbuild to SSH-based communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,7 @@ dist/app/webp/output
 logs
 log/
 app/*/.init
+
+# SSH keys generated for distbuild
+app/distbuild/id_rsa
+app/distbuild/id_rsa.pub

--- a/app/distbuild/Dockerfile.master
+++ b/app/distbuild/Dockerfile.master
@@ -10,11 +10,11 @@ RUN apt-get update \
     && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys \
     && chmod 600 /root/.ssh/authorized_keys /root/.ssh/id_rsa
 
-RUN pip install --no-cache-dir --break-system-packages fabric invoke
-
 WORKDIR /app
-COPY py /app/py
-ENV PYTHONPATH=/app/py
+COPY . /app
+RUN pip install --no-cache-dir --break-system-packages .
+RUN mkdir -p /data
+WORKDIR /data
 
 EXPOSE 22
 ENTRYPOINT ["/usr/sbin/sshd", "-D"]

--- a/app/distbuild/Dockerfile.master
+++ b/app/distbuild/Dockerfile.master
@@ -10,11 +10,11 @@ RUN apt-get update \
     && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys \
     && chmod 600 /root/.ssh/authorized_keys /root/.ssh/id_rsa
 
-RUN pip install --no-cache-dir fabric invoke
+RUN pip install --no-cache-dir --break-system-packages fabric invoke
 
 WORKDIR /app
 COPY py /app/py
 ENV PYTHONPATH=/app/py
 
 EXPOSE 22
-CMD ["/usr/sbin/sshd", "-D"]
+ENTRYPOINT ["/usr/sbin/sshd", "-D"]

--- a/app/distbuild/Dockerfile.master
+++ b/app/distbuild/Dockerfile.master
@@ -1,0 +1,20 @@
+FROM press-shell
+
+RUN apt-get update \
+    && apt-get install -y openssh-server \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /var/run/sshd \
+    && ssh-keygen -A \
+    && mkdir -p /root/.ssh \
+    && ssh-keygen -t rsa -N '' -f /root/.ssh/id_rsa \
+    && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys \
+    && chmod 600 /root/.ssh/authorized_keys /root/.ssh/id_rsa
+
+RUN pip install --no-cache-dir fabric invoke
+
+WORKDIR /app
+COPY py /app/py
+ENV PYTHONPATH=/app/py
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/app/distbuild/Dockerfile.worker
+++ b/app/distbuild/Dockerfile.worker
@@ -10,11 +10,11 @@ RUN apt-get update \
     && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys \
     && chmod 600 /root/.ssh/authorized_keys /root/.ssh/id_rsa
 
-RUN pip install --no-cache-dir --break-system-packages fabric invoke
-
 WORKDIR /app
-COPY py /app/py
-ENV PYTHONPATH=/app/py
+COPY . /app
+RUN pip install --no-cache-dir --break-system-packages .
+RUN mkdir -p /data
+WORKDIR /data
 
 EXPOSE 22
 ENTRYPOINT ["/usr/sbin/sshd", "-D"]

--- a/app/distbuild/Dockerfile.worker
+++ b/app/distbuild/Dockerfile.worker
@@ -10,11 +10,11 @@ RUN apt-get update \
     && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys \
     && chmod 600 /root/.ssh/authorized_keys /root/.ssh/id_rsa
 
-RUN pip install --no-cache-dir fabric invoke
+RUN pip install --no-cache-dir --break-system-packages fabric invoke
 
 WORKDIR /app
 COPY py /app/py
 ENV PYTHONPATH=/app/py
 
 EXPOSE 22
-CMD ["/usr/sbin/sshd", "-D"]
+ENTRYPOINT ["/usr/sbin/sshd", "-D"]

--- a/app/distbuild/Dockerfile.worker
+++ b/app/distbuild/Dockerfile.worker
@@ -1,0 +1,20 @@
+FROM press-shell
+
+RUN apt-get update \
+    && apt-get install -y openssh-server \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /var/run/sshd \
+    && ssh-keygen -A \
+    && mkdir -p /root/.ssh \
+    && ssh-keygen -t rsa -N '' -f /root/.ssh/id_rsa \
+    && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys \
+    && chmod 600 /root/.ssh/authorized_keys /root/.ssh/id_rsa
+
+RUN pip install --no-cache-dir fabric invoke
+
+WORKDIR /app
+COPY py /app/py
+ENV PYTHONPATH=/app/py
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/app/distbuild/README.md
+++ b/app/distbuild/README.md
@@ -1,0 +1,42 @@
+# Distributed Build Prototype
+
+This directory provides a minimal master/worker build system driven entirely
+over SSH. The master node dispatches commands to workers using
+[Fabric](https://www.fabfile.org/) (Paramiko/SSH).
+
+## Components
+
+- `py/distbuild/cli.py` – console entrypoint that relays jobs to the worker.
+- `py/distbuild/worker.py` – helper module providing `execute_commands` used by
+  the master.
+- `Dockerfile.master` and `Dockerfile.worker` – container images running an SSH
+  daemon for the master and worker nodes.
+- `tests/` – unit tests for the worker module.
+- `bin/distbuild` – host helper script that invokes the master over SSH.
+
+## Usage
+
+1. Build and start the services:
+
+   ```bash
+   docker compose up -d build-master build-worker
+   ```
+
+2. Render a Markdown file with pandoc through the master:
+
+   ```bash
+   ./app/distbuild/bin/distbuild "pandoc README.md -o README.html"
+   ```
+
+   The resulting `README.html` will be written to the repository root.
+
+Fresh SSH keys are generated for both containers on each build. The master
+connects to workers listed in the `WORKER_HOSTS` environment variable and uses a
+simple round-robin load balancer that favors remote workers before falling back
+to local execution.
+
+The `Dockerfile.master` and `Dockerfile.worker` both run the same `ssh-keygen`
+steps. Docker's layer cache reuses the generated key material across the two
+images, so the master and worker end up sharing an identical key pair. The
+master's private key (`/root/.ssh/id_rsa`) matches the public key preloaded into
+the worker's `authorized_keys`, enabling passwordless SSH between the nodes.

--- a/app/distbuild/bin/distbuild
+++ b/app/distbuild/bin/distbuild
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
+set -x
 ssh -o StrictHostKeyChecking=no -p 2222 root@localhost python -m distbuild.cli "$@"

--- a/app/distbuild/bin/distbuild
+++ b/app/distbuild/bin/distbuild
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ssh -o StrictHostKeyChecking=no -p 2222 root@localhost python -m distbuild.cli "$@"

--- a/app/distbuild/bin/distbuild
+++ b/app/distbuild/bin/distbuild
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-set -x
 # Run this wrapper via `docker compose exec build-master ./bin/distbuild`.
 ssh -o StrictHostKeyChecking=no root@localhost "cd /data && distbuild \"$@\""

--- a/app/distbuild/bin/distbuild
+++ b/app/distbuild/bin/distbuild
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 set -x
-ssh -o StrictHostKeyChecking=no -p 2222 root@localhost python -m distbuild.cli "$@"
+# Run this wrapper via `docker compose exec build-master ./bin/distbuild`.
+ssh -o StrictHostKeyChecking=no root@localhost "cd /data && distbuild \"$@\""

--- a/app/distbuild/docs/README.md
+++ b/app/distbuild/docs/README.md
@@ -1,0 +1,14 @@
+# Distbuild
+
+The `distbuild` package provides a CLI for dispatching commands to workers over SSH.
+
+## Usage
+
+Run the wrapper script from the host using Docker Compose:
+
+```bash
+docker compose exec build-master ./bin/distbuild <command>
+```
+
+All commands executed by `distbuild` start in the `/data` directory within the
+`build-master` and `build-worker` containers.

--- a/app/distbuild/py/distbuild/__main__.py
+++ b/app/distbuild/py/distbuild/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/app/distbuild/py/distbuild/cli.py
+++ b/app/distbuild/py/distbuild/cli.py
@@ -1,0 +1,31 @@
+import argparse
+import sys
+
+from .worker import execute_commands
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Dispatch commands to a worker via SSH"
+    )
+    parser.add_argument("commands", nargs="+", help="Commands to execute")
+    parser.add_argument("--host", help="Explicit worker hostname")
+    args = parser.parse_args()
+    results = execute_commands(
+        args.commands,
+        host=args.host,
+        connect_kwargs={"key_filename": "/root/.ssh/id_rsa"},
+    )
+    exit_code = 0
+    for res in results:
+        if res["stdout"]:
+            sys.stdout.write(res["stdout"])
+        if res["stderr"]:
+            sys.stderr.write(res["stderr"])
+        if res["returncode"]:
+            exit_code = res["returncode"]
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/distbuild/py/distbuild/cli.py
+++ b/app/distbuild/py/distbuild/cli.py
@@ -1,10 +1,13 @@
 import argparse
+import os
 import sys
 
 from .worker import execute_commands
 
 
 def main() -> None:
+    if os.path.isdir("/data"):
+        os.chdir("/data")
     parser = argparse.ArgumentParser(
         description="Dispatch commands to a worker via SSH"
     )

--- a/app/distbuild/py/distbuild/worker.py
+++ b/app/distbuild/py/distbuild/worker.py
@@ -1,0 +1,74 @@
+from collections import deque
+import os
+from typing import Any, Deque, Dict, List, Optional
+
+from fabric import Connection, Config
+from invoke import run as local_run
+
+
+class RoundRobinBalancer:
+    """Simple round-robin load balancer.
+
+    Remote hosts are rotated first and the local machine is appended to the
+    cycle, ensuring remote workers receive jobs before falling back to local
+    execution.
+    """
+
+    def __init__(self, hosts: List[str]):
+        self.hosts: Deque[Optional[str]] = deque(h for h in hosts if h)
+        self.hosts.append(None)  # local fallback
+
+    def next(self) -> Optional[str]:
+        host = self.hosts[0]
+        self.hosts.rotate(-1)
+        return host
+
+
+_BALANCER = RoundRobinBalancer(
+    os.environ.get("WORKER_HOSTS", "").split(",")
+)
+
+
+def execute_commands(
+    commands: List[str],
+    host: Optional[str] = None,
+    connect_kwargs: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """Execute shell commands sequentially and collect their results.
+
+    Commands are dispatched to hosts in a round-robin fashion with remote hosts
+    prioritized. If ``host`` is provided it overrides the balancer selection.
+    ``fabric`` (Paramiko) executes remote commands; local commands use
+    ``invoke``.
+    """
+
+    results: List[Dict[str, Any]] = []
+    connect_kwargs = connect_kwargs or {}
+
+    if host is None:
+        host = _BALANCER.next()
+
+    if host:
+        config = Config(overrides={"load_known_hosts": False})
+        conn = Connection(
+            host,
+            user="root",
+            connect_kwargs=connect_kwargs,
+            config=config,
+        )
+        runner = lambda c: conn.run(c, hide=True, warn=True, pty=False, in_stream=False)
+    else:
+        runner = lambda c: local_run(c, hide=True, warn=True, pty=False, in_stream=False)
+
+    for cmd in commands:
+        completed = runner(cmd)
+        results.append(
+            {
+                "cmd": cmd,
+                "returncode": completed.exited,
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+            }
+        )
+    return results
+

--- a/app/distbuild/py/distbuild/worker.py
+++ b/app/distbuild/py/distbuild/worker.py
@@ -56,7 +56,9 @@ def execute_commands(
             connect_kwargs=connect_kwargs,
             config=config,
         )
-        runner = lambda c: conn.run(c, hide=True, warn=True, pty=False, in_stream=False)
+        runner = lambda c: conn.run(
+            f"cd /data && {c}", hide=True, warn=True, pty=False, in_stream=False
+        )
     else:
         runner = lambda c: local_run(c, hide=True, warn=True, pty=False, in_stream=False)
 

--- a/app/distbuild/requirements.txt
+++ b/app/distbuild/requirements.txt
@@ -1,0 +1,3 @@
+fabric
+invoke
+-e file:../shell/py/pie

--- a/app/distbuild/setup.py
+++ b/app/distbuild/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="distbuild",
+    version="0.1.0",
+    packages=find_packages(where="py"),
+    package_dir={"": "py"},
+    install_requires=[
+        "fabric",
+        "invoke",
+    ],
+    entry_points={
+        "console_scripts": [
+            "distbuild=distbuild.cli:main",
+        ],
+    },
+)

--- a/app/distbuild/tests/test_worker.py
+++ b/app/distbuild/tests/test_worker.py
@@ -1,0 +1,11 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "py"))
+from distbuild.worker import execute_commands
+
+
+def test_execute_commands_echo():
+    results = execute_commands(["echo hello"])
+    assert results[0]["returncode"] == 0
+    assert "hello" in results[0]["stdout"].strip()

--- a/app/distbuild/tests/test_worker.py
+++ b/app/distbuild/tests/test_worker.py
@@ -1,7 +1,3 @@
-import pathlib
-import sys
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "py"))
 from distbuild.worker import execute_commands
 
 

--- a/app/shell/Dockerfile
+++ b/app/shell/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get update -qq && \
         locales \
         make \
         minify \
-        pysassc && \
+        pysassc \
+        wget && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,3 +94,25 @@ services:
     volumes:
       - ./app/shell/py/pie:/pie
     profiles: ["pdoc"]
+
+  build-worker:
+    build:
+      context: ./app/distbuild
+      dockerfile: Dockerfile.worker
+    container_name: press-build-worker
+    volumes:
+      - ./:/data
+
+  build-master:
+    build:
+      context: ./app/distbuild
+      dockerfile: Dockerfile.master
+    container_name: press-build-master
+    environment:
+      WORKER_HOSTS: build-worker
+    volumes:
+      - ./:/data
+    ports:
+      - "2222:22"
+    depends_on:
+      - build-worker


### PR DESCRIPTION
## Summary
- replace `master.py` with a `distbuild` CLI and helper host script
- document converting Markdown with Pandoc via the new CLI
- remove stray Fabric dependency from pie requirements
- relocate `distbuild` host wrapper to `app/distbuild/bin`

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `(cd app/distbuild && pip install -r requirements.txt)`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a74a99486083219af69bbfd11be236