### PR TITLE
Log offending line for YAML parse errors

### DIFF
--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -82,7 +82,7 @@ def test_load_metadata_pair_conflict_shows_path(tmp_path):
 
 
 def test_read_from_yaml_error_logs_path(tmp_path):
-    """Malformed YAML reports the filename."""
+    """Malformed YAML reports the filename and offending line."""
     bad = tmp_path / "bad.yml"
     bad.write_text(":\n")
     os.chdir(tmp_path)
@@ -92,4 +92,6 @@ def test_read_from_yaml_error_logs_path(tmp_path):
     finally:
         os.chdir("/tmp")
     assert "bad.yml" in str(excinfo.value)
+    notes = getattr(excinfo.value, "__notes__", [])
+    assert any("line 1: :" in note for note in notes)
 


### PR DESCRIPTION
## Summary
- include the problematic line in YAML parse error logging
- test that metadata parser reports the line of malformed YAML

## Testing
- `pytest app/shell/py/pie/tests/test_metadata.py::test_read_from_yaml_error_logs_path -q`
- `pytest -q` *(fails: test_read_from_yaml_error_logs_path passes but update_link_filters tests fail with unexpected quoting)*

------
https://chatgpt.com/codex/tasks/task_e_68aa296d619c83218313f4bc97c839f1