### PR TITLE
Add unescaped dollar sign checker

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -140,6 +140,8 @@ check:
 	$(Q)check-author $(SRC_DIR)
 	$(call status,Check for bad MathJax)
 	$(Q)check-bad-mathjax $(SRC_DIR)
+	$(call status,Check for unescaped dollar signs)
+	$(Q)check-unescaped-dollar $(SRC_DIR)
 	$(call status,Check page titles)
 	$(Q)check-page-title -x $(CFG_DIR)/check-page-title-exclude.yml $(BUILD_DIR)
 	$(call status,Check post-build artifacts)

--- a/app/shell/py/pie/pie/check/unescaped_dollar.py
+++ b/app/shell/py/pie/pie/check/unescaped_dollar.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Report unescaped dollar signs in Markdown files."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
+from pie.utils import load_exclude_file
+
+DEFAULT_LOG = "log/check-unescaped-dollar.txt"
+DEFAULT_EXCLUDE = Path("cfg/check-unescaped-dollar-exclude.yml")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Return parsed command line arguments."""
+    parser = create_parser(
+        "Check Markdown files for unescaped dollar signs.",
+        log_default=DEFAULT_LOG,
+    )
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="src",
+        help="Root directory to scan for Markdown files",
+    )
+    parser.add_argument(
+        "-x",
+        "--exclude",
+        help=(
+            "YAML file listing Markdown files to skip "
+            f"(default: {DEFAULT_EXCLUDE})"
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _has_single_dollar(text: str) -> bool:
+    text = text.replace("\\$", "")
+    for line in text.splitlines():
+        if line.count("$") % 2:
+            return True
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``check-unescaped-dollar`` console script."""
+    args = parse_args(argv)
+    Path(args.log).parent.mkdir(parents=True, exist_ok=True)
+    configure_logging(args.verbose, args.log)
+
+    root = Path(args.directory)
+    if args.exclude:
+        exclude = load_exclude_file(args.exclude, root)
+    elif DEFAULT_EXCLUDE.is_file():
+        exclude = load_exclude_file(DEFAULT_EXCLUDE, root)
+    else:
+        exclude = set()
+    ok = True
+    for md in root.rglob("*.md"):
+        if md.resolve() in exclude:
+            continue
+        text = md.read_text(encoding="utf-8")
+        if _has_single_dollar(text):
+            logger.error("Unescaped dollar sign", path=str(md))
+            ok = False
+    if ok:
+        logger.info("No unescaped dollar signs found.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -21,6 +21,7 @@ setup(
             'check-author=pie.check.author:main',
             'check-bad-jinja-output=pie.check.bad_jinja_output:main',
             'check-bad-mathjax=pie.check.bad_mathjax:main',
+            'check-unescaped-dollar=pie.check.unescaped_dollar:main',
             'check-page-title=pie.check.page_title:main',
             'check-post-build=pie.check.post_build:main',
             'check-unexpanded-jinja=pie.check.unexpanded_jinja:main',

--- a/app/shell/py/pie/tests/test_check_unescaped_dollar.py
+++ b/app/shell/py/pie/tests/test_check_unescaped_dollar.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from __future__ import annotations
+
+from pathlib import Path
+import os
+
+from pie.check import unescaped_dollar as check_unescaped_dollar
+
+
+def test_main_pass(tmp_path: Path) -> None:
+    """Markdown with escaped dollars passes."""
+    md = tmp_path / "index.md"
+    md.write_text("$a$ and \\$5", encoding="utf-8")
+    assert check_unescaped_dollar.main([str(tmp_path)]) == 0
+
+
+def test_fail(tmp_path: Path, capsys) -> None:
+    """Single unescaped dollars report an error."""
+    md = tmp_path / "index.md"
+    md.write_text("Cost $5", encoding="utf-8")
+    assert check_unescaped_dollar.main([str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert "dollar sign" in captured.err
+
+
+def test_exclude_file(tmp_path: Path) -> None:
+    """Files listed in the exclude YAML are ignored."""
+    bad = tmp_path / "bad.md"
+    bad.write_text("Cost $5", encoding="utf-8")
+    exclude = tmp_path / "exclude.yml"
+    exclude.write_text(f"- {bad.name}\n", encoding="utf-8")
+    assert check_unescaped_dollar.main([str(tmp_path), "-x", str(exclude)]) == 0
+
+
+def test_default_exclude_file(tmp_path: Path) -> None:
+    """Default exclude YAML is used when present."""
+    bad = tmp_path / "bad.md"
+    bad.write_text("Cost $5", encoding="utf-8")
+    cfg = tmp_path / "cfg"
+    cfg.mkdir()
+    exclude = cfg / "check-unescaped-dollar-exclude.yml"
+    exclude.write_text(f"- {bad.name}\n", encoding="utf-8")
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        assert check_unescaped_dollar.main([str(tmp_path)]) == 0
+    finally:
+        os.chdir(cwd)

--- a/cfg/check-unescaped-dollar-exclude.yml
+++ b/cfg/check-unescaped-dollar-exclude.yml
@@ -1,0 +1,1 @@
+# List Markdown files for check-unescaped-dollar to skip.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -24,6 +24,8 @@ concepts and data formats, see the
   artifacts.
 - [check-bad-mathjax](../pie/check/check-bad-mathjax.md) – detect old
   MathJax delimiters.
+- [check-unescaped-dollar](../pie/check/check-unescaped-dollar.md) – detect
+  unescaped dollar signs.
 - [tests.md](tests.md) – run the automated test suite.
 
 ## Services and utilities

--- a/docs/pie/check/README.md
+++ b/docs/pie/check/README.md
@@ -10,4 +10,6 @@ Documentation for Pie's validation scripts.
   rendering.
 - [check-bad-mathjax](check-bad-mathjax.md) – detect deprecated MathJax
   delimiters.
+- [check-unescaped-dollar](check-unescaped-dollar.md) – detect unescaped
+  dollar signs.
 

--- a/docs/pie/check/check-unescaped-dollar.md
+++ b/docs/pie/check/check-unescaped-dollar.md
@@ -1,0 +1,16 @@
+# check-unescaped-dollar
+
+`check-unescaped-dollar` scans Markdown files for single `$` characters that are
+not escaped. Unescaped dollar signs can trigger MathJax parsing. The script
+returns a non-zero exit status when any unescaped dollar signs are found.
+
+## Usage
+
+```bash
+check-unescaped-dollar [-x EXCLUDE] [directory]
+```
+
+The optional directory defaults to `src`. When present,
+`cfg/check-unescaped-dollar-exclude.yml` is loaded to determine files to skip.
+Use `-x` to supply a different YAML file. Each file with an unescaped dollar
+sign is logged for review.

--- a/makefile
+++ b/makefile
@@ -141,6 +141,8 @@ check:
 	$(Q)check-author $(SRC_DIR)
 	$(call status,Check for bad MathJax)
 	$(Q)check-bad-mathjax $(SRC_DIR)
+	$(call status,Check for unescaped dollar signs)
+	$(Q)check-unescaped-dollar $(SRC_DIR)
 	$(call status,Check page titles)
 	$(Q)check-page-title -x $(CFG_DIR)/check-page-title-exclude.yml $(BUILD_DIR)
 	$(call status,Check post-build artifacts)


### PR DESCRIPTION
## Summary
- add `check-unescaped-dollar` console script to flag unescaped `$` in Markdown
- run checker during build process and expose via CLI
- document and test the new validation step
- fix makefile indentation for new check

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `cd app/shell/py/pie && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a92764f5b48321bfb9a7a59db9c742