### PR TITLE
Prune Docker resources during upgrade

### DIFF
--- a/bin/upgrade
+++ b/bin/upgrade
@@ -31,6 +31,7 @@ run_make() {
 
 cleanup() {
   "${DOCKER_COMPOSE[@]}" down
+  docker prune
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## Summary
- Clean up unused Docker resources as part of `bin/upgrade`

## Testing
- `shellcheck bin/upgrade`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8bb32f91c8321a3d4cffc4fc23b0d