### PR TITLE
Allow overriding builder SSH port

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ directory using SCSS syntax to customize the site appearance.
 
 All project documentation lives under [docs/](docs/). Start with the [guides](docs/guides/README.md) for step-by-step workflows and see the [reference](docs/reference/README.md) for technical details.
 
+
+## SSH port
+
+The builder service exposes its SSH daemon on the host. By default port 2222
+is used. Override it by setting `SSH_PORT`:
+
+```
+SSH_PORT=3000 docker compose up builder
+SSH_PORT=3000 make test
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       TEST_HOST_URL: ${TEST_HOST_URL:-http://nginx-test}
       BASE_URL: ${BASE_URL:-http://localhost}
     ports:
-      - "2222:22"
+      - "${SSH_PORT:-2222}:22"
     volumes:
       - ./:/data
       - ~/.ssh/id_rsa.pub:/tmp/id_rsa.pub:ro

--- a/redo.mk
+++ b/redo.mk
@@ -24,7 +24,8 @@ DOCKER_COMPOSE := docker compose -f $(COMPOSE_FILE)
 COMPOSE_RUN := $(DOCKER_COMPOSE) run --build --rm -T
 PYTEST_CMD  := $(DOCKER_COMPOSE) run --entrypoint pytest --rm shell
 
-SSH_MAKE := ssh -p 2222 -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@localhost make -C /data
+SSH_PORT ?= 2222
+SSH_MAKE := ssh -p $(SSH_PORT) -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@localhost make -C /data
 
 # Verbosity control
 VERBOSE ?= 0


### PR DESCRIPTION
## Summary
- make builder's SSH port configurable via `SSH_PORT`
- document SSH port override

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest app/shell/py/pie/tests`
- `SSH_PORT=3000 docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d9a8bb3c8321a7a11b1c377df5e1