### PR TITLE
Add canonical link metadata generation

### DIFF
--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -8,6 +8,7 @@ import os
 import warnings
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional
+from urllib.parse import urljoin
 
 import redis
 from flatten_dict import unflatten
@@ -99,10 +100,32 @@ def _add_id_if_missing(metadata: dict[str, Any], filepath: str) -> None:
         )
 
 
+def _add_canonical_link_if_missing(
+    metadata: dict[str, Any], filepath: str
+) -> None:
+    """Create ``link.canonical`` from ``url`` when missing."""
+
+    if metadata.get("link", {}).get("canonical"):
+        return
+
+    url = metadata.get("url")
+    if url is None:
+        logger.debug(
+            "Skipping canonical link; no url present", filename=filepath
+        )
+        return
+
+    base_url = os.getenv("BASE_URL", "").rstrip("/")
+    canonical = urljoin(base_url + "/", url.lstrip("/")) if base_url else url
+
+    metadata.setdefault("link", {})["canonical"] = canonical
+
+
 def generate_missing_metadata(metadata: dict[str, Any], filepath: str) -> dict[str, Any]:
     """Populate ``metadata`` with fields derived from ``filepath`` if absent."""
 
     _add_url_if_missing(metadata, filepath)
+    _add_canonical_link_if_missing(metadata, filepath)
     _add_citation_if_missing(metadata, filepath)
     _add_id_if_missing(metadata, filepath)
     return metadata

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -15,6 +15,7 @@ This document lists the common metadata keys used by Press and explains how miss
 - `icon` – Emoji or icon displayed by link globals.
 - `link.tracking` – Boolean controlling external link behaviour.
 - `link.class` – CSS class for rendered links.
+- `link.canonical` – Absolute URL for the page.
 - `name` – **Deprecated.** Former display name used in navigation and indexes.
 
 ## Auto‑Generated Values
@@ -26,6 +27,7 @@ During indexing, `generate_missing_metadata` in `pie.metadata` fills in several 
 | `id`       | Filename without the extension                 |
 | `citation` | Lowercase form of the `title` value            |
 | `url`      | Derived from the source path (e.g. `src/foo.md` → `/foo.html`) |
+| `link.canonical` | Absolute form of the `url` value              |
 
 The `citation` value is used as the anchor text when other pages link to this document using Jinja globals such as `linktitle`.
 The helper that assigns these defaults lives in `generate_missing_metadata` within `pie.metadata`.

--- a/src/pandoc-template.html
+++ b/src/pandoc-template.html
@@ -35,6 +35,10 @@
         <meta$if(meta.name)$ name="$meta.name$"$endif$$if(meta.property)$ property="$meta.property$"$endif$ content="$meta.content$" />
         $endfor$
 
+        $if(link.canonical)$
+        <link rel="canonical" href="$link.canonical$" />
+        $endif$
+
         <!-- If you supply multiple CSS files via metadata -->
         <!-- The main stylesheet has to be included here because mobile browsers
             don't seem to apply the stylesheet otherwise, and fonts are too


### PR DESCRIPTION
## Summary
- generate `link.canonical` from `url` and `BASE_URL`
- include canonical `<link>` in pandoc template
- document canonical link metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7784280188321aa41b5727a319ff7