### PR TITLE
Package distbuild and expose CLI

### DIFF
--- a/app/distbuild/Dockerfile.master
+++ b/app/distbuild/Dockerfile.master
@@ -10,11 +10,11 @@ RUN apt-get update \
     && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys \
     && chmod 600 /root/.ssh/authorized_keys /root/.ssh/id_rsa
 
-RUN pip install --no-cache-dir --break-system-packages fabric invoke
-
 WORKDIR /app
-COPY py /app/py
-ENV PYTHONPATH=/app/py
+COPY . /app
+RUN pip install --no-cache-dir --break-system-packages .
+RUN mkdir -p /data
+WORKDIR /data
 
 EXPOSE 22
 ENTRYPOINT ["/usr/sbin/sshd", "-D"]

--- a/app/distbuild/Dockerfile.worker
+++ b/app/distbuild/Dockerfile.worker
@@ -10,11 +10,11 @@ RUN apt-get update \
     && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys \
     && chmod 600 /root/.ssh/authorized_keys /root/.ssh/id_rsa
 
-RUN pip install --no-cache-dir --break-system-packages fabric invoke
-
 WORKDIR /app
-COPY py /app/py
-ENV PYTHONPATH=/app/py
+COPY . /app
+RUN pip install --no-cache-dir --break-system-packages .
+RUN mkdir -p /data
+WORKDIR /data
 
 EXPOSE 22
 ENTRYPOINT ["/usr/sbin/sshd", "-D"]

--- a/app/distbuild/bin/distbuild
+++ b/app/distbuild/bin/distbuild
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 set -x
-ssh -o StrictHostKeyChecking=no -p 2222 root@localhost python -m distbuild.cli "$@"
+# Run this wrapper via `docker compose exec build-master ./bin/distbuild`.
+ssh -o StrictHostKeyChecking=no root@localhost "cd /data && distbuild \"$@\""

--- a/app/distbuild/docs/README.md
+++ b/app/distbuild/docs/README.md
@@ -1,0 +1,14 @@
+# Distbuild
+
+The `distbuild` package provides a CLI for dispatching commands to workers over SSH.
+
+## Usage
+
+Run the wrapper script from the host using Docker Compose:
+
+```bash
+docker compose exec build-master ./bin/distbuild <command>
+```
+
+All commands executed by `distbuild` start in the `/data` directory within the
+`build-master` and `build-worker` containers.

--- a/app/distbuild/py/distbuild/cli.py
+++ b/app/distbuild/py/distbuild/cli.py
@@ -1,10 +1,13 @@
 import argparse
+import os
 import sys
 
 from .worker import execute_commands
 
 
 def main() -> None:
+    if os.path.isdir("/data"):
+        os.chdir("/data")
     parser = argparse.ArgumentParser(
         description="Dispatch commands to a worker via SSH"
     )

--- a/app/distbuild/py/distbuild/worker.py
+++ b/app/distbuild/py/distbuild/worker.py
@@ -56,7 +56,9 @@ def execute_commands(
             connect_kwargs=connect_kwargs,
             config=config,
         )
-        runner = lambda c: conn.run(c, hide=True, warn=True, pty=False, in_stream=False)
+        runner = lambda c: conn.run(
+            f"cd /data && {c}", hide=True, warn=True, pty=False, in_stream=False
+        )
     else:
         runner = lambda c: local_run(c, hide=True, warn=True, pty=False, in_stream=False)
 

--- a/app/distbuild/setup.py
+++ b/app/distbuild/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="distbuild",
+    version="0.1.0",
+    packages=find_packages(where="py"),
+    package_dir={"": "py"},
+    install_requires=[
+        "fabric",
+        "invoke",
+    ],
+    entry_points={
+        "console_scripts": [
+            "distbuild=distbuild.cli:main",
+        ],
+    },
+)

--- a/app/distbuild/tests/test_worker.py
+++ b/app/distbuild/tests/test_worker.py
@@ -1,7 +1,3 @@
-import pathlib
-import sys
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "py"))
 from distbuild.worker import execute_commands
 
 


### PR DESCRIPTION
## Summary
- ensure distbuild runs from `/data` in master and worker images
- document `distbuild` usage and wrapper invocation
- drop custom SSH port from wrapper script

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pip install -e app/distbuild`
- `pytest app/distbuild`


------
https://chatgpt.com/codex/tasks/task_e_68a76ef5d4688321bf0a661eeb7b1c88