### PR TITLE
docs: explain BUILD_VER cache busting

### DIFF
--- a/docs/guides/build-process.md
+++ b/docs/guides/build-process.md
@@ -84,6 +84,11 @@ to `build/css/style.css`.
 To add additional stylesheets, create new files in `src/css/` and reference the
 resulting `/css/*.css` paths from your pages or templates.
 
+The build injects a version query string into stylesheet links using the
+`BUILD_VER` variable. Each run sets it to the short Git commit hash,
+producing references like `/css/style.css?v=<hash>` so browsers always
+fetch the latest CSS after each commit.
+
 ## Cleaning up
 
 Use the provided targets to tidy generated files:

--- a/docs/guides/redo-mk.md
+++ b/docs/guides/redo-mk.md
@@ -23,6 +23,11 @@ This repository actually uses three Makefiles that work together:
 - **`COMPOSE_FILE`** – Compose file used by commands. Defaults to `docker-compose.yml` in the project root.
 - **`DOCKER_COMPOSE`** – Shortcut for `docker compose -f $(COMPOSE_FILE)`.
 - **`VERBOSE`** – Set to `1` to print each command executed by `make` in addition to status messages.
+- **`BUILD_VER`** – Short Git commit hash used to bust caches for static
+  assets. The value comes from `git rev-parse --short HEAD` and is appended
+  as a query string in generated URLs, for example
+  `/css/style.css?v=<hash>`. This ensures browsers fetch updated assets
+  after each commit.
 
 ## Common Targets
 


### PR DESCRIPTION
## Summary
- document BUILD_VER variable in redo.mk guide
- clarify stylesheet versioning using BUILD_VER in build process guide

## Testing
- `make -f redo.mk DOCKER_COMPOSE='docker-compose -f docker-compose.yml' pytest` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68ac800459ac8321a71cb4659c343b3e