### PR TITLE
Clarify dep.mk inclusion comments

### DIFF
--- a/app/indextree/dep.mk
+++ b/app/indextree/dep.mk
@@ -1,5 +1,6 @@
 # Build rules for the IndexTree React interface.
-# Included by src/dep.mk so build.mk knows how to generate assets.
+# Included by src/dep.mk so the top-level makefile knows how to
+# generate assets.
 # See docs/guides/dep-mk.md for details on dependency makefiles.
 
 # Ensure built JS is available under build/static/

--- a/app/magicbar/dep.mk
+++ b/app/magicbar/dep.mk
@@ -1,5 +1,6 @@
 # Build rules for the MagicBar React interface.
-# Included by src/dep.mk so build.mk knows how to generate assets.
+# Included by src/dep.mk so the top-level makefile knows how to
+# generate assets.
 # See docs/guides/dep-mk.md for details on dependency makefiles.
 
 # Ensure built JS is available under build/static/

--- a/app/quiz/dep.mk
+++ b/app/quiz/dep.mk
@@ -1,6 +1,6 @@
 # Build rules for the React quiz interface.
-# Included by the main `dep.mk` so that `build.mk` knows how to
-# generate and copy quiz assets.
+# Included by the main `dep.mk` so that the top-level makefile
+# knows how to generate and copy quiz assets.
 # See docs/guides/dep-mk.md for details on dependency makefiles.
 #
 # The `all` target ensures that the compiled JavaScript bundle and any

--- a/src/dep.mk
+++ b/src/dep.mk
@@ -1,4 +1,4 @@
-## Aggregate dependency rules for Press. Included by build.mk so
+## Aggregate dependency rules for Press. Included by the top-level makefile so
 ## module-specific makefiles can provide asset targets.
 ## See docs/guides/dep-mk.md for details on dependency makefiles.
  


### PR DESCRIPTION
## Summary
- Clarify that dependency makefiles are included by the top-level makefile

## Testing
- `make -f redo.mk check` *(fails: unknown shorthand flag: 'f' in -f)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9cd594a88321a89db119c25a7af0