### PR TITLE
Use default makefile in make/remake scripts

### DIFF
--- a/bin/make
+++ b/bin/make
@@ -2,10 +2,10 @@
 #
 # Description:
 #   Invoke `make` inside the Docker Compose `shell` service.
-#   This mirrors running `make -f app/shell/mk/build.mk` but
-#   executes inside the container so the build environment is
-#   consistent across systems. All arguments are passed directly
-#   to the underlying `make` command.
+#   Runs from the project root (/data) so the default `makefile`
+#   is used, ensuring a consistent build environment across
+#   systems. All arguments are passed directly to the underlying
+#   `make` command.
 #
 # Usage:
 #   make [MAKE_TARGETS]
@@ -18,5 +18,5 @@
 # removed after completion.
 
 docker compose run \
-  --rm --entrypoint make -u "$(id -u)" \
-  shell -f /app/mk/build.mk "$@"
+  --rm --entrypoint make -u "$(id -u)" -w /data \
+  shell "$@"

--- a/bin/remake
+++ b/bin/remake
@@ -2,8 +2,9 @@
 #
 # Description:
 #   Remove the specified build directories and then invoke
-#   `make` with the same arguments. This is useful when
-#   you want to force a clean rebuild of one or more targets.
+#   `make` inside the Docker Compose `shell` service. Runs
+#   from the project root (/data) so the default `makefile`
+#   is used, allowing a clean rebuild of one or more targets.
 #
 # Usage:
 #   remake [TARGETS...]
@@ -17,5 +18,5 @@
 
 rm -rf "$@"
 docker compose run \
-  --rm --entrypoint make -u "$(id -u)" \
-  shell -f /app/mk/build.mk "$@"
+  --rm --entrypoint make -u "$(id -u)" -w /data \
+  shell "$@"


### PR DESCRIPTION
## Summary
- run `make` and `remake` inside container from project root so default makefile is used
- drop explicit `build.mk` path and document the new behavior

## Testing
- `bin/make check` *(fails: docker command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac88e904ac83218fe6c086df84726f