### PR TITLE
Version CSS path with build hash

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -42,15 +42,18 @@ CFG_DIR   := cfg
 PANDOC_CMD := pandoc
 PANDOC_TEMPLATE := $(SRC_DIR)/pandoc-template.html
 
+# Git version for cache busting
+BUILD_VER := $(shell git rev-parse --short HEAD)
+
 # Options for generating HTML output with Pandoc
 PANDOC_OPTS := \
-                --css '/css/style.css' \
-                --standalone \
-                -t html \
-                --toc \
-                --toc-depth=2 \
-                --filter pandoc-crossref \
-                --mathjax \
+	--css '/css/style.css?v=$(BUILD_VER)' \
+	--standalone \
+	-t html \
+	--toc \
+	--toc-depth=2 \
+	--filter pandoc-crossref \
+	--mathjax \
 
 # Options for generating PDF output with Pandoc
 PANDOC_OPTS_PDF := \

--- a/makefile
+++ b/makefile
@@ -48,15 +48,18 @@ CFG_DIR   := cfg
 PANDOC_CMD := pandoc
 PANDOC_TEMPLATE := $(SRC_DIR)/pandoc-template.html
 
+# Git version for cache busting
+BUILD_VER := $(shell git rev-parse --short HEAD)
+
 # Options for generating HTML output with Pandoc
 PANDOC_OPTS := \
-        --css '/css/style.css' \
-        --standalone \
-        -t html \
-        --toc \
-        --toc-depth=2 \
-        --filter pandoc-crossref \
-        --mathjax \
+	--css '/css/style.css?v=$(BUILD_VER)' \
+	--standalone \
+	-t html \
+	--toc \
+	--toc-depth=2 \
+	--filter pandoc-crossref \
+	--mathjax \
 
 # Options for generating PDF output with Pandoc
 PANDOC_OPTS_PDF := \


### PR DESCRIPTION
## Summary
- version stylesheet path in Pandoc builds
- derive BUILD_VER from git for cache-busting

## Testing
- `make clean` *(passes)*
- `PATH=/workspace/press/app/shell/bin:$PATH make all` *(fails: template not found)*
- `PATH=/workspace/press/app/shell/bin:$PATH make test` *(fails: minify not found)*
- `pandoc $PANDOC_OPTS -o build/index.html src/index.md` *(passes with warning)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7a7cefbc83218c42c85ec7d68f57