### PR TITLE
Add tests for sitemap hostname checks

### DIFF
--- a/app/shell/py/pie/tests/test_check_sitemap_hostname.py
+++ b/app/shell/py/pie/tests/test_check_sitemap_hostname.py
@@ -1,3 +1,9 @@
+import runpy
+import sys
+from pathlib import Path
+
+import pytest
+
 from pie.check import sitemap_hostname as check_sitemap_hostname
 
 
@@ -24,3 +30,23 @@ def test_parse_args_defaults():
     args = check_sitemap_hostname.parse_args([])
     assert args.file == "build/sitemap.xml"
     assert args.log == "log/check-sitemap-hostname.txt"
+
+
+def test_main_missing_file(tmp_path):
+    """Absent sitemap file -> exit code 1."""
+    rc = check_sitemap_hostname.main(
+        [str(tmp_path / "sitemap.xml"), "-l", str(tmp_path / "log.txt")]
+    )
+    assert rc == 1
+
+
+def test_run_module_as_script(tmp_path, monkeypatch):
+    """Executing module as a script exits via :class:`SystemExit`."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1]))
+    monkeypatch.setattr(sys, "argv", ["sitemap_hostname.py"])
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_module(
+            "pie.check.sitemap_hostname", run_name="__main__", alter_sys=True
+        )
+    assert excinfo.value.code == 1


### PR DESCRIPTION
## Summary
- add coverage for missing sitemap and script execution

## Testing
- `pytest app/shell/py/pie/tests/test_check_sitemap_hostname.py -q`
- `coverage report -m app/shell/py/pie/pie/check/sitemap_hostname.py`


------
https://chatgpt.com/codex/tasks/task_e_68abc8f0e75c8321a3be09032f0da0b9