### PR TITLE
check-bad-mathjax: add exclude list option

### DIFF
--- a/app/shell/py/pie/pie/check/bad_mathjax.py
+++ b/app/shell/py/pie/pie/check/bad_mathjax.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from pie.cli import create_parser
 from pie.logging import configure_logging, logger
+from pie.utils import load_exclude_file
 
 DEFAULT_LOG = "log/check-bad-mathjax.txt"
 PATTERNS = [
@@ -29,6 +30,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="src",
         help="Root directory to scan for Markdown files",
     )
+    parser.add_argument(
+        "-x",
+        "--exclude",
+        help="YAML file listing Markdown files to skip",
+    )
     return parser.parse_args(argv)
 
 
@@ -43,8 +49,11 @@ def main(argv: list[str] | None = None) -> int:
     configure_logging(args.verbose, args.log)
 
     root = Path(args.directory)
+    exclude = load_exclude_file(args.exclude, root)
     ok = True
     for md in root.rglob("*.md"):
+        if md.resolve() in exclude:
+            continue
         text = md.read_text(encoding="utf-8")
         if _has_bad_math(text):
             logger.error("Found bad math delimiter", path=str(md))

--- a/app/shell/py/pie/pie/check/bad_mathjax.py
+++ b/app/shell/py/pie/pie/check/bad_mathjax.py
@@ -12,6 +12,7 @@ from pie.logging import configure_logging, logger
 from pie.utils import load_exclude_file
 
 DEFAULT_LOG = "log/check-bad-mathjax.txt"
+DEFAULT_EXCLUDE = Path("cfg/check-bad-mathjax-exclude.yml")
 PATTERNS = [
     re.compile(r"\\\([^\n]*?\\\)"),
     re.compile(r"\\\[[^\n]*?\\\]"),
@@ -33,7 +34,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "-x",
         "--exclude",
-        help="YAML file listing Markdown files to skip",
+        help=(
+            "YAML file listing Markdown files to skip "
+            f"(default: {DEFAULT_EXCLUDE})"
+        ),
     )
     return parser.parse_args(argv)
 
@@ -49,7 +53,12 @@ def main(argv: list[str] | None = None) -> int:
     configure_logging(args.verbose, args.log)
 
     root = Path(args.directory)
-    exclude = load_exclude_file(args.exclude, root)
+    if args.exclude:
+        exclude = load_exclude_file(args.exclude, root)
+    elif DEFAULT_EXCLUDE.is_file():
+        exclude = load_exclude_file(DEFAULT_EXCLUDE, root)
+    else:
+        exclude = set()
     ok = True
     for md in root.rglob("*.md"):
         if md.resolve() in exclude:

--- a/app/shell/py/pie/pie/check/page_title.py
+++ b/app/shell/py/pie/pie/check/page_title.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from bs4 import BeautifulSoup
 from pie.cli import create_parser
 from pie.logging import configure_logging
-from pie.utils import read_yaml
+from pie.utils import load_exclude_file
 
 
 # Detect whether we should emit ANSI colour codes. We only use colours when
@@ -68,14 +68,7 @@ def main(argv: list[str] | None = None) -> int:
     configure_logging(args.verbose, args.log)
     directory = Path(args.directory).resolve()
     html_files = list(directory.rglob("*.html"))
-    exclude: set[Path] = set()
-    if args.exclude:
-        data = read_yaml(args.exclude) or []
-        for item in data:
-            p = Path(item)
-            if not p.is_absolute():
-                p = directory / p
-            exclude.add(p.resolve())
+    exclude = load_exclude_file(args.exclude, directory)
     ok = True
     for html_file in html_files:
         if html_file.resolve() in exclude:

--- a/app/shell/py/pie/pie/utils/__init__.py
+++ b/app/shell/py/pie/pie/utils/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+from pathlib import Path
 
 import yaml
 
@@ -61,6 +62,25 @@ def write_yaml(data, filename: str) -> None:
     logger.debug("Writing YAML", filename=filename)
     with open(filename, "w", encoding="utf-8") as f:
         yaml.safe_dump(data, f, allow_unicode=True, sort_keys=False)
+
+
+def load_exclude_file(filename: str | Path | None, root: Path) -> set[Path]:
+    """Return a set of resolved paths listed in *filename*.
+
+    The YAML file may contain absolute paths or ones relative to *root*.
+    If *filename* is ``None`` an empty set is returned.
+    """
+
+    exclude: set[Path] = set()
+    if not filename:
+        return exclude
+    data = read_yaml(str(filename)) or []
+    for item in data:
+        p = Path(item)
+        if not p.is_absolute():
+            p = root / p
+        exclude.add(p.resolve())
+    return exclude
 
 
 def get_pubdate(date: datetime | None = None) -> str:

--- a/app/shell/py/pie/tests/test_check_bad_mathjax.py
+++ b/app/shell/py/pie/tests/test_check_bad_mathjax.py
@@ -28,3 +28,12 @@ def test_fail_display(tmp_path: Path, capsys) -> None:
     assert check_bad_mathjax.main([str(tmp_path)]) == 1
     captured = capsys.readouterr()
     assert "bad math" in captured.err
+
+
+def test_exclude_file(tmp_path: Path) -> None:
+    """Files listed in the exclude YAML are ignored."""
+    bad = tmp_path / "bad.md"
+    bad.write_text("text \\(a+b\\)", encoding="utf-8")
+    exclude = tmp_path / "exclude.yml"
+    exclude.write_text(f"- {bad.name}\n", encoding="utf-8")
+    assert check_bad_mathjax.main([str(tmp_path), "-x", str(exclude)]) == 0

--- a/app/shell/py/pie/tests/test_check_bad_mathjax.py
+++ b/app/shell/py/pie/tests/test_check_bad_mathjax.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import os
 
 from pie.check import bad_mathjax as check_bad_mathjax
 
@@ -37,3 +38,19 @@ def test_exclude_file(tmp_path: Path) -> None:
     exclude = tmp_path / "exclude.yml"
     exclude.write_text(f"- {bad.name}\n", encoding="utf-8")
     assert check_bad_mathjax.main([str(tmp_path), "-x", str(exclude)]) == 0
+
+
+def test_default_exclude_file(tmp_path: Path) -> None:
+    """Default exclude YAML is used when present."""
+    bad = tmp_path / "bad.md"
+    bad.write_text("text \\(a+b\\)", encoding="utf-8")
+    cfg = tmp_path / "cfg"
+    cfg.mkdir()
+    exclude = cfg / "check-bad-mathjax-exclude.yml"
+    exclude.write_text(f"- {bad.name}\n", encoding="utf-8")
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        assert check_bad_mathjax.main([str(tmp_path)]) == 0
+    finally:
+        os.chdir(cwd)

--- a/cfg/check-bad-mathjax-exclude.yml
+++ b/cfg/check-bad-mathjax-exclude.yml
@@ -1,0 +1,2 @@
+# List Markdown files for check-bad-mathjax to skip.
+# Paths may be absolute or relative to the repository root.

--- a/docs/pie/check/check-bad-mathjax.md
+++ b/docs/pie/check/check-bad-mathjax.md
@@ -9,7 +9,8 @@ returns a non-zero exit status when deprecated delimiters are found.
 ```bash
 check-bad-mathjax [-x EXCLUDE] [directory]
 ```
-
-The optional directory defaults to `src`. Pass ``-x`` to supply a YAML file
-listing Markdown files to ignore. Each file that contains forbidden delimiters
-is logged for review.
+ 
+The optional directory defaults to `src`. When present,
+`cfg/check-bad-mathjax-exclude.yml` is loaded to determine files to skip. Use
+``-x`` to supply a different YAML file. Each file that contains forbidden
+delimiters is logged for review.

--- a/docs/pie/check/check-bad-mathjax.md
+++ b/docs/pie/check/check-bad-mathjax.md
@@ -7,8 +7,9 @@ returns a non-zero exit status when deprecated delimiters are found.
 ## Usage
 
 ```bash
-check-bad-mathjax [directory]
+check-bad-mathjax [-x EXCLUDE] [directory]
 ```
 
-The optional directory defaults to `src`. Each file that contains forbidden
-delimiters is logged for review.
+The optional directory defaults to `src`. Pass ``-x`` to supply a YAML file
+listing Markdown files to ignore. Each file that contains forbidden delimiters
+is logged for review.


### PR DESCRIPTION
## Summary
- allow check-bad-mathjax to skip files listed in a YAML exclude file via `-x/--exclude`
- document the `-x` option and its usage
- test that excluded files are ignored
- centralize exclude-file parsing and reuse for check-page-title

## Testing
- `pytest app/shell/py/pie/tests/test_check_bad_mathjax.py app/shell/py/pie/tests/test_check_page_title.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8de6331448321a31ee0546acecda2