### PR TITLE
Allow configurable template dir and fix tests

### DIFF
--- a/app/shell/py/pie/pie/render/jinja.py
+++ b/app/shell/py/pie/pie/render/jinja.py
@@ -457,7 +457,10 @@ def load_config(path: str | Path = DEFAULT_CONFIG) -> dict:
 def create_env():
     """Create and configure the Jinja2 environment."""
 
-    env = Environment(loader=FileSystemLoader("/data"), undefined=StrictUndefined)
+    data_dir = os.environ.get("PIE_DATA_DIR", "/data")
+    env = Environment(
+        loader=FileSystemLoader(data_dir), undefined=StrictUndefined
+    )
     env.globals["link"] = render_link
     env.globals["linktitle"] = linktitle
     env.globals["linkcap"] = linkcap

--- a/app/shell/py/pie/tests/__init__.py
+++ b/app/shell/py/pie/tests/__init__.py
@@ -27,7 +27,9 @@ class _Env:
     def get_template(self, name: str):
         return _Template(Path(name).read_text(encoding='utf-8'))
 
-if 'jinja2' not in sys.modules:
+try:  # pragma: no cover - only used when jinja2 is missing
+    import jinja2  # type: ignore[unused-import]
+except ModuleNotFoundError:  # pragma: no cover - fallback for missing dep
     class _FSLoader:
         def __init__(self, _path: str):
             self.path = _path
@@ -35,8 +37,8 @@ if 'jinja2' not in sys.modules:
     class _StrictUndefined:
         pass
 
-    jinja2 = types.ModuleType('jinja2')
+    jinja2 = types.ModuleType("jinja2")
     jinja2.Environment = lambda *a, **k: _Env()
     jinja2.FileSystemLoader = _FSLoader
     jinja2.StrictUndefined = _StrictUndefined
-    sys.modules['jinja2'] = jinja2
+    sys.modules["jinja2"] = jinja2

--- a/app/shell/py/pie/tests/test_render_jinja.py
+++ b/app/shell/py/pie/tests/test_render_jinja.py
@@ -93,22 +93,25 @@ def test_main_renders_template(tmp_path, monkeypatch):
     index = tmp_path / "index.json"
     index.write_text(json.dumps({"name": "World"}), encoding="utf-8")
     out = tmp_path / "out.txt"
-    jinja.main([str(tmpl), str(out), "--index", str(index)])
+    monkeypatch.setenv("PIE_DATA_DIR", str(tmp_path))
+    jinja.env = jinja.create_env()
+    jinja.main(["tmpl.txt", str(out), "--index", str(index)])
     assert out.read_text(encoding="utf-8") == "Hello World"
 
 def test_entry_point_executes_main(tmp_path, monkeypatch):
-    data_dir = Path("/data")
-    data_dir.mkdir(exist_ok=True)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
     tmpl = data_dir / "tmpl.txt"
     tmpl.write_text("Hi {{ name }}", encoding="utf-8")
     index = tmp_path / "index.json"
     index.write_text(json.dumps({"name": "Agent"}), encoding="utf-8")
     out = tmp_path / "out.txt"
     script = Path(__file__).resolve().parent.parent / "pie" / "render" / "jinja.py"
+    monkeypatch.setenv("PIE_DATA_DIR", str(data_dir))
     monkeypatch.setattr(
         sys,
         "argv",
-        ["jinja.py", str(tmpl), str(out), "--index", str(index)],
+        ["jinja.py", "tmpl.txt", str(out), "--index", str(index)],
         raising=False,
     )
     runpy.run_path(str(script), run_name="__main__")


### PR DESCRIPTION
## Summary
- enable overriding template directory using `PIE_DATA_DIR`
- ensure tests use real jinja2 when available
- update render tests to configure template directory dynamically

## Testing
- `pytest app/shell/py/pie/tests/test_render_jinja.py -q`
- `pytest app/shell/py/pie/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac979d575c83218fa638438c859f7f