### PR TITLE
docs: reference makefile instead of build.mk

### DIFF
--- a/docs/guides/include-filter.md
+++ b/docs/guides/include-filter.md
@@ -2,8 +2,8 @@
 
 `include-filter` processes Markdown files and expands inline Python directives.
 
-Typical usage chains the command multiple times in `app/shell/mk/build.mk`
-to resolve nested includes before Pandoc.
+Typical usage chains the command multiple times in the project `makefile` to
+resolve nested includes before Pandoc.
 
 It resolves custom `include()` calls and renders Mermaid diagrams during
 preprocessing. Any links ending with `.md` are automatically rewritten to

--- a/docs/guides/picasso.md
+++ b/docs/guides/picasso.md
@@ -1,9 +1,10 @@
 # picasso Makefile Generator
 
 `picasso` scans the `src/` directory for YAML metadata files and emits Makefile
-rules that convert them to HTML using Pandoc. The generated rules are written to
-`build/picasso.mk` and included by `app/shell/mk/build.mk` during the build.
-Refer to [Metadata Fields](../reference/metadata-fields.md) for the supported metadata keys.
+rules that convert them to HTML using Pandoc. The generated rules are
+written to `build/picasso.mk` and included by the `makefile` during the
+build. Refer to [Metadata Fields](../reference/metadata-fields.md) for the
+supported metadata keys.
 
 ## Usage
 
@@ -13,8 +14,8 @@ Run the command and redirect its output to `build/picasso.mk`:
 picasso > build/picasso.mk
 ```
 
-This happens automatically in `build.mk` whenever any `.yml` file under `src/`
-changes.
+This happens automatically in the `makefile` whenever any `.yml` file under
+`src/` changes.
 
 You can override the source or build directories using `--src` and `--build`:
 

--- a/docs/guides/preprocess.md
+++ b/docs/guides/preprocess.md
@@ -22,7 +22,7 @@ Each input file is processed in place:
 
 ### Makefile Integration
 
-`app/shell/mk/build.mk` invokes `preprocess` when building `.md` targets:
+The project's `makefile` invokes `preprocess` when building `.md` targets:
 
 ```make
 build/%.md: %.md | build


### PR DESCRIPTION
## Summary
- update include-filter guide to reference project makefile
- clarify picasso guide references to build rules and automatic invocation via makefile
- note in preprocess guide that makefile runs preprocess for Markdown targets

## Testing
- `make -f redo.mk check` *(fails: unknown shorthand flag: 'f' in -f)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9ac4dd1c8321883fdb7c30eaaa66