### PR TITLE
docs: add blog link to index

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1,13 +1,15 @@
-Welcome to the demo site for **Press**. Use the links below to explore key features.
+Welcome to the demo site for **Press**. Use the links below to explore key
+features.
 
-- [Quickstart](quickstart.md)
-- [Jinja Examples](examples/jinja.md)
-- [Link Global Examples](examples/link-globals.md)
-- [Responsive Image Examples](examples/responsive-images.md)
+- [Blog Demo](examples/blog/index.md)
 - [Chicago Citation Examples](examples/chicago-citations.md)
 - [Index Tree Demo](examples/indextree/index.md)
-- [Quiz Demo](quiz/index.md)
+- [Jinja Examples](examples/jinja.md)
+- [Link Global Examples](examples/link-globals.md)
 - [MagicBar Demo](magicbar/index.md)
+- [Quickstart](quickstart.md)
+- [Quiz Demo](quiz/index.md)
+- [Responsive Image Examples](examples/responsive-images.md)
 
 ## Emoji Replacement
 
@@ -23,7 +25,8 @@ For loops and other Jinja tricks see the [Jinja Examples](examples/jinja.md).
 
 ## Link Globals
 
-The [Link Global Examples](examples/link-globals.md) page shows how to format links using different helpers.
+The [Link Global Examples](examples/link-globals.md) page shows how to format
+links using different helpers.
 
 ## Quiz Demo
 


### PR DESCRIPTION
## Summary
- add blog demo link to index and sort examples alphabetically

## Testing
- `make -f redo.mk pytest` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a77946442c8321b922e404bdfb0306