### PR TITLE
docs: update build instructions

### DIFF
--- a/app/shell/README.md
+++ b/app/shell/README.md
@@ -1,6 +1,7 @@
 # Shell Service
 
-The `shell` directory defines the Docker image that provides the build and test environment for Press.
+The `shell` directory defines the Docker image that provides the build and test
+environment for Press.
 
 ## Layout
 
@@ -11,7 +12,10 @@ The `shell` directory defines the Docker image that provides the build and test 
 
 ## Usage
 
-The top-level Makefile `redo.mk` builds this image and runs `app/shell/mk/build.mk` inside it. Open an interactive container with:
+The top-level `redo.mk` file builds this image and then invokes the root
+`makefile` inside it. Targets can be run from the host with
+`make -f redo.mk <target>` or directly inside the container with `make`.
+Open an interactive container with:
 
 ```bash
 make -f redo.mk shell
@@ -20,5 +24,7 @@ make -f redo.mk shell
 Run the test suite inside the container with:
 
 ```bash
-make -f redo.mk pytest
+make -f redo.mk test
+# or inside the container
+make test
 ```

--- a/app/shell/py/pie/pie/filter/include.py
+++ b/app/shell/py/pie/pie/filter/include.py
@@ -8,7 +8,7 @@ Markdown files and ``mermaid()`` for converting Mermaid diagrams to images.
 
 Links that end with ``.md`` are rewritten to ``.html`` so the output can be fed
 directly to Pandoc.  The command is primarily driven via ``preprocess`` and the
-``build.mk`` makefile.
+repository root ``makefile``.
 """
 
 from __future__ import annotations

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 # Makefile for building and managing Press
-# Migrated from app/shell/mk/build.mk. Targets now run from the repository root.
+# Targets run from the repository root.
 
 export PATH := /app/bin:$(PATH)
 


### PR DESCRIPTION
## Summary
- document using root makefile with redo.mk for running shell targets
- drop build.mk migration note from the main makefile
- point include filter docs to the root makefile

## Testing
- `make -f redo.mk DOCKER_COMPOSE='docker-compose -f docker-compose.yml' test` *(fails: Error while fetching server API version: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9de9d2708321958a19aecffc2a19