### PR TITLE
feat: add SSH builder service

### DIFF
--- a/app/shell/Dockerfile
+++ b/app/shell/Dockerfile
@@ -22,10 +22,12 @@ RUN apt-get update -qq && \
         locales \
         make \
         minify \
+        openssh-server \
         pysassc && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /run/sshd
 
 # -------------------------------------------------------------------
 # Locale configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,15 @@ services:
       - ./app/shell/py/pie/tests:/press/py/pie/tests
       - ./src/dep.mk:/app/mk/dep.mk
 
+  builder:
+    image: press-shell
+    container_name: press-builder
+    entrypoint: ["sshd", "-D"]
+    ports:
+      - "2222:22"
+    volumes:
+      - ~/.ssh/id_rsa.pub:/root/.ssh/authorized_keys:ro
+
   release:
     image: press-release
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,10 +84,11 @@ services:
     image: press-shell
     container_name: press-builder
     # Copy the host's public key to a root-owned file before starting sshd.
-    entrypoint: ["/bin/sh", "-c", "install -m 600 /tmp/id_rsa.pub /root/.ssh/authorized_keys && /usr/sbin/sshd -D"]
+    entrypoint: ["/bin/sh", "-c", "mkdir -p /root/.ssh; install -m 600 /tmp/id_rsa.pub /root/.ssh/authorized_keys && /usr/sbin/sshd -D"]
     ports:
       - "2222:22"
     volumes:
+      - ./:/data
       - ~/.ssh/id_rsa.pub:/tmp/id_rsa.pub:ro
 
   release:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,11 +83,12 @@ services:
   builder:
     image: press-shell
     container_name: press-builder
-    entrypoint: ["sshd", "-D"]
+    # Copy the host's public key to a root-owned file before starting sshd.
+    entrypoint: ["/bin/sh", "-c", "install -m 600 /tmp/id_rsa.pub /root/.ssh/authorized_keys && /usr/sbin/sshd -D"]
     ports:
       - "2222:22"
     volumes:
-      - ~/.ssh/id_rsa.pub:/root/.ssh/authorized_keys:ro
+      - ~/.ssh/id_rsa.pub:/tmp/id_rsa.pub:ro
 
   release:
     image: press-release


### PR DESCRIPTION
## Summary
- install openssh-server in the shell image and prepare run directory for sshd
- add a builder service that runs sshd on port 2222 with authorized keys from the host

## Testing
- `pytest app/shell/py/pie/tests` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bf6eee6c8321a6690b5dc6c3acbf