### PR TITLE
Add mermaid diagram example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,6 @@ services:
   mermaid:
     image: minlag/mermaid-cli
     container_name: press-mermaid
-    entrypoint: ["mmdc"]
     volumes:
       - ./:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - ../log:/app/log
 
   mermaid:
-    image: ghcr.io/mermaid-js/mermaid-cli:latest
+    image: minlag/mermaid-cli
     container_name: press-mermaid
     entrypoint: ["mmdc"]
     volumes:

--- a/redo.mk
+++ b/redo.mk
@@ -51,8 +51,13 @@ $(BUILD_DIR): ## Helper target used by other rules
 	$(call status,Prepare build directory $@)
 	$(Q)mkdir -p $@
 
+all: build/examples/mermaid/diagram.svg | build/examples/mermaid
+
+build/examples/mermaid:
+	mkdir -p $@
+
 # Generate SVG diagrams from Mermaid source files
-$(BUILD_DIR)/%.svg: $(BUILD_DIR)/%.mmd | $(BUILD_DIR)
+$(BUILD_DIR)/%.svg: $(SRC_DIR)/%.mmd | $(dir $@)
 	$(call status,Render Mermaid $<)
 	$(Q)$(COMPOSE_RUN) mermaid -i $< -o $@
 

--- a/redo.mk
+++ b/redo.mk
@@ -59,7 +59,7 @@ build/examples/mermaid:
 # Generate SVG diagrams from Mermaid source files
 $(BUILD_DIR)/%.svg: $(SRC_DIR)/%.mmd | $(dir $@)
 	$(call status,Render Mermaid $<)
-	$(Q)$(COMPOSE_RUN) mermaid -i $< -o $@
+	$(Q)$(COMPOSE_RUN) -u `id -u` mermaid -i $< -o $@
 
 # Docker-related targets
 # Initialize Docker authentication and build the Nginx image

--- a/src/dep.mk
+++ b/src/dep.mk
@@ -9,3 +9,12 @@ build/static/js:
 include app/quiz/dep.mk
 include app/indextree/dep.mk
 include app/magicbar/dep.mk
+
+# Mermaid example diagram
+all: build/examples/mermaid/diagram.mmd
+
+build/examples/mermaid:
+	mkdir -p $@
+
+build/examples/mermaid/diagram.mmd: src/examples/mermaid/diagram.mmd | build/examples/mermaid
+	cp $< $@

--- a/src/dep.mk
+++ b/src/dep.mk
@@ -9,12 +9,3 @@ build/static/js:
 include app/quiz/dep.mk
 include app/indextree/dep.mk
 include app/magicbar/dep.mk
-
-# Mermaid example diagram
-all: build/examples/mermaid/diagram.mmd
-
-build/examples/mermaid:
-	mkdir -p $@
-
-build/examples/mermaid/diagram.mmd: src/examples/mermaid/diagram.mmd | build/examples/mermaid
-	cp $< $@

--- a/src/examples/mermaid/diagram.mmd
+++ b/src/examples/mermaid/diagram.mmd
@@ -1,0 +1,5 @@
+flowchart TD
+    A[Start] --> B{Is it working?}
+    B -- Yes --> C[Great]
+    B -- No --> D[Try again]
+    D --> B

--- a/src/examples/mermaid/index.md
+++ b/src/examples/mermaid/index.md
@@ -1,30 +1,15 @@
-# Mermaid Example
+two ways to include mermaid diagrams
 
-This short tutorial shows how to render a Mermaid diagram during the build.
+## method 1
 
-The source lives in `diagram.mmd`:
+use include.py
 
 ```mermaid
 {{ include("diagram.mmd") }}
 ```
 
-The `src/dep.mk` file copies the source into the build tree and invokes the
-Mermaid CLI:
+## method 2
 
-```make
-all: build/examples/mermaid/diagram.mmd
-
-build/examples/mermaid:
-        mkdir -p $@
-
-build/examples/mermaid/diagram.mmd: src/examples/mermaid/diagram.mmd | \
-    build/examples/mermaid
-        cp $< $@
-```
-
-The rule above uses a pattern from `redo.mk` to convert the copied `.mmd`
-file into `diagram.svg`.
-
-Refer to the generated image below:
+use build rules in redo.mk to generate .svg and include it as an image
 
 ![Example flowchart](diagram.svg)

--- a/src/examples/mermaid/index.md
+++ b/src/examples/mermaid/index.md
@@ -1,0 +1,30 @@
+# Mermaid Example
+
+This short tutorial shows how to render a Mermaid diagram during the build.
+
+The source lives in `diagram.mmd`:
+
+```mermaid
+{{ include("diagram.mmd") }}
+```
+
+The `src/dep.mk` file copies the source into the build tree and invokes the
+Mermaid CLI:
+
+```make
+all: build/examples/mermaid/diagram.mmd
+
+build/examples/mermaid:
+        mkdir -p $@
+
+build/examples/mermaid/diagram.mmd: src/examples/mermaid/diagram.mmd | \
+    build/examples/mermaid
+        cp $< $@
+```
+
+The rule above uses a pattern from `redo.mk` to convert the copied `.mmd`
+file into `diagram.svg`.
+
+Refer to the generated image below:
+
+![Example flowchart](diagram.svg)

--- a/src/examples/mermaid/index.md
+++ b/src/examples/mermaid/index.md
@@ -1,15 +1,3 @@
-two ways to include mermaid diagrams
-
-## method 1
-
-use include.py
-
-```mermaid
-{{ include("diagram.mmd") }}
-```
-
-## method 2
-
 use build rules in redo.mk to generate .svg and include it as an image
 
 ![Example flowchart](diagram.svg)

--- a/src/examples/mermaid/index.yml
+++ b/src/examples/mermaid/index.yml
@@ -1,4 +1,4 @@
-title: Mermaid Diagram Example
-id: mermaid-example
 author: Brian Lee
-pubdate: Aug 12, 2025
+id: mermaid-example
+pubdate: Aug 22, 2025
+title: Mermaid Diagram Example

--- a/src/examples/mermaid/index.yml
+++ b/src/examples/mermaid/index.yml
@@ -1,0 +1,4 @@
+title: Mermaid Diagram Example
+id: mermaid-example
+author: Brian Lee
+pubdate: Aug 12, 2025

--- a/src/index.md
+++ b/src/index.md
@@ -6,6 +6,7 @@ features.
 - [Index Tree Demo](examples/indextree/index.md)
 - [Jinja Examples](examples/jinja.md)
 - [Link Global Examples](examples/link-globals.md)
+- [Mermaid Diagram Example](examples/mermaid/index.md)
 - [MagicBar Demo](magicbar/index.md)
 - [Quickstart](quickstart.md)
 - [Quiz Demo](quiz/index.md)


### PR DESCRIPTION
## Summary
- add a mermaid flowchart example and tutorial
- hook mermaid diagram into the build pipeline
- link example from site index

## Testing
- `make -f redo.mk build/examples/mermaid/diagram.svg` *(fails: docker: No such file or directory)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68a8a5ab54188321a9bc7b420f92f909