### PR TITLE
Use dynamic parallelism and cached source lists

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -4,9 +4,10 @@
 
 # Override MAKEFLAGS (so your settings can’t be clobbered by the environment)
 # docker-make passes these flags to the container; see docs/guides/docker-make.md
+NPROC := $(shell nproc)
 override MAKEFLAGS += --warn-undefined-variables  \
                       --no-builtin-rules        \
-                      -j16                      \
+                      -j$(NPROC)                      \
                       --no-print-directory      \
 
 # Export it so sub-makes see the same flags
@@ -72,9 +73,9 @@ TEST_HOST_URL ?= https://nginx-test
 
 VPATH := $(SRC_DIR)
 
-# Find all Markdown files excluding specified directories
-MARKDOWNS := $(shell find $(SRC_DIR)/ -name '*.md')
-YAMLS := $(shell find $(SRC_DIR) -name "*.yml")
+# Collect source files using wildcard to avoid repeated find scans
+MARKDOWNS := $(wildcard $(SRC_DIR)/**/*.md)
+YAMLS := $(wildcard $(SRC_DIR)/**/*.yml)
 BUILD_YAMLS := $(patsubst $(SRC_DIR)/%,$(BUILD_DIR)/%,$(YAMLS))
 
 # Define the corresponding HTML and PDF output files

--- a/app/shell/py/pie/pie/create/templates/redo.mk.jinja
+++ b/app/shell/py/pie/pie/create/templates/redo.mk.jinja
@@ -1,9 +1,10 @@
 # Makefile for building and managing Press
 
 # Override MAKEFLAGS (so your settings can’t be clobbered by the environment)
+NPROC := $(shell nproc)
 override MAKEFLAGS += --warn-undefined-variables  \
 	              --no-builtin-rules        \
-	              -j16                      \
+	              -j$(NPROC)                      \
 
 # Export it so sub-makes see the same flags
 export MAKEFLAGS

--- a/makefile
+++ b/makefile
@@ -11,9 +11,10 @@ export BASE_URL
 
 # Override MAKEFLAGS (so your settings can’t be clobbered by the environment)
 # docker-make previously passed these flags inside the container; still useful.
+NPROC := $(shell nproc)
 override MAKEFLAGS += --warn-undefined-variables  \
               --no-builtin-rules        \
-              -j16                      \
+              -j$(NPROC)                      \
               --no-print-directory      \
 
 # Export it so sub-makes see the same flags
@@ -78,9 +79,9 @@ TEST_HOST_URL ?= http://nginx-test
 
 VPATH := $(SRC_DIR)
 
-# Find all Markdown files excluding specified directories
-MARKDOWNS := $(shell find $(SRC_DIR)/ -name '*.md')
-YAMLS := $(shell find $(SRC_DIR) -name "*.yml")
+# Collect source files using wildcard to avoid repeated find scans
+MARKDOWNS := $(wildcard $(SRC_DIR)/**/*.md)
+YAMLS := $(wildcard $(SRC_DIR)/**/*.yml)
 BUILD_YAMLS := $(patsubst $(SRC_DIR)/%,$(BUILD_DIR)/%,$(YAMLS))
 
 # Define the corresponding HTML and PDF output files

--- a/redo.mk
+++ b/redo.mk
@@ -1,9 +1,10 @@
 # Makefile for building and managing Press
 
 # Override MAKEFLAGS (so your settings can’t be clobbered by the environment)
+NPROC := $(shell nproc)
 override MAKEFLAGS += --warn-undefined-variables  \
 	              --no-builtin-rules        \
-	              -j16                      \
+	              -j$(NPROC)                      \
 
 # Export it so sub-makes see the same flags
 export MAKEFLAGS


### PR DESCRIPTION
## Summary
- derive MAKEFLAGS parallelism from `nproc` instead of a fixed 16 jobs
- gather Markdown and YAML sources with `wildcard` globs to avoid repeated `find`

## Testing
- `make check` *(fails: check-all: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7e24dc28832189d4a8e3b7fb8548