### PR TITLE
docs: explain makefile setup for index tree

### DIFF
--- a/docs/guides/react-index-tree.md
+++ b/docs/guides/react-index-tree.md
@@ -23,6 +23,48 @@ indextree-json docs doc-tree.json
 
 A runnable demo lives in `app/indextree` and can be started with `npm run dev`.
 
+## Build setup
+
+Include the IndexTree makefile so the bundle is produced during regular
+builds. Add the dependency to `src/dep.mk`:
+
+```make
+include app/indextree/dep.mk
+```
+
+Running `make` compiles the React source with Vite and copies
+`build/static/js/indextree.js` into the build tree. The rule installs any
+required packages on first run.
+
+Define a rule to build the tree data alongside the bundle. The example
+below writes `build/static/doc-tree.json` whenever a YAML metadata file
+changes and adds both outputs to the `build` target:
+
+```make
+DOC_TREE := build/static/doc-tree.json
+
+$(DOC_TREE): $(shell find docs -name '*.yaml' -o -name '*.yml')
+	indextree-json docs $@
+
+build: $(DOC_TREE) build/static/js/indextree.js
+```
+
+## Markdown integration
+
+Generate the tree data and embed the component in a Markdown file:
+
+```bash
+indextree-json docs doc-tree.json
+```
+
+```markdown
+<div id="indextree-root" data-src="/doc-tree.json"></div>
+<script type="module" src="/static/js/indextree.js" defer></script>
+```
+
+The `div` marks where the tree renders. The script loads the JSON and
+displays a collapsible index when the page loads.
+
 ## Usage
 
 ```jsx


### PR DESCRIPTION
## Summary
- document how to include IndexTree rules in `src/dep.mk`
- show how to generate JSON and embed the tree in Markdown
- add example make rules to build tree data with the bundle

## Testing
- `pytest` (fails: 43 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68ac9dbe079083219aeb5fe015e6d3f5