### PR TITLE
Respect BASE_URL environment in Makefile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       REDIS_HOST: dragonfly
       REDIS_PORT: 6379
       TEST_HOST_URL: ${TEST_HOST_URL:-http://nginx-test}
-      BASE_URL: ${BASE_URL:-http://localhost}
+      BASE_URL: ${BASE_URL:-http://press.io}
     volumes:
       - ./:/data
       - ./app/shell/mk:/app/mk
@@ -96,7 +96,7 @@ services:
       REDIS_HOST: dragonfly
       REDIS_PORT: 6379
       TEST_HOST_URL: ${TEST_HOST_URL:-http://nginx-test}
-      BASE_URL: ${BASE_URL:-http://localhost}
+      BASE_URL: ${BASE_URL:-http://press.io}
     ports:
       - "${SSH_PORT:-2222}:22"
     volumes:

--- a/makefile
+++ b/makefile
@@ -2,7 +2,12 @@
 # Migrated from app/shell/mk/build.mk. Targets now run from the repository root.
 
 export PATH := /app/bin:$(PATH)
-export BASE_URL := http://localhost
+
+# Allow the environment to override BASE_URL instead of forcing localhost.
+# This ensures tooling such as the sitemap generator picks up the value
+# provided via docker-compose or the user's shell.
+BASE_URL ?= http://localhost
+export BASE_URL
 
 # Override MAKEFLAGS (so your settings can’t be clobbered by the environment)
 # docker-make previously passed these flags inside the container; still useful.

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ export PATH := /app/bin:$(PATH)
 # Allow the environment to override BASE_URL instead of forcing localhost.
 # This ensures tooling such as the sitemap generator picks up the value
 # provided via docker-compose or the user's shell.
-BASE_URL ?= http://localhost
+BASE_URL ?= http://press.io
 export BASE_URL
 
 # Override MAKEFLAGS (so your settings can’t be clobbered by the environment)


### PR DESCRIPTION
## Summary
- allow BASE_URL env var to override localhost default so sitemap and
  metadata honor docker-compose configuration

## Testing
- `BASE_URL=https://example.com make check` *(fails: Missing artifact build/static/js/indextree.js)*
- `BASE_URL=https://example.com make everything` *(fails: Error -2 connecting to dragonfly:6379)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6007b2b88321bf8c7fa79b53ad33