### PR TITLE
refactor: remove mk volumes and use project root make

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -192,7 +192,7 @@ clean:
 
 # Optionally include user dependencies; see docs/guides/redo-mk.md and
 # docs/guides/dep-mk.md.
--include /app/mk/dep.mk
+-include $(SRC_DIR)/dep.mk
 
 $(BUILD_DIR)/picasso.mk: $(YAMLS) | $(BUILD_DIR)
 	$(call status,Generate picasso rules)

--- a/app/shell/py/pie/pie/create/templates/docker-compose.yml.jinja
+++ b/app/shell/py/pie/pie/create/templates/docker-compose.yml.jinja
@@ -16,8 +16,8 @@ services:
 
   shell:
     build: app/shell
+    working_dir: /data
     entrypoint: ["bash"]
 
     volumes:
       - ./:/data
-      - ./src/dep.mk:/app/mk/dep.mk

--- a/app/shell/py/pie/pie/create/templates/redo.mk.jinja
+++ b/app/shell/py/pie/pie/create/templates/redo.mk.jinja
@@ -21,7 +21,7 @@ VPATH := $(SRC_DIR)
 COMPOSE_FILE := docker-compose.yml
 DOCKER_COMPOSE := docker compose -f $(COMPOSE_FILE)
 
-MAKE_CMD := $(DOCKER_COMPOSE) run --rm --entrypoint make -u $(shell id -u) -T shell
+MAKE_CMD := $(DOCKER_COMPOSE) run --rm --entrypoint make -u $(shell id -u) -T shell -C /data
 
 # Verbosity control
 VERBOSE ?= 0
@@ -39,10 +39,10 @@ status = @echo "==> $(1)"
 
 # Define the default target to build everything
 .PHONY: all
-all: ## Build the site by invoking /app/mk/build.mk inside the shell container
+all: ## Build the site using the shell service
 	$(call status,Build site)
 	$(Q)$(DOCKER_COMPOSE) up -d dragonfly
-	$(Q)$(MAKE_CMD) -f /app/mk/build.mk VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR)
+	$(Q)$(MAKE_CMD) VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR)
 
 $(BUILD_DIR): ## Helper target used by other rules
 	$(call status,Prepare build directory $@)
@@ -68,7 +68,7 @@ docker: test ## Build and push the Nginx image after running test
 .PHONY: test
 test: ## Restart nginx-dev and run tests
 	$(call status,Run tests)
-	$(Q)$(MAKE_CMD) -f /app/mk/build.mk VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
+	$(Q)$(MAKE_CMD) VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
 
 # Target to bring up the development Nginx container
 .PHONY: up
@@ -163,7 +163,7 @@ cov:
 .PHONY: t
 t: ## Restart nginx-dev and run tests, ansi colors
 	$(call status,Run tests with colors)
-	$(Q)$(DOCKER_COMPOSE) run --entrypoint make --rm shell -f /app/mk/build.mk VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
+	$(Q)$(DOCKER_COMPOSE) run --entrypoint make --rm shell -C /data VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
 	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell /press/py/pie/tests
 
 .PHONY: redis

--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -15,9 +15,9 @@ def test_create_scaffolding(tmp_path: Path) -> None:
     for svc in ["nginx:", "nginx-dev:", "dragonfly:", "shell:"]:
         assert svc in text
     assert "    build: app/shell" in text
+    assert "    working_dir: /data" in text
     assert '    entrypoint: ["bash"]' in text
     assert "      - ./:/data" in text
-    assert "      - ./src/dep.mk:/app/mk/dep.mk" in text
     assert (target / "src").is_dir()
 
     dep_mk = target / "src/dep.mk"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
     image: press-shell
     build: ./app/shell
     container_name: press-shell
+    working_dir: /data
     entrypoint: ["bash"]
     environment:
       OPENAI_API_KEY: "${OPENAI_API_KEY}"
@@ -80,11 +81,9 @@ services:
       BASE_URL: ${BASE_URL:-http://press.io}
     volumes:
       - ./:/data
-      - ./app/shell/mk:/app/mk
       - ./app/shell/bin:/app/bin
       - ./app/shell/py/pie/pie:/press/py/pie/pie
       - ./app/shell/py/pie/tests:/press/py/pie/tests
-      - ./src/dep.mk:/app/mk/dep.mk
 
 
   release:

--- a/docs/guides/dep-mk.md
+++ b/docs/guides/dep-mk.md
@@ -1,23 +1,15 @@
 # dep.mk Custom Dependencies
 
-`dep.mk` is an optional Makefile that extends the build process with project specific rules.
-It is included at the end of `app/shell/mk/build.mk` if present.
+`dep.mk` is an optional Makefile that extends the build process with project
+specific rules. Place it under `src/dep.mk` and the main Makefile will include
+it automatically if present.
 
 ## How It Works
 
-`build.mk` contains the line:
+The top-level `makefile` contains the line:
 
 ```make
--include /app/mk/dep.mk
-```
-
-During `docker compose` runs, the repository's `dep.mk` is mounted into the
-shell container at `/app/mk/dep.mk`:
-
-```yaml
-shell:
-  volumes:
-    - ./dep.mk:/app/mk/dep.mk
+-include src/dep.mk
 ```
 
 If the file doesn't exist, the include is ignored. Any targets defined here run
@@ -39,4 +31,4 @@ include app/quiz/dep.mk
 
 Add your own targets or includes to `dep.mk` to hook extra tools into the build.
 This is a convenient place to generate assets that are not handled by the core
-`build.mk` file.
+`makefile`.

--- a/docs/guides/redo-mk.md
+++ b/docs/guides/redo-mk.md
@@ -6,13 +6,13 @@ is meant to be invoked with `make -f redo.mk` (often aliased to `r`). By default
 it prints only brief status messages; set `VERBOSE=1` to also show the
 underlying commands.
 
-This repository actually uses three Makefiles that work together:
+This repository uses two Makefiles that work together:
 
 - **`redo.mk`** – run from the host to start Docker containers and delegate
   commands.
-- **`build.mk`** – copied into the shell container as `/app/mk/build.mk` and
-  executed by `make` inside that container to build the site.
-- **`dep.mk`** – optional file included by `build.mk` for custom dependencies.
+- **`makefile`** – lives in the project root and runs inside the shell
+  container to build the site. It optionally includes `src/dep.mk` for custom
+  dependencies.
 
 ## Variables
 
@@ -33,7 +33,7 @@ This repository actually uses three Makefiles that work together:
 
 | Target | Description |
 | ------ | ----------- |
-| `all`  | Builds the site by invoking `/app/mk/build.mk` inside the shell container. |
+| `all`  | Builds the site by invoking the top-level makefile inside the shell container. |
 | `clean` | Removes everything under `build/`. |
 | `cov` | Generates an HTML coverage report for the `pie` package inside the shell container (output in `log/cov`). |
 | `distclean` | Runs `clean` and removes `.init` markers and the Dragonfly index cache. |
@@ -47,7 +47,7 @@ This repository actually uses three Makefiles that work together:
 | `setup` | Prepares `app/webp` directories and builds all services. |
 | `shell` | Opens an interactive shell container. |
 | `sync` | Runs the `sync` container to upload site files to S3 (bucket from `S3_BUCKET_PATH`, default `s3://press`; config from `S3CFG_PATH`, default `/root/.s3cfg`). |
-| `test` | Restarts `nginx-dev` and runs tests defined in `/app/mk/build.mk`. |
+| `test` | Restarts `nginx-dev` and runs tests defined in the top-level makefile. |
 | `up` / `upd` | Starts development containers (`SERVICES`). `upd` runs detached. |
 | `webp` | Runs the image conversion service. |
 


### PR DESCRIPTION
## Summary
- remove shell mk mounts from docker-compose and set working dir to project root
- update build scripts and docs to include dep.mk from src
- adjust scaffolding templates and tests to run make from /data

## Testing
- `make -f redo.mk pytest` *(fails: docker: No such file or directory)*
- `pytest app/shell/py/pie/tests/test_create.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac94b6d1988321b307142b7aa3b76b