### PR TITLE
Install yamllint and add make target

### DIFF
--- a/app/shell/Dockerfile
+++ b/app/shell/Dockerfile
@@ -51,7 +51,8 @@ COPY ./py/pie /press/py/pie
 
 RUN pip install --no-cache-dir --break-system-packages \
         -e /press/py/pie \
-        -r /press/py/pie/requirements.txt
+        -r /press/py/pie/requirements.txt \
+        yamllint
 
 # -------------------------------------------------------------------
 # Custom helper scripts and makefiles

--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -128,6 +128,11 @@ $(BUILD_DIR)/.minify:
 	$(call status,Minify HTML and CSS)
 	$(Q)cd $(BUILD_DIR); $(MINIFY_CMD) -a -v -r -o . .
 
+.PHONY: yamllint
+yamllint:
+	$(call status,Check YAML files)
+	$(Q)yamllint $(BUILD_DIR)
+
 .PHONY: test
 # Triggered by the test target in redo.mk; see docs/guides/redo-mk.md.
 test: $(BUILD_DIR)/.minify check | $(LOG_DIR)
@@ -135,7 +140,7 @@ test: $(BUILD_DIR)/.minify check | $(LOG_DIR)
 	$(Q)$(CHECKLINKS_CMD) $(TEST_HOST_URL)
 
 .PHONY: check
-check:
+check: yamllint
 	$(call status,Check metadata authors)
 	$(Q)check-author $(SRC_DIR)
 	$(call status,Check for bad MathJax)

--- a/makefile
+++ b/makefile
@@ -129,6 +129,11 @@ $(BUILD_DIR)/.minify:
 	$(call status,Minify HTML and CSS)
 	$(Q)cd $(BUILD_DIR); $(MINIFY_CMD) -a -v -r -o . .
 
+.PHONY: yamllint
+yamllint:
+	$(call status,Check YAML files)
+	$(Q)yamllint $(BUILD_DIR)
+
 .PHONY: test
 # Triggered by the test target; see docs/guides/redo-mk.md.
 test: $(BUILD_DIR)/.minify check | $(LOG_DIR)
@@ -136,7 +141,7 @@ test: $(BUILD_DIR)/.minify check | $(LOG_DIR)
 	$(Q)$(CHECKLINKS_CMD) $(TEST_HOST_URL)
 
 .PHONY: check
-check:
+check: yamllint
 	$(call status,Check metadata authors)
 	$(Q)check-author $(SRC_DIR)
 	$(call status,Check for bad MathJax)


### PR DESCRIPTION
## Summary
- install yamllint in shell Docker image
- add yamllint target to makefiles and hook into check

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pip install yamllint`
- `yamllint build/` *(fails: No such file or directory)*
- `pytest` *(fails: 3 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2c4960788321953fb051fcb0f3d7