### PR TITLE
chore: remove shell build wrapper

### DIFF
--- a/app/shell/mk/build.mk
+++ b/app/shell/mk/build.mk
@@ -1,3 +1,0 @@
-# Deprecated wrapper for legacy builds
-$(warning app/shell/mk/build.mk is deprecated; use ../../makefile)
-include $(dir $(lastword $(MAKEFILE_LIST)))../../../makefile


### PR DESCRIPTION
## Summary
- remove deprecated shell build wrapper `app/shell/mk/build.mk`

## Testing
- `rg build\.mk`
- `make -f redo.mk all` *(fails: No rule to make target 'build/examples/mermaid/diagram.svg')*

------
https://chatgpt.com/codex/tasks/task_e_68ac9f3c4a9c8321b9d2c10142e9860a