### PR TITLE
fix: escape sequences in bad_mathjax docstring

### DIFF
--- a/app/shell/py/pie/pie/check/bad_mathjax.py
+++ b/app/shell/py/pie/pie/check/bad_mathjax.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail if Markdown files use \(\) or \[\] math delimiters."""
+r"""Fail if Markdown files use \(\) or \[\] math delimiters."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- prefix bad_mathjax checker module docstring with a raw string to silence SyntaxWarning

## Testing
- `python3 -Wall -m py_compile app/shell/py/pie/pie/check/bad_mathjax.py`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8a3eb52888321bbfeae38e193fdf7