### PR TITLE
Use shell service for builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,3 @@ r cov
 Coverage reports are written to `log/cov`. See
 [docs/guides/tests.md](docs/guides/tests.md) for more details.
 
-## SSH port
-
-The builder service exposes its SSH daemon on the host. By default port 2222
-is used. Override it by setting `SSH_PORT`:
-
-```
-SSH_PORT=3000 docker compose up builder
-SSH_PORT=3000 make test
-```

--- a/bin/make
+++ b/bin/make
@@ -4,8 +4,8 @@
 #   Invoke `make` inside the Docker Compose `shell` service.
 #   Runs from the project root (/data) so the default `makefile`
 #   is used, ensuring a consistent build environment across
-#   systems. All arguments are passed directly to the underlying
-#   `make` command.
+#   systems. All arguments are passed directly to the
+#   underlying `make` command.
 #
 # Usage:
 #   make [MAKE_TARGETS]
@@ -13,10 +13,9 @@
 # Example:
 #   make all
 #
-# Run "make" in the container with the current user's UID so that
-# generated files are owned by the invoking user. The container is
-# removed after completion.
+# Run `make` in a disposable container via:
+#   docker compose run --rm --user "$(id -u):$(id -g)" shell make
+# Files are created with the invoking user's UID and GID to avoid
+# permission issues. The container is removed after completion.
 
-docker compose run \
-  --rm --entrypoint make -u "$(id -u)" -w /data \
-  shell "$@"
+docker compose run --rm --user "$(id -u):$(id -g)" shell make "$@"

--- a/bin/release
+++ b/bin/release
@@ -48,7 +48,7 @@ echo "Starting release build..."
 echo "Stopping existing containers..."
 "${DOCKER_COMPOSE[@]}" down >/dev/null 2>&1 || true
 echo "Starting dragonfly..."
-"${DOCKER_COMPOSE[@]}" up -d dragonfly builder
+"${DOCKER_COMPOSE[@]}" up -d dragonfly
 echo "Running distclean..."
 run_make distclean
 echo "Building shell image..."

--- a/bin/remake
+++ b/bin/remake
@@ -4,7 +4,8 @@
 #   Remove the specified build directories and then invoke
 #   `make` inside the Docker Compose `shell` service. Runs
 #   from the project root (/data) so the default `makefile`
-#   is used, allowing a clean rebuild of one or more targets.
+#   is used, allowing a clean rebuild of one or more
+#   targets.
 #
 # Usage:
 #   remake [TARGETS...]
@@ -13,10 +14,9 @@
 #   remake build webp
 #
 # Each argument is recursively deleted with `rm -rf` before
-# delegating to `make` so the build artifacts are regenerated
-# from scratch.
+# delegating to `make` so the build artifacts are
+# regenerated from scratch. `make` is run via:
+#   docker compose run --rm --user "$(id -u):$(id -g)" shell make
 
 rm -rf "$@"
-docker compose run \
-  --rm --entrypoint make -u "$(id -u)" -w /data \
-  shell "$@"
+docker compose run --rm --user "$(id -u):$(id -g)" shell make "$@"

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -39,10 +39,10 @@ echo "Starting upgrade build..."
 
 echo "Stopping existing containers..."
 "${DOCKER_COMPOSE[@]}" down >/dev/null 2>&1 || true
-echo "Building shell and builder images..."
-"${DOCKER_COMPOSE[@]}" build shell builder
-echo "Starting dragonfly and builder..."
-"${DOCKER_COMPOSE[@]}" up -d dragonfly builder
+echo "Building shell image..."
+"${DOCKER_COMPOSE[@]}" build shell
+echo "Starting dragonfly..."
+"${DOCKER_COMPOSE[@]}" up -d dragonfly
 echo "Running distclean..."
 run_make distclean
 if [ "$RUN_PULL" -eq 1 ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,24 +86,6 @@ services:
       - ./app/shell/py/pie/tests:/press/py/pie/tests
       - ./src/dep.mk:/app/mk/dep.mk
 
-  builder:
-    image: press-shell
-    container_name: press-builder
-    # Copy the host's public key to a root-owned file before starting sshd.
-    entrypoint: ["/bin/sh", "-c", "mkdir -p /root/.ssh; install -m 600 /tmp/id_rsa.pub /root/.ssh/authorized_keys && /usr/sbin/sshd -D"]
-    environment:
-      OPENAI_API_KEY: "${OPENAI_API_KEY}"
-      REDIS_HOST: dragonfly
-      REDIS_PORT: 6379
-      TEST_HOST_URL: ${TEST_HOST_URL:-http://nginx-test}
-      BASE_URL: ${BASE_URL:-http://press.io}
-    ports:
-      - "${SSH_PORT:-2222}:22"
-    volumes:
-      - ./:/data
-      - ~/.ssh/id_rsa.pub:/tmp/id_rsa.pub:ro
-    depends_on:
-      - shell
 
   release:
     image: press-release

--- a/docs/guides/build-process.md
+++ b/docs/guides/build-process.md
@@ -30,7 +30,7 @@ Start the development stack and render the site:
 
 ```bash
 r up      # start compose services
-r all     # run the repository makefile inside the builder container
+r all     # run the repository makefile in the shell service
 ```
 
 The build reads source files under `src/` (or `SRC_DIR` if overridden) and
@@ -38,15 +38,13 @@ writes HTML and assets to `build/`. Logs are stored in `log/`.
 
 If you only need the build step without starting services, run `r all` directly.
 
-Behind the scenes `r all` talks to the **builder** service over SSH. Builder
-shares the same image and mounted volumes as `shell` but exposes an SSH daemon
-so the host Makefile can drive the project-root `makefile` inside a long-lived
-container. Use `shell` for ad-hoc commands and tests; rely on `builder` for
-repeatable builds from the host.
+Behind the scenes `r all` runs the build inside the `shell` service using
+`docker compose run`. Use `shell` for ad-hoc commands, tests, and
+repeatable builds.
 
 ## Pipeline overview
 
-Running `r all` triggers a sequence of Make targets inside the builder
+Running `r all` triggers a sequence of Make targets inside the `shell`
 container:
 
 1. **Index discovery** – Markdown and YAML files are scanned and their metadata
@@ -57,7 +55,7 @@ container:
    Examples include `preprocess` for macro expansion, YAML normalization, and
    rules that turn Mermaid diagrams into SVG. Diagram rendering delegates to the
    standalone `mermaid` service, which isolates the third-party CLI from core
-   images such as `shell` and `builder`.
+   images such as `shell`.
 3. **Pandoc rendering** – Pre-processed Markdown is converted to HTML and PDF
    using a shared template. The command enables table of contents generation,
    MathJax rendering, and cross-reference resolution.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -15,12 +15,11 @@ serving the generated site.
 
 ## Orchestration
 The top-level Makefile (`redo.mk`) drives all host-side automation. It
-launches required services and executes the repository Makefile through
-the builder service:
+launches required services and executes the repository Makefile in the
+`shell` service:
 
-- The default goal starts `dragonfly` and `builder` and uses SSH to run the
-  project-root `makefile` inside the builder container, which shares its
-  image with `shell`.
+- The default goal starts `dragonfly` and runs the project-root
+  `makefile` inside an ephemeral `shell` container.
 - A `test` target reruns the build's own tests from the host environment.
 
 ## Services
@@ -28,14 +27,11 @@ the builder service:
 
 - `nginx` and `nginx-dev` serve generated content.
 - `shell` provides the build environment and exposes tools and tests.
-- `builder` runs the same image as `shell` but exposes an SSH daemon. The
-  host Makefile drives builds through it for a clean, repeatable
-  environment.
 - `dragonfly` supplies a Redis-compatible store used for tracking
   document metadata.
 - `mermaid` renders diagram sources with `mermaid-cli`. It remains a
   standalone service because the tool is self-contained and kept
-  separate from containers like `shell` and `builder`.
+  separate from containers like `shell`.
 - Auxiliary services `sync`, `seed`, and `webp` handle S3 uploads,
   database seeding, and WebP image conversion. The `sync` and `seed`
   containers read the S3 bucket from the `S3_BUCKET_PATH` environment
@@ -43,12 +39,13 @@ the builder service:
   `S3CFG_PATH` (default: `/root/.s3cfg`).
 
 ## Build Pipeline
-The builder service runs the project-root `makefile` to transform sources
-into deliverables. It performs index discovery, pre-processing, rendering,
-asset handling, and validation. See the [build-process guide](../guides/
-build-process.md) for a detailed walkthrough of each stage. Make's
-dependency tracking means subsequent runs only rebuild files whose inputs
-changed; use `remake` or `r clean` to force a full regeneration.
+The `shell` service runs the project-root `makefile` to transform sources
+into deliverables. It performs index discovery, pre-processing,
+rendering, asset handling, and validation. See the [build-process
+guide](../guides/build-process.md) for a detailed walkthrough of each
+stage. Make's dependency tracking means subsequent runs only rebuild
+files whose inputs changed; use `remake` or `r clean` to force a full
+regeneration.
 
 ## Data Flow
 Source files in `src/` become processed artifacts in `build/`. The


### PR DESCRIPTION
## Summary
- run project makefiles via `docker compose run --rm --user "$(id -u):$(id -g)" shell make`
- drop legacy builder service and related references
- document new build approach using the shell service

## Testing
- `bash -n bin/make bin/remake bin/release bin/upgrade`
- `make -f redo.mk help`
- `docker compose config` *(fails: command not found)*
- `shellcheck bin/make bin/remake bin/release bin/upgrade` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8ae69aac8321bdc0acfc5110da4c