### PR TITLE
feat: switch blog example to MUI theme

### DIFF
--- a/src/examples/blog/hero.svg
+++ b/src/examples/blog/hero.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 400">
+  <rect width="1200" height="400" fill="#F4A460"/>
+  <text x="50%" y="50%" fill="#FFFFFF" font-size="64" dominant-baseline="middle"
+        text-anchor="middle">Fall Hero</text>
+</svg>

--- a/src/examples/blog/index.md
+++ b/src/examples/blog/index.md
@@ -1,6 +1,6 @@
 <section>
 Welcome to the future of blogging! This sample article demonstrates the
-`pandoc` blog template included with Press.
+MUI-powered blog template included with Press.
 </section>
 
 <section>
@@ -29,8 +29,8 @@ improving performance on slower devices.
 - customize accent colors
 - extend the fade-in effect with your own classes
 
-Water.css provides a clean base, while the template's variables make it
-simple to tweak the look.
+MUI's baseline and theming system make it simple to tweak the look while
+keeping the footprint small.
 </section>
 
 <section>

--- a/src/examples/blog/index.yml
+++ b/src/examples/blog/index.yml
@@ -2,7 +2,7 @@ title: Trendy Blog Template Demo
 author: Ada Lovelace
 id: trendy-blog-template
 pubdate: Jan 1, 2025
-hero_image: https://via.placeholder.com/1200x400/F4A460/FFFFFF?text=Fall+Hero
+hero_image: hero.svg
 preamble: A short intro shows how you might tease readers into the story.
 pandoc:
   template: src/examples/blog/pandoc-template.html
@@ -12,6 +12,6 @@ css:
 header-includes:
   - '<script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>'
   - '<script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>'
-  - '<script src="https://unpkg.com/@emotion/react@11.11.1/umd/emotion-react.umd.min.js" crossorigin></script>'
-  - '<script src="https://unpkg.com/@emotion/styled@11.11.0/umd/emotion-styled.umd.min.js" crossorigin></script>'
+  - '<script src="https://unpkg.com/@emotion/react@11.11.1/dist/emotion-react.umd.min.js" crossorigin="anonymous"></script>'
+  - '<script src="https://unpkg.com/@emotion/styled@11.11.0/dist/emotion-styled.umd.min.js" crossorigin="anonymous"></script>'
   - '<script src="https://unpkg.com/@mui/material@5.15.0/umd/material-ui.production.min.js" crossorigin></script>'

--- a/src/examples/blog/index.yml
+++ b/src/examples/blog/index.yml
@@ -7,4 +7,11 @@ preamble: A short intro shows how you might tease readers into the story.
 pandoc:
   template: src/examples/blog/pandoc-template.html
 css:
-  - https://cdn.jsdelivr.net/npm/water.css@2/out/water.css
+  - https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap
+  - https://fonts.googleapis.com/icon?family=Material+Icons
+header-includes:
+  - '<script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>'
+  - '<script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>'
+  - '<script src="https://unpkg.com/@emotion/react@11.11.1/umd/emotion-react.umd.min.js" crossorigin></script>'
+  - '<script src="https://unpkg.com/@emotion/styled@11.11.0/umd/emotion-styled.umd.min.js" crossorigin></script>'
+  - '<script src="https://unpkg.com/@mui/material@5.15.0/umd/material-ui.production.min.js" crossorigin></script>'

--- a/src/examples/blog/pandoc-template.html
+++ b/src/examples/blog/pandoc-template.html
@@ -11,124 +11,58 @@
     <link rel="stylesheet" href="$css$"/>
     $endfor$
     <style>
-      :root {
-        --accent: #d17b0f;
-        --bg: #fff7ed;
-        --text: #332f2c;
-        --section-bg-1: #fff7ed;
-        --section-bg-2: #f4e3d7;
-      }
-      body {
-        background: var(--bg);
-        color: var(--text);
-        margin: auto;
-      }
-      .blog-post {
-        max-width: 70ch;
-        margin-left: auto;
-        margin-right: auto;
-        padding: 2rem;
-        font-family: system-ui, sans-serif;
-        line-height: 1.7;
-      }
-      .blog-post header {
-        text-align: center;
-        margin-bottom: 2.5rem;
-      }
-      .blog-post header .hero img {
-        width: 100%;
-        height: auto;
-        border-radius: 0.75rem;
-      }
-      .blog-post header .byline {
-        color: #666;
-        font-size: 0.95rem;
-        margin-top: 0.5rem;
-      }
-      .blog-post header .preamble {
-        font-style: italic;
-        color: #555;
-        margin-top: 1rem;
-      }
-      .blog-post h1,
-      .blog-post h2 {
-        color: var(--accent);
-        margin-top: var(--space-md);
-      }
-      .blog-post footer {
-        margin-top: 4rem;
-        text-align: center;
-        font-size: 0.85rem;
-        color: #777;
-      }
-      .content > section {
-        padding: 1rem;
-        margin: 0;
-      }
-      .content > section + section {
-        margin-top: 1.5rem;
-      }
-      .content > section:nth-of-type(odd) {
-        background: var(--section-bg-1);
-      }
-      .content > section:nth-of-type(even) {
-        background: var(--section-bg-2);
-      }
-      .fade-in {
-        opacity: 0;
-        transform: translateY(1.5rem);
-        transition: opacity .8s ease-out, transform .8s ease-out;
-      }
-      .fade-in.appear {
-        opacity: 1;
-        transform: none;
-      }
-      @media (max-width: 600px) {
-        .blog-post {
-          padding: 1.5rem;
-          margin-left: auto;
-          margin-right: auto;
-        }
-      }
+      .hero img { width: 100%; height: auto; border-radius: 4px; }
+      .byline { color: rgba(0,0,0,0.6); margin-top: 0.5rem; }
+      .preamble { font-style: italic; color: rgba(0,0,0,0.6); margin-top: 1rem; }
+      .fade-in { opacity: 0; transform: translateY(1.5rem); transition: opacity .8s ease-out, transform .8s ease-out; }
+      .fade-in.appear { opacity: 1; transform: none; }
     </style>
   </head>
   <body>
-    <article class="blog-post">
-      <header class="fade-in">
-        $if(hero_image)$
-        <div class="hero"><img src="$hero_image$" alt=""/></div>
-        $endif$
-        <h1>$title$</h1>
-        <p class="byline">
-          $if(author)$<span class="author">$author$</span>$endif$
-          $if(pubdate)$ • <time datetime="$pubdate$">$pubdate$</time>$endif$
-        </p>
-        $if(preamble)$<p class="preamble">$preamble$</p>$endif$
-      </header>
-      <section class="content">
-        $body$
-      </section>
-      <footer class="fade-in">
-        <hr/>
-        <p><small>Enjoyed this article? Share it!</small></p>
-      </footer>
-    </article>
+    <div id="root"></div>
+    <div id="content" style="display:none">
+      $if(hero_image)$
+      <div class="hero fade-in"><img src="$hero_image$" alt=""/></div>
+      $endif$
+      <h1 class="fade-in">$title$</h1>
+      <p class="byline fade-in">
+        $if(author)$<span class="author">$author$</span>$endif$
+        $if(pubdate)$ • <time datetime="$pubdate$">$pubdate$</time>$endif$
+      </p>
+      $if(preamble)$<p class="preamble fade-in">$preamble$</p>$endif$
+      <div class="content">$body$</div>
+    </div>
     $for(header-includes)$
     $header-includes$
     $endfor$
     <script>
-      document.addEventListener('DOMContentLoaded', () => {
-        document.querySelectorAll('.content > section').forEach(el => el.classList.add('fade-in'));
-        const observer = new IntersectionObserver((entries) => {
-          entries.forEach(entry => {
-            if (entry.isIntersecting) {
-              entry.target.classList.add('appear');
-              observer.unobserve(entry.target);
-            }
-          });
-        }, { threshold: 0.1 });
-        document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
-      });
+      const contentElement = document.getElementById('content');
+      const content = contentElement.innerHTML;
+      contentElement.remove();
+      const { createTheme, ThemeProvider, CssBaseline, Container } = MaterialUI;
+      function Blog() {
+        return React.createElement(ThemeProvider, { theme: createTheme() },
+          React.createElement(React.Fragment, null,
+            React.createElement(CssBaseline, null),
+            React.createElement(Container, { maxWidth: 'md', sx: { my: 4 } },
+              React.createElement('div', { dangerouslySetInnerHTML: { __html: content } })
+            )
+          )
+        );
+      }
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(React.createElement(Blog));
+      document.querySelectorAll('.content > section').forEach(el => el.classList.add('fade-in'));
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('appear');
+            observer.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.1 });
+      document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
     </script>
   </body>
 </html>
+


### PR DESCRIPTION
## Summary
- replace water.css with Material UI scripts and fonts to showcase a MUI-only blog theme
- refresh example copy to mention MUI baseline
- rebuild pandoc template so the demo renders through React and Material UI components

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7611619b083219691ab5a53cf033b