### PR TITLE
feat: run combined checkers

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -136,20 +136,8 @@ test: $(BUILD_DIR)/.minify check | $(LOG_DIR)
 
 .PHONY: check
 check:
-	$(call status,Check metadata authors)
-	$(Q)check-author $(SRC_DIR)
-	$(call status,Check for bad MathJax)
-	$(Q)check-bad-mathjax $(SRC_DIR)
-	$(call status,Check for unescaped dollar signs)
-	$(Q)check-unescaped-dollar $(SRC_DIR)
-	$(call status,Check page titles)
-	$(Q)check-page-title -x $(CFG_DIR)/check-page-title-exclude.yml $(BUILD_DIR)
-	$(call status,Check post-build artifacts)
-	$(Q)check-post-build -c $(CFG_DIR)/check-post-build.yml
-	$(call status,Check for unexpanded Jinja)
-	$(Q)check-unexpanded-jinja $(BUILD_DIR)
-	$(call status,Check for URL underscores)
-	$(Q)check-underscores $(BUILD_DIR)
+	$(call status,Run checks)
+	$(Q)check-all
 
 # Create necessary build directories
 $(BUILD_DIR): | $(BUILD_SUBDIRS)

--- a/app/shell/py/pie/pie/check/all.py
+++ b/app/shell/py/pie/pie/check/all.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Callable, Iterable
+
+from pie.check import (
+    author,
+    bad_mathjax,
+    unescaped_dollar,
+    page_title,
+    post_build,
+    unexpanded_jinja,
+    underscores,
+    canonical,
+    sitemap_hostname,
+)
+
+CheckFunc = Callable[[], int]
+
+CHECKS: Iterable[tuple[str, CheckFunc]] = (
+    ("Check metadata authors", lambda: author.main(["src"])),
+    ("Check for bad MathJax", lambda: bad_mathjax.main(["src"])),
+    (
+        "Check for unescaped dollar signs",
+        lambda: unescaped_dollar.main(["src"]),
+    ),
+    (
+        "Check page titles",
+        lambda: page_title.main([
+            "-x",
+            "cfg/check-page-title-exclude.yml",
+            "build",
+        ]),
+    ),
+    (
+        "Check post-build artifacts",
+        lambda: post_build.main(["-c", "cfg/check-post-build.yml"]),
+    ),
+    (
+        "Check for unexpanded Jinja",
+        lambda: unexpanded_jinja.main(["build"]),
+    ),
+    (
+        "Check for URL underscores",
+        lambda: underscores.main(["build"]),
+    ),
+    ("Check canonical links", lambda: canonical.main(["build"])),
+    ("Check sitemap", lambda: sitemap_hostname.main([])),
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run all checkers sequentially.
+
+    This combines the existing stand-alone scripts into a single entry
+    point, avoiding repeated Python start-up costs during a build.
+    """
+
+    ok = True
+    for message, func in CHECKS:
+        print(f"==> {message}")
+        if func() != 0:
+            ok = False
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -28,6 +28,7 @@ setup(
             'check-sitemap-hostname=pie.check.sitemap_hostname:main',
             'check-unexpanded-jinja=pie.check.unexpanded_jinja:main',
             'check-underscores=pie.check.underscores:main',
+            'check-all=pie.check.all:main',
             'create-post=pie.create.post:main',
             'create-site=pie.create.site:main',
             'emojify=pie.filter.emojify:main',

--- a/makefile
+++ b/makefile
@@ -142,24 +142,8 @@ test: $(BUILD_DIR)/.minify check | $(LOG_DIR)
 
 .PHONY: check
 check:
-	$(call status,Check metadata authors)
-	$(Q)check-author $(SRC_DIR)
-	$(call status,Check for bad MathJax)
-	$(Q)check-bad-mathjax $(SRC_DIR)
-	$(call status,Check for unescaped dollar signs)
-	$(Q)check-unescaped-dollar $(SRC_DIR)
-	$(call status,Check page titles)
-	$(Q)check-page-title -x $(CFG_DIR)/check-page-title-exclude.yml $(BUILD_DIR)
-	$(call status,Check post-build artifacts)
-	$(Q)check-post-build -c $(CFG_DIR)/check-post-build.yml
-	$(call status,Check for unexpanded Jinja)
-	$(Q)check-unexpanded-jinja $(BUILD_DIR)
-	$(call status,Check for URL underscores)
-	$(Q)check-underscores $(BUILD_DIR)
-	$(call status,Check canonical links)
-	$(Q)check-canonical $(BUILD_DIR)
-	$(call status,Check sitemap)
-	$(Q)check-sitemap-hostname
+	$(call status,Run checks)
+	$(Q)check-all
 
 # Create necessary build directories
 $(BUILD_DIR): | $(BUILD_SUBDIRS)


### PR DESCRIPTION
## Summary
- add `check-all` script to run all validators in one process
- wire makefiles to use `check-all`
- expose combined checker via setup entry points

## Testing
- `PYTHONPATH=app/shell/py/pie pytest app/shell/py/pie/tests`


------
https://chatgpt.com/codex/tasks/task_e_68ab6a97cf44832193f7474788cbecde