### PR TITLE
feat: avoid rewriting unchanged YAML

### DIFF
--- a/docs/guides/process-yaml.md
+++ b/docs/guides/process-yaml.md
@@ -8,8 +8,11 @@ usage: process-yaml <file.yml> [file.yml ...]
 ```
 
 The command reads each YAML file and generates any missing values as described
-in [Metadata Fields](../reference/metadata-fields.md). It writes the result back
-to the same path. Use `--log` to save verbose logs.
+in [Metadata Fields](../reference/metadata-fields.md). It writes the result
+back to the same path. If the destination exists and its metadata is
+unchanged, the file is left as is; cosmetic differences like key ordering or
+quoting are ignored. Otherwise a new or updated file is written. Use `--log`
+to save verbose logs.
 
 Example:
 


### PR DESCRIPTION
## Summary
- compare YAML metadata structures to skip rewrites
- expand process-yaml tests for structural comparisons
- document that cosmetic YAML differences do not trigger rewrites

## Testing
- `pytest app/shell/py/pie/tests/test_process_yaml.py`


------
https://chatgpt.com/codex/tasks/task_e_68abc12b5ce483219c3aaf37c45be3b2