### PR TITLE
Add MathJax delimiter check

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -138,6 +138,8 @@ test: $(BUILD_DIR)/.minify check | $(LOG_DIR)
 check:
 	$(call status,Check metadata authors)
 	$(Q)check-author $(SRC_DIR)
+	$(call status,Check for bad MathJax)
+	$(Q)check-bad-mathjax $(SRC_DIR)
 	$(call status,Check page titles)
 	$(Q)check-page-title -x $(CFG_DIR)/check-page-title-exclude.yml $(BUILD_DIR)
 	$(call status,Check post-build artifacts)

--- a/app/shell/py/pie/pie/check/bad_mathjax.py
+++ b/app/shell/py/pie/pie/check/bad_mathjax.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Fail if Markdown files use \(\) or \[\] math delimiters."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
+
+DEFAULT_LOG = "log/check-bad-mathjax.txt"
+PATTERNS = [
+    re.compile(r"\\\([^\n]*?\\\)"),
+    re.compile(r"\\\[[^\n]*?\\\]"),
+]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Return parsed command line arguments."""
+    parser = create_parser(
+        "Check Markdown files for LaTeX delimiters \\(\\) or \\[\\]",
+        log_default=DEFAULT_LOG,
+    )
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="src",
+        help="Root directory to scan for Markdown files",
+    )
+    return parser.parse_args(argv)
+
+
+def _has_bad_math(text: str) -> bool:
+    return any(pattern.search(text) for pattern in PATTERNS)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``check-bad-mathjax`` console script."""
+    args = parse_args(argv)
+    Path(args.log).parent.mkdir(parents=True, exist_ok=True)
+    configure_logging(args.verbose, args.log)
+
+    root = Path(args.directory)
+    ok = True
+    for md in root.rglob("*.md"):
+        text = md.read_text(encoding="utf-8")
+        if _has_bad_math(text):
+            logger.error("Found bad math delimiter", path=str(md))
+            ok = False
+    if ok:
+        logger.info("No bad math delimiters found.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -20,6 +20,7 @@ setup(
             'build-index=pie.build_index:main',
             'check-author=pie.check.author:main',
             'check-bad-jinja-output=pie.check.bad_jinja_output:main',
+            'check-bad-mathjax=pie.check.bad_mathjax:main',
             'check-page-title=pie.check.page_title:main',
             'check-post-build=pie.check.post_build:main',
             'check-unexpanded-jinja=pie.check.unexpanded_jinja:main',

--- a/app/shell/py/pie/tests/test_check_bad_mathjax.py
+++ b/app/shell/py/pie/tests/test_check_bad_mathjax.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pie.check import bad_mathjax as check_bad_mathjax
+
+
+def test_main_pass(tmp_path: Path) -> None:
+    """Markdown without bad delimiters -> exit code 0."""
+    md = tmp_path / "index.md"
+    md.write_text("$a$ and $$b$$", encoding="utf-8")
+    assert check_bad_mathjax.main([str(tmp_path)]) == 0
+
+
+def test_fail_inline(tmp_path: Path, capsys) -> None:
+    """Inline math using \(\) reports an error."""
+    md = tmp_path / "index.md"
+    md.write_text("text \\(a+b\\)", encoding="utf-8")
+    assert check_bad_mathjax.main([str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert "bad math" in captured.err
+
+
+def test_fail_display(tmp_path: Path, capsys) -> None:
+    """Display math using \[\] reports an error."""
+    md = tmp_path / "index.md"
+    md.write_text("\\[a+b\\]", encoding="utf-8")
+    assert check_bad_mathjax.main([str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert "bad math" in captured.err

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -17,6 +17,7 @@ concepts and data formats, see the
 - [checklinks.md](checklinks.md) – scan rendered HTML for broken links.
 - [check-page-title.md](check-page-title.md) – verify page titles.
 - [check-underscores.md](check-underscores.md) – report internal URLs that contain underscores.
+- [check-bad-mathjax.md](check-bad-mathjax.md) – detect old MathJax delimiters.
 - [tests.md](tests.md) – run the automated test suite.
 
 ## Services and utilities

--- a/docs/guides/check-bad-mathjax.md
+++ b/docs/guides/check-bad-mathjax.md
@@ -1,0 +1,14 @@
+# check-bad-mathjax
+
+`check-bad-mathjax` scans Markdown files for MathJax `\(` `\)` and `\[` `\]`
+delimiters. Inline math must use `$...$` and block math `$$...$$`. The script
+returns a non-zero exit status when deprecated delimiters are found.
+
+## Usage
+
+```bash
+check-bad-mathjax [directory]
+```
+
+The optional directory defaults to `src`. Each file that contains forbidden
+delimiters is logged for review.


### PR DESCRIPTION
## Summary
- fix tab indentation in `build.mk` check target
- add `check-bad-mathjax` guide and link from docs index

## Testing
- `pytest app/shell/py/pie/tests/test_check_bad_mathjax.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8a02319248321935566a763d66365