### PR TITLE
pie: add sitemap hostname check

### DIFF
--- a/app/shell/py/pie/pie/check/sitemap_hostname.py
+++ b/app/shell/py/pie/pie/check/sitemap_hostname.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Ensure ``sitemap.xml`` does not reference ``localhost``."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
+
+DEFAULT_LOG = "log/check-sitemap-hostname.txt"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Return parsed command line arguments."""
+    parser = create_parser(
+        "Verify sitemap.xml does not contain the hostname localhost.",
+        log_default=DEFAULT_LOG,
+    )
+    parser.add_argument(
+        "file",
+        nargs="?",
+        default="build/sitemap.xml",
+        help="Path to sitemap.xml to verify",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Return ``0`` if ``localhost`` is absent, ``1`` otherwise."""
+    args = parse_args(argv)
+    Path(args.log).parent.mkdir(parents=True, exist_ok=True)
+    configure_logging(args.verbose, args.log)
+
+    path = Path(args.file)
+    if not path.is_file():
+        logger.error("Missing sitemap", path=str(path))
+        return 1
+    text = path.read_text(encoding="utf-8")
+    if "localhost" in text:
+        logger.error("Found localhost", path=str(path))
+        return 1
+    logger.info("No localhost hostnames found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -24,6 +24,7 @@ setup(
             'check-unescaped-dollar=pie.check.unescaped_dollar:main',
             'check-page-title=pie.check.page_title:main',
             'check-post-build=pie.check.post_build:main',
+            'check-sitemap-hostname=pie.check.sitemap_hostname:main',
             'check-unexpanded-jinja=pie.check.unexpanded_jinja:main',
             'check-underscores=pie.check.underscores:main',
             'create-post=pie.create.post:main',

--- a/app/shell/py/pie/tests/test_check_sitemap_hostname.py
+++ b/app/shell/py/pie/tests/test_check_sitemap_hostname.py
@@ -1,0 +1,26 @@
+from pie.check import sitemap_hostname as check_sitemap_hostname
+
+
+def test_main_reports_localhost(tmp_path):
+    """If sitemap references localhost -> exit code 1."""
+    sm = tmp_path / "sitemap.xml"
+    sm.write_text("<loc>http://localhost/foo</loc>", encoding="utf-8")
+    rc = check_sitemap_hostname.main([str(sm), "-l", str(tmp_path / "log.txt")])
+    assert rc == 1
+
+
+def test_main_passes_and_logs(tmp_path):
+    """No localhost -> exit 0 and create log."""
+    sm = tmp_path / "sitemap.xml"
+    sm.write_text("<loc>https://example.com/foo</loc>", encoding="utf-8")
+    log = tmp_path / "log.txt"
+    rc = check_sitemap_hostname.main([str(sm), "-l", str(log)])
+    assert rc == 0
+    assert log.exists()
+
+
+def test_parse_args_defaults():
+    """parse_args returns default paths."""
+    args = check_sitemap_hostname.parse_args([])
+    assert args.file == "build/sitemap.xml"
+    assert args.log == "log/check-sitemap-hostname.txt"


### PR DESCRIPTION
## Summary
- add console script that validates sitemap.xml does not contain localhost hostnames
- expose new checker as `check-sitemap-hostname`
- test sitemap hostname checker behavior

## Testing
- `pytest app/shell/py/pie/tests/test_check_sitemap_hostname.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3b3a76108321ada29d8c3e977e6b