### PR TITLE
Enable ETag headers for nginx configs

### DIFF
--- a/app/nginx/Dockerfile
+++ b/app/nginx/Dockerfile
@@ -7,4 +7,5 @@ ARG NGINX_CONF=app/nginx/default.conf
 # mount.
 COPY ${NGINX_CONF} /etc/nginx/conf.d/default.conf
 
-COPY ./build /usr/share/nginx/html
+# Copy built site and preserve timestamps for Last-Modified headers
+COPY --link ./build /usr/share/nginx/html

--- a/app/nginx/default.conf
+++ b/app/nginx/default.conf
@@ -10,6 +10,7 @@ server {
     # Directory containing the built site
     root /usr/share/nginx/html;
     index index.html;            # Default file to serve
+    etag on;                  # Enable ETag headers
 
     # Serve static files and return 404 for missing paths
     location / {

--- a/app/nginx/prod.conf
+++ b/app/nginx/prod.conf
@@ -10,6 +10,7 @@ server {
     # Directory containing the built static site
     root /usr/share/nginx/html;
     index index.html;            # Default file to serve
+    etag on;                  # Enable ETag headers
 
     # Serve static files and return 404 for missing paths
     location / {


### PR DESCRIPTION
## Summary
- enable `etag` in default and production nginx configs
- preserve static file timestamps in nginx Dockerfile to keep Last-Modified accurate

## Testing
- `pytest app/shell/py/pie/tests`
- `nginx -t -c app/nginx/default.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7a82c2008321b7da39b32a678b75