### PR TITLE
Add tests for check aggregator

### DIFF
--- a/app/shell/py/pie/tests/test_check_all.py
+++ b/app/shell/py/pie/tests/test_check_all.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import runpy
+import sys
+import types
+
+import pytest
+
+from pie.check import all as check_all
+
+
+def test_main_ok(monkeypatch, capsys) -> None:
+    """Return code 0 when all checks pass."""
+    monkeypatch.setattr(
+        check_all,
+        "CHECKS",
+        [("First", lambda: 0), ("Second", lambda: 0)],
+    )
+    rc = check_all.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "==> First" in out
+    assert "==> Second" in out
+
+
+def test_main_failure(monkeypatch) -> None:
+    """Return code 1 when a check fails."""
+    monkeypatch.setattr(
+        check_all,
+        "CHECKS",
+        [("One", lambda: 0), ("Two", lambda: 1)],
+    )
+    rc = check_all.main()
+    assert rc == 1
+
+
+def test_run_as_script(monkeypatch) -> None:
+    """The module exits via SystemExit when run as a script."""
+    check_pkg = types.ModuleType("pie.check")
+    monkeypatch.setitem(sys.modules, "pie.check", check_pkg)
+    for name in [
+        "author",
+        "bad_mathjax",
+        "unescaped_dollar",
+        "page_title",
+        "post_build",
+        "unexpanded_jinja",
+        "underscores",
+        "canonical",
+        "sitemap_hostname",
+    ]:
+        mod = types.ModuleType(f"pie.check.{name}")
+        mod.main = lambda _a, _name=name: 0
+        setattr(check_pkg, name, mod)
+        monkeypatch.setitem(sys.modules, f"pie.check.{name}", mod)
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_module("pie.check.all", run_name="__main__")
+    assert excinfo.value.code == 0


### PR DESCRIPTION
## Summary
- add tests for pie.check.all covering success, failure, and script execution

## Testing
- `pytest app/shell/py/pie/tests/test_check_all.py -q`
- `pytest app/shell/py/pie/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab70ecbbd48321989501571641f059