### PR TITLE
feat: move build rules to root makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Makefile for building and managing Press
 # Migrated from app/shell/mk/build.mk. Targets now run from the repository root.
 
+export PATH := /app/bin:$(PATH)
+export BASE_URL := http://localhost
+
 # Override MAKEFLAGS (so your settings can’t be clobbered by the environment)
 # docker-make previously passed these flags inside the container; still useful.
 override MAKEFLAGS += --warn-undefined-variables  \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,197 @@
+# Makefile for building and managing Press
+# Migrated from app/shell/mk/build.mk. Targets now run from the repository root.
+
+# Override MAKEFLAGS (so your settings can’t be clobbered by the environment)
+# docker-make previously passed these flags inside the container; still useful.
+override MAKEFLAGS += --warn-undefined-variables  \
+              --no-builtin-rules        \
+              -j16                      \
+              --no-print-directory      \
+
+# Export it so sub-makes see the same flags
+export MAKEFLAGS
+
+# Verbosity control
+VERBOSE ?= 0
+ifeq ($(VERBOSE),1)
+Q :=
+else
+Q := @
+endif
+
+# Helper to print status messages
+status = @echo "==> $(1)"
+
+# Redis connection settings
+REDIS_HOST ?= dragonfly
+REDIS_PORT ?= 6379
+export REDIS_HOST
+export REDIS_PORT
+
+# Directories
+SRC_DIR   := src
+BUILD_DIR := build
+LOG_DIR   := log
+CFG_DIR   := cfg
+
+# Define the Pandoc command used inside the container
+#       -T: Don't allocate pseudo-tty. Makes parallel builds work.
+# For container setup details, see docs/guides/docker-make.md.
+PANDOC_CMD := pandoc
+PANDOC_TEMPLATE := $(SRC_DIR)/pandoc-template.html
+
+# Options for generating HTML output with Pandoc
+PANDOC_OPTS := \
+        --css '/css/style.css' \
+        --standalone \
+        -t html \
+        --toc \
+        --toc-depth=2 \
+        --filter pandoc-crossref \
+        --mathjax \
+
+# Options for generating PDF output with Pandoc
+PANDOC_OPTS_PDF := \
+        --css "/css/style.css" \
+        --standalone \
+        -t pdf \
+        --toc \
+        --toc-depth=2 \
+        --number-sections \
+        --pdf-engine=xelatex \
+        --resource-path=$(BUILD_DIR) \
+        --filter pandoc-crossref \
+
+# Command for minifying HTML files
+MINIFY_CMD := minify
+
+CHECKLINKS_CMD := checklinks
+TEST_HOST_URL ?= https://nginx-test
+
+VPATH := $(SRC_DIR)
+
+# Find all Markdown files excluding specified directories
+MARKDOWNS := $(shell find $(SRC_DIR)/ -name '*.md')
+YAMLS := $(shell find $(SRC_DIR) -name "*.yml")
+
+# Define the corresponding HTML and PDF output files
+HTMLS := $(patsubst $(SRC_DIR)/%.md, $(BUILD_DIR)/%.html, $(MARKDOWNS))
+PDFS := $(patsubst $(SRC_DIR)/%.md, $(BUILD_DIR)/%.pdf, $(MARKDOWNS))
+
+# Sort and define build subdirectories based on HTML files
+BUILD_SUBDIRS := $(sort $(dir $(HTMLS))) $(LOG_DIR) $(BUILD_DIR)/static $(BUILD_DIR)/css
+
+CSS_SRC := $(wildcard $(SRC_DIR)/css/*.css)
+CSS := $(patsubst $(SRC_DIR)/css/%.css,$(BUILD_DIR)/css/%.css, $(CSS_SRC))
+
+# Nginx permalink redirect configuration
+PERMALINKS_CONF := $(BUILD_DIR)/permalinks.conf
+
+# Define the default target to build everything
+.PHONY: everything
+everything: | $(BUILD_DIR) $(BUILD_SUBDIRS)
+	$(call status,Updating author)
+	$(Q)update-author --sort-keys
+	$(call status,Updating pubdate)
+	$(Q)update-pubdate --sort-keys
+	$(Q)$(MAKE) -s $(BUILD_DIR)/.update-index VERBOSE=$(VERBOSE)
+	$(Q)$(MAKE) -s all VERBOSE=$(VERBOSE)
+
+all: $(HTMLS)
+all: $(CSS)
+all: $(BUILD_DIR)/robots.txt
+all: $(BUILD_DIR)/sitemap.xml
+all: $(PERMALINKS_CONF)
+
+$(BUILD_DIR)/robots.txt: $(SRC_DIR)/robots.txt
+	cp $< $@
+
+$(BUILD_DIR)/sitemap.xml: $(HTMLS)
+	$(call status,Generate sitemap)
+	$(Q)sitemap $(BUILD_DIR)
+
+$(PERMALINKS_CONF): $(MARKDOWNS) $(YAMLS) | $(BUILD_DIR) $(LOG_DIR)
+	$(call status,Generate permalink redirects)
+	$(Q)nginx-permalinks $(SRC_DIR) -o $@ --log $(LOG_DIR)/nginx-permalinks.txt
+
+$(BUILD_DIR)/.update-index: $(MARKDOWNS) $(YAMLS)
+	$(call status,Updating Redis Index)
+	$(Q)update-index --host $(REDIS_HOST) --port $(REDIS_PORT) src
+	$(Q)touch $@
+
+# Target to minify HTML and CSS files
+# Modifies file timestamps. The preserve option doesn't seem to work.
+# No touch at the end. Minify should always execute.
+$(BUILD_DIR)/.minify:
+	$(call status,Minify HTML and CSS)
+	$(Q)cd $(BUILD_DIR); $(MINIFY_CMD) -a -v -r -o . .
+
+.PHONY: test
+# Triggered by the test target; see docs/guides/redo-mk.md.
+test: $(BUILD_DIR)/.minify check | $(LOG_DIR)
+	$(call status,Run link check)
+	$(Q)$(CHECKLINKS_CMD) $(TEST_HOST_URL)
+
+.PHONY: check
+check:
+	$(call status,Check metadata authors)
+	$(Q)check-author $(SRC_DIR)
+	$(call status,Check page titles)
+	$(Q)check-page-title -x $(CFG_DIR)/check-page-title-exclude.yml $(BUILD_DIR)
+	$(call status,Check post-build artifacts)
+	$(Q)check-post-build -c $(CFG_DIR)/check-post-build.yml
+	$(call status,Check for unexpanded Jinja)
+	$(Q)check-unexpanded-jinja $(BUILD_DIR)
+	$(call status,Check for URL underscores)
+	$(Q)check-underscores $(BUILD_DIR)
+
+# Create necessary build directories
+$(BUILD_DIR): | $(BUILD_SUBDIRS)
+
+# Create each build subdirectory if it doesn't exist
+$(BUILD_SUBDIRS):
+	$(call status,Create directory $@)
+	$(Q)mkdir -p $@
+
+# Compile SCSS files to the build directory
+$(BUILD_DIR)/css/%.css: $(SRC_DIR)/css/%.css | $(BUILD_DIR)/css
+	$(call status,Compile SCSS $<)
+	$(Q)pysassc $< $@
+
+# Include and preprocess Markdown files up to three levels deep
+# See docs/guides/preprocess.md for preprocessing details
+$(BUILD_DIR)/%.md: %.md | $(BUILD_DIR)
+	$(call status,Preprocess $<)
+	$(Q)preprocess $<
+
+# Generate HTML from processed Markdown using Pandoc
+$(BUILD_DIR)/%.html: $(BUILD_DIR)/%.md $(PANDOC_TEMPLATE) | $(BUILD_DIR)
+	$(call status,Generate HTML $@)
+	$(Q)$(PANDOC_CMD) $(PANDOC_OPTS) --template=$(PANDOC_TEMPLATE) -o $@ $<
+
+# Generate PDF from processed Markdown using Pandoc
+# include-filter usage is documented in docs/guides/include-filter.md
+$(BUILD_DIR)/%.pdf: %.md | $(BUILD_DIR)
+	$(call status,Generate PDF $@)
+	$(Q)include-filter $(BUILD_DIR) $< $(BUILD_DIR)/$*.1.md
+	$(Q)include-filter $(BUILD_DIR) $(BUILD_DIR)/$*.1.md $(BUILD_DIR)/$*.2.md
+	$(Q)include-filter $(BUILD_DIR) $(BUILD_DIR)/$*.2.md $(BUILD_DIR)/$*.3.md
+	$(Q)$(PANDOC_CMD) \
+$(PANDOC_OPTS_PDF) \
+-o $@ \
+$(BUILD_DIR)/$*.3.md
+
+# Clean the build directory by removing all build artifacts
+.PHONY: clean
+clean:
+	$(call status,Remove build artifacts)
+	$(Q)-rm -rf $(BUILD_DIR)
+
+# Optionally include user dependencies
+-include dep.mk
+
+$(BUILD_DIR)/picasso.mk: $(YAMLS) | $(BUILD_DIR)
+	$(call status,Generate picasso rules)
+	$(Q)picasso --src $(SRC_DIR) --build $(BUILD_DIR) > $@
+
+include $(BUILD_DIR)/picasso.mk

--- a/app/shell/Dockerfile
+++ b/app/shell/Dockerfile
@@ -22,10 +22,12 @@ RUN apt-get update -qq && \
         locales \
         make \
         minify \
+        openssh-server \
         pysassc && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /run/sshd
 
 # -------------------------------------------------------------------
 # Locale configuration

--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -138,6 +138,8 @@ test: $(BUILD_DIR)/.minify check | $(LOG_DIR)
 check:
 	$(call status,Check metadata authors)
 	$(Q)check-author $(SRC_DIR)
+	$(call status,Check for bad MathJax)
+	$(Q)check-bad-mathjax $(SRC_DIR)
 	$(call status,Check page titles)
 	$(Q)check-page-title -x $(CFG_DIR)/check-page-title-exclude.yml $(BUILD_DIR)
 	$(call status,Check post-build artifacts)

--- a/app/shell/py/pie/pie/check/bad_mathjax.py
+++ b/app/shell/py/pie/pie/check/bad_mathjax.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Fail if Markdown files use \(\) or \[\] math delimiters."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
+
+DEFAULT_LOG = "log/check-bad-mathjax.txt"
+PATTERNS = [
+    re.compile(r"\\\([^\n]*?\\\)"),
+    re.compile(r"\\\[[^\n]*?\\\]"),
+]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Return parsed command line arguments."""
+    parser = create_parser(
+        "Check Markdown files for LaTeX delimiters \\(\\) or \\[\\]",
+        log_default=DEFAULT_LOG,
+    )
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="src",
+        help="Root directory to scan for Markdown files",
+    )
+    return parser.parse_args(argv)
+
+
+def _has_bad_math(text: str) -> bool:
+    return any(pattern.search(text) for pattern in PATTERNS)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``check-bad-mathjax`` console script."""
+    args = parse_args(argv)
+    Path(args.log).parent.mkdir(parents=True, exist_ok=True)
+    configure_logging(args.verbose, args.log)
+
+    root = Path(args.directory)
+    ok = True
+    for md in root.rglob("*.md"):
+        text = md.read_text(encoding="utf-8")
+        if _has_bad_math(text):
+            logger.error("Found bad math delimiter", path=str(md))
+            ok = False
+    if ok:
+        logger.info("No bad math delimiters found.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/shell/py/pie/pie/check/bad_mathjax.py
+++ b/app/shell/py/pie/pie/check/bad_mathjax.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail if Markdown files use \(\) or \[\] math delimiters."""
+r"""Fail if Markdown files use \(\) or \[\] math delimiters."""
 
 from __future__ import annotations
 

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -20,6 +20,7 @@ setup(
             'build-index=pie.build_index:main',
             'check-author=pie.check.author:main',
             'check-bad-jinja-output=pie.check.bad_jinja_output:main',
+            'check-bad-mathjax=pie.check.bad_mathjax:main',
             'check-page-title=pie.check.page_title:main',
             'check-post-build=pie.check.post_build:main',
             'check-unexpanded-jinja=pie.check.unexpanded_jinja:main',

--- a/app/shell/py/pie/tests/test_check_bad_mathjax.py
+++ b/app/shell/py/pie/tests/test_check_bad_mathjax.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pie.check import bad_mathjax as check_bad_mathjax
+
+
+def test_main_pass(tmp_path: Path) -> None:
+    """Markdown without bad delimiters -> exit code 0."""
+    md = tmp_path / "index.md"
+    md.write_text("$a$ and $$b$$", encoding="utf-8")
+    assert check_bad_mathjax.main([str(tmp_path)]) == 0
+
+
+def test_fail_inline(tmp_path: Path, capsys) -> None:
+    """Inline math using \(\) reports an error."""
+    md = tmp_path / "index.md"
+    md.write_text("text \\(a+b\\)", encoding="utf-8")
+    assert check_bad_mathjax.main([str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert "bad math" in captured.err
+
+
+def test_fail_display(tmp_path: Path, capsys) -> None:
+    """Display math using \[\] reports an error."""
+    md = tmp_path / "index.md"
+    md.write_text("\\[a+b\\]", encoding="utf-8")
+    assert check_bad_mathjax.main([str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert "bad math" in captured.err

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -31,6 +31,7 @@ run_make() {
 
 cleanup() {
   "${DOCKER_COMPOSE[@]}" down
+  docker prune
 }
 trap cleanup EXIT
 

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -31,7 +31,7 @@ run_make() {
 
 cleanup() {
   "${DOCKER_COMPOSE[@]}" down
-  docker prune
+  docker system prune -f
 }
 trap cleanup EXIT
 

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # Run after git pull to rebuild everything required for development.
+# Use -p to run bin/pull after distclean.
 set -euo pipefail
+
+RUN_PULL=0
+while getopts "p" opt; do
+  case "$opt" in
+    p) RUN_PULL=1 ;;
+    *) echo "Usage: $0 [-p]" >&2; exit 1 ;;
+  esac
+done
+shift $((OPTIND - 1))
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
@@ -32,6 +42,10 @@ echo "Starting dragonfly..."
 "${DOCKER_COMPOSE[@]}" up -d dragonfly
 echo "Running distclean..."
 run_make distclean
+if [ "$RUN_PULL" -eq 1 ]; then
+  echo "Running pull..."
+  bin/pull
+fi
 echo "Building shell image..."
 "${DOCKER_COMPOSE[@]}" build shell
 echo "Running make..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,9 +54,8 @@ services:
       - ../log:/app/log
 
   mermaid:
-    image: ghcr.io/mermaid-js/mermaid-cli:latest
+    image: minlag/mermaid-cli
     container_name: press-mermaid
-    entrypoint: ["mmdc"]
     volumes:
       - ./:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,11 +89,12 @@ services:
   builder:
     image: press-shell
     container_name: press-builder
-    entrypoint: ["sshd", "-D"]
+    # Copy the host's public key to a root-owned file before starting sshd.
+    entrypoint: ["/bin/sh", "-c", "install -m 600 /tmp/id_rsa.pub /root/.ssh/authorized_keys && /usr/sbin/sshd -D"]
     ports:
       - "2222:22"
     volumes:
-      - ~/.ssh/id_rsa.pub:/root/.ssh/authorized_keys:ro
+      - ~/.ssh/id_rsa.pub:/tmp/id_rsa.pub:ro
 
   release:
     image: press-release

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,10 +90,11 @@ services:
     image: press-shell
     container_name: press-builder
     # Copy the host's public key to a root-owned file before starting sshd.
-    entrypoint: ["/bin/sh", "-c", "install -m 600 /tmp/id_rsa.pub /root/.ssh/authorized_keys && /usr/sbin/sshd -D"]
+    entrypoint: ["/bin/sh", "-c", "mkdir -p /root/.ssh; install -m 600 /tmp/id_rsa.pub /root/.ssh/authorized_keys && /usr/sbin/sshd -D"]
     ports:
       - "2222:22"
     volumes:
+      - ./:/data
       - ~/.ssh/id_rsa.pub:/tmp/id_rsa.pub:ro
 
   release:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,8 @@ services:
     volumes:
       - ./:/data
       - ~/.ssh/id_rsa.pub:/tmp/id_rsa.pub:ro
+    depends_on:
+      - shell
 
   release:
     image: press-release

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,15 @@ services:
       - ./app/shell/py/pie/tests:/press/py/pie/tests
       - ./src/dep.mk:/app/mk/dep.mk
 
+  builder:
+    image: press-shell
+    container_name: press-builder
+    entrypoint: ["sshd", "-D"]
+    ports:
+      - "2222:22"
+    volumes:
+      - ~/.ssh/id_rsa.pub:/root/.ssh/authorized_keys:ro
+
   release:
     image: press-release
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,12 @@ services:
     container_name: press-builder
     # Copy the host's public key to a root-owned file before starting sshd.
     entrypoint: ["/bin/sh", "-c", "mkdir -p /root/.ssh; install -m 600 /tmp/id_rsa.pub /root/.ssh/authorized_keys && /usr/sbin/sshd -D"]
+    environment:
+      OPENAI_API_KEY: "${OPENAI_API_KEY}"
+      REDIS_HOST: dragonfly
+      REDIS_PORT: 6379
+      TEST_HOST_URL: ${TEST_HOST_URL:-http://nginx-test}
+      BASE_URL: ${BASE_URL:-http://localhost}
     ports:
       - "2222:22"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,13 @@ services:
       - ./app/webp/output:/app/output
       - ../log:/app/log
 
+  mermaid:
+    image: ghcr.io/mermaid-js/mermaid-cli:latest
+    container_name: press-mermaid
+    entrypoint: ["mmdc"]
+    volumes:
+      - ./:/data
+
   # Default port is 6379. Not exposed to the host to avoid port conflicts.
   # You can run redis-cli within this container.
   #   docker compose exec dragonfly redis-cli

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -17,6 +17,7 @@ concepts and data formats, see the
 - [checklinks.md](checklinks.md) – scan rendered HTML for broken links.
 - [check-page-title.md](check-page-title.md) – verify page titles.
 - [check-underscores.md](check-underscores.md) – report internal URLs that contain underscores.
+- [check-bad-mathjax.md](check-bad-mathjax.md) – detect old MathJax delimiters.
 - [tests.md](tests.md) – run the automated test suite.
 
 ## Services and utilities

--- a/docs/guides/check-bad-mathjax.md
+++ b/docs/guides/check-bad-mathjax.md
@@ -1,0 +1,14 @@
+# check-bad-mathjax
+
+`check-bad-mathjax` scans Markdown files for MathJax `\(` `\)` and `\[` `\]`
+delimiters. Inline math must use `$...$` and block math `$$...$$`. The script
+returns a non-zero exit status when deprecated delimiters are found.
+
+## Usage
+
+```bash
+check-bad-mathjax [directory]
+```
+
+The optional directory defaults to `src`. Each file that contains forbidden
+delimiters is logged for review.

--- a/redo.mk
+++ b/redo.mk
@@ -51,10 +51,15 @@ $(BUILD_DIR): ## Helper target used by other rules
 	$(call status,Prepare build directory $@)
 	$(Q)mkdir -p $@
 
+all: build/examples/mermaid/diagram.svg | build/examples/mermaid
+
+build/examples/mermaid:
+	mkdir -p $@
+
 # Generate SVG diagrams from Mermaid source files
-$(BUILD_DIR)/%.svg: $(BUILD_DIR)/%.mmd | $(BUILD_DIR)
+$(BUILD_DIR)/%.svg: $(SRC_DIR)/%.mmd | $(dir $@)
 	$(call status,Render Mermaid $<)
-	$(Q)$(COMPOSE_RUN) mermaid -i $< -o $@
+	$(Q)$(COMPOSE_RUN) -u `id -u` mermaid -i $< -o $@
 
 # Docker-related targets
 # Initialize Docker authentication and build the Nginx image

--- a/redo.mk
+++ b/redo.mk
@@ -24,7 +24,7 @@ DOCKER_COMPOSE := docker compose -f $(COMPOSE_FILE)
 COMPOSE_RUN := $(DOCKER_COMPOSE) run --build --rm -T
 PYTEST_CMD  := $(DOCKER_COMPOSE) run --entrypoint pytest --rm shell
 
-SSH_MAKE := ssh -p2222 root@localhost make -C /data
+SSH_MAKE := ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p2222 root@localhost make -C /data
 
 # Verbosity control
 VERBOSE ?= 0
@@ -44,7 +44,7 @@ status = @echo "==> $(1)"
 .PHONY: all
 all: ## Build the site using the builder service
 	$(call status,Build site)
-	$(Q)$(DOCKER_COMPOSE) up -d dragonfly
+	$(Q)$(DOCKER_COMPOSE) up -d dragonfly builder
 	$(Q)$(SSH_MAKE) VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR)
 
 $(BUILD_DIR): ## Helper target used by other rules

--- a/redo.mk
+++ b/redo.mk
@@ -51,6 +51,11 @@ $(BUILD_DIR): ## Helper target used by other rules
 	$(call status,Prepare build directory $@)
 	$(Q)mkdir -p $@
 
+# Generate SVG diagrams from Mermaid source files
+$(BUILD_DIR)/%.svg: $(BUILD_DIR)/%.mmd | $(BUILD_DIR)
+	$(call status,Render Mermaid $<)
+	$(Q)$(COMPOSE_RUN) mermaid -i $< -o $@
+
 # Docker-related targets
 # Initialize Docker authentication and build the Nginx image
 # Uncomment the lines below to tag and push the Docker image

--- a/src/examples/mermaid/diagram.mmd
+++ b/src/examples/mermaid/diagram.mmd
@@ -1,0 +1,5 @@
+flowchart TD
+    A[Start] --> B{Is it working?}
+    B -- Yes --> C[Great]
+    B -- No --> D[Try again]
+    D --> B

--- a/src/examples/mermaid/index.md
+++ b/src/examples/mermaid/index.md
@@ -1,0 +1,41 @@
+Mermaid converts text descriptions into diagrams. This example demonstrates
+how to generate a diagram with Press.
+
+Write your diagram in `diagram.mmd`:
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Is it working?}
+    B -- Yes --> C[Great]
+    B -- No --> D[Try again]
+    D --> B
+```
+
+Run `redo` to render the SVG:
+
+```
+redo diagram.svg
+```
+
+Include the image in your document:
+
+```markdown
+![Example flowchart](diagram.svg)
+```
+
+It will show up like this:
+
+![Example flowchart](diagram.svg)
+
+Mermaid supports many chart types. The snippet below shows a simple
+sequence diagram:
+
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>Bob: Hello Bob, how are you?
+    Bob-->>Alice: I am good thanks!
+```
+
+Explore [Mermaid's docs](https://mermaid.js.org/) for more examples.

--- a/src/examples/mermaid/index.yml
+++ b/src/examples/mermaid/index.yml
@@ -1,0 +1,4 @@
+author: Brian Lee
+id: mermaid-example
+pubdate: Aug 22, 2025
+title: Mermaid Diagram Example

--- a/src/index.md
+++ b/src/index.md
@@ -6,6 +6,7 @@ features.
 - [Index Tree Demo](examples/indextree/index.md)
 - [Jinja Examples](examples/jinja.md)
 - [Link Global Examples](examples/link-globals.md)
+- [Mermaid Diagram Example](examples/mermaid/index.md)
 - [MagicBar Demo](magicbar/index.md)
 - [Quickstart](quickstart.md)
 - [Quiz Demo](quiz/index.md)


### PR DESCRIPTION
## Summary
- migrate build rules from app/shell/mk/build.mk into a new root Makefile
- update redo.mk to use builder service via SSH instead of MAKE_CMD
- fix recipe indentation in redo.mk to use tabs

## Testing
- `pip install picasso`
- `make test` *(fails: check-author, minify not found)*
- `make -f redo.mk test` *(fails: SSH connection refused)*
- `make -f redo.mk check` *(fails: SSH connection refused)*


------
https://chatgpt.com/codex/tasks/task_e_68a89b8bcf6483219e6c348a0556c747