### PR TITLE
feat: support custom indextree ordering

### DIFF
--- a/app/shell/py/pie/pie/gen_markdown_index.py
+++ b/app/shell/py/pie/pie/gen_markdown_index.py
@@ -13,7 +13,7 @@ from typing import Iterator
 
 from pie.cli import create_parser
 from pie.logging import configure_logging
-from pie.index_tree import walk, getopt_link, getopt_show
+from pie.index_tree import walk, getopt_link, getopt_show, sort_entries
 
 warnings.warn(
     "pie.gen_markdown_index is deprecated and will be removed in a future release",
@@ -24,7 +24,8 @@ warnings.warn(
 
 def generate(directory: Path, level: int = 0) -> Iterator[str]:
     """Yield Markdown list items for *directory* recursively."""
-    entries = sorted(walk(directory), key=lambda x: x[0]["title"].lower())
+    entries = list(walk(directory))
+    sort_entries(entries)
     for meta, path in entries:
         entry_id = meta["id"]
         title = meta["title"]

--- a/app/shell/py/pie/pie/indextree_json.py
+++ b/app/shell/py/pie/pie/indextree_json.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from pie.cli import create_parser
 from pie.logging import logger, configure_logging
 
-from pie.index_tree import walk, getopt_link, getopt_show
+from pie.index_tree import walk, getopt_link, getopt_show, sort_entries
 
 
 def process_dir(directory: Path):
@@ -16,7 +16,7 @@ def process_dir(directory: Path):
     for meta, path in entries:
         if "title" not in meta:
             raise ValueError(f"Missing 'title' in {path}")
-    entries.sort(key=lambda x: x[0]["title"].lower())
+    sort_entries(entries)
     for meta, path in entries:
         entry_id = meta["id"]
         entry_title = meta["title"]

--- a/app/shell/py/pie/tests/test_indextree_json.py
+++ b/app/shell/py/pie/tests/test_indextree_json.py
@@ -120,6 +120,28 @@ def test_process_dir_honours_show_and_link(tmp_path, monkeypatch):
     ]
 
 
+def test_process_dir_sorts_by_numeric_filename(tmp_path, monkeypatch):
+    """Numeric file names are ordered numerically."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "1.yml").touch()
+    (src / "2.yml").touch()
+
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(metadata, "redis_conn", fake)
+
+    save_meta(fake, "src/1.yml", "one", {"title": "Beta"})
+    save_meta(fake, "src/2.yml", "two", {"title": "Alpha"})
+
+    os.chdir(tmp_path)
+    try:
+        data = list(indextree_json.process_dir(Path("src")))
+    finally:
+        os.chdir("/tmp")
+
+    assert [node["id"] for node in data] == ["one", "two"]
+
+
 def test_main_writes_output_file(tmp_path, monkeypatch, capsys):
     """JSON is written to file when an output path is provided."""
     src = tmp_path / "src"

--- a/docs/guides/gen-markdown-index.md
+++ b/docs/guides/gen-markdown-index.md
@@ -1,6 +1,9 @@
 # gen-markdown-index
 
-`gen-markdown-index` walks a directory tree of YAML metadata files and prints a Markdown list.
+`gen-markdown-index` walks a directory tree of YAML metadata files and
+prints a Markdown list. Nodes honour `indextree.order` to customise
+sorting. Items with numerical filenames are ordered numerically before
+falling back to case-insensitive titles.
 
 ```
 usage: gen-markdown-index [ROOT_DIR]

--- a/docs/guides/react-index-tree.md
+++ b/docs/guides/react-index-tree.md
@@ -13,7 +13,9 @@ scanning a directory of YAML metadata files and producing nodes for each
 file and subdirectory. Entries honour the same `indextree`
 options (`show` and `link`) used by the Markdown index generator. When
 linking is enabled, the `url` property is copied from the metadata
-without modification:
+without modification. Items may also specify `indextree.order` to control
+their position. Numeric filenames are sorted numerically before falling
+back to case-insensitive titles:
 
 ```bash
 indextree-json docs doc-tree.json


### PR DESCRIPTION
## Summary
- allow sorting indextree nodes by metadata or numeric filenames
- document new ordering options for index generators
- clarify sort key return values for explicit, numeric, or title ordering

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest app/shell/py/pie/tests/test_indextree_json.py app/shell/py/pie/tests/test_gen_markdown_index.py`


------
https://chatgpt.com/codex/tasks/task_e_68abe06c6e388321bf09b26b9eaa41b0