### PR TITLE
feat: add update-url script

### DIFF
--- a/app/shell/py/pie/pie/update/url.py
+++ b/app/shell/py/pie/pie/update/url.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
+from .common import get_changed_files, update_files as common_update_files
+from pie.metadata import load_metadata_pair
+
+__all__ = ["main"]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = create_parser(
+        "Replace underscores with dashes in filenames and metadata url fields",
+        log_default="log/update-url.txt",
+    )
+    parser.add_argument(
+        "--sort-keys",
+        action="store_true",
+        help="Sort keys when writing YAML output",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def update_files(paths: Iterable[Path], sort_keys: bool = False) -> tuple[list[str], int]:
+    """Rename files and update url fields for all *paths*.
+
+    Returns a tuple ``(messages, checked)`` where ``messages`` contains log
+    entries for each modification and ``checked`` is the number of files that
+    were examined. When ``sort_keys`` is true YAML mappings are serialized with
+    keys in sorted order.
+    """
+    messages: list[str] = []
+    processed: set[Path] = set()
+    checked = 0
+
+    for path in paths:
+        base = path.with_suffix("")
+        if base in processed:
+            continue
+        processed.add(base)
+
+        metadata = load_metadata_pair(path)
+        file_paths: set[Path] = {path}
+        if metadata and "path" in metadata:
+            file_paths.update(Path(p) for p in metadata["path"])
+
+        renamed_paths: list[Path] = []
+        for fp in sorted(file_paths):
+            if not fp.exists():
+                continue
+            checked += 1
+            new_fp = fp.with_name(fp.name.replace("_", "-"))
+            if new_fp != fp:
+                fp.rename(new_fp)
+                msg = f"{fp} -> {new_fp}"
+                logger.info(msg)
+                messages.append(msg)
+            renamed_paths.append(new_fp)
+
+        if metadata and isinstance(metadata.get("url"), str):
+            old_url = metadata["url"]
+            new_url = old_url.replace("_", "-")
+            if new_url != old_url:
+                url_msgs, _ = common_update_files(
+                    renamed_paths, "url", new_url, sort_keys=sort_keys
+                )
+                messages.extend(url_msgs)
+
+    return messages, checked
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the ``update-url`` console script."""
+    args = parse_args(argv)
+    if args.log:
+        Path(args.log).parent.mkdir(parents=True, exist_ok=True)
+    configure_logging(args.verbose, args.log)
+    changed = get_changed_files()
+    changed = list(filter(lambda p: str(p).startswith("src/"), changed))
+    messages, checked = update_files(changed, args.sort_keys)
+    changed_count = len(messages)
+    logger.info("Summary", checked=checked, changed_count=changed_count)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -45,6 +45,7 @@ setup(
             'update-index=pie.update.index:main',
             'update-link-filters=pie.update.link_filters:main',
             'update-pubdate=pie.update.pubdate:main',
+            'update-url=pie.update.url:main',
             'upgrade-indextree=pie.update.indextree:main',
             'process-yaml=pie.process_yaml:main',
             'sitemap=pie.sitemap:main',

--- a/app/shell/py/pie/tests/update/test_update_url.py
+++ b/app/shell/py/pie/tests/update/test_update_url.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pie.update import url as update_url
+
+
+def test_renames_files_and_updates_url(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Filenames and url fields replace underscores with dashes."""
+    src = tmp_path / "src"
+    src.mkdir()
+    md = src / "hello_world.md"
+    md.write_text("---\n---\n", encoding="utf-8")
+    yml = src / "hello_world.yml"
+    yml.write_text("url: /hello_world/\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        update_url, "get_changed_files", lambda: [Path("src/hello_world.md")]
+    )
+
+    update_url.main([])
+
+    new_md = src / "hello-world.md"
+    new_yml = src / "hello-world.yml"
+    assert new_md.exists()
+    assert new_yml.exists()
+    assert "url: /hello-world/" in new_yml.read_text(encoding="utf-8")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    log_text = (tmp_path / "log/update-url.txt").read_text(encoding="utf-8")
+    assert "src/hello_world.md -> src/hello-world.md" in log_text
+    assert "src/hello_world.yml -> src/hello-world.yml" in log_text
+    assert "src/hello-world.yml: /hello_world/ -> /hello-world/" in log_text
+    assert "Summary {'checked': 2, 'changed_count': 3}" in log_text

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -17,6 +17,7 @@ documents provide context for the task‑oriented
 - [update-author.md](update-author.md) – refresh the `author` field for existing documents.
 - [update-index.md](update-index.md) – insert index values into Redis.
 - [update-pubdate.md](update-pubdate.md) – update the `pubdate` field for modified files.
+- [update-url.md](update-url.md) – rename files and update URL fields.
 - [update-link-filters.md](update-link-filters.md) – convert legacy `link*` filters into globals.
 - [shell.md](shell.md) – run the project's shell service via docker compose.
 - [sitemap.md](sitemap.md) – generate an XML sitemap with absolute URLs.

--- a/docs/reference/update-url.md
+++ b/docs/reference/update-url.md
@@ -1,0 +1,18 @@
+Replace underscores with dashes in filenames and the `url` field of metadata
+files changed in git.
+
+The console script scans `git status --short` for paths under `src/` that have
+been added or modified. Each matched file and its paired metadata are renamed by
+substituting `-` for `_`. When a `url` field is present in the metadata, its
+value is updated accordingly.
+
+```bash
+update-url [--sort-keys] [-l LOGFILE] [-v]
+```
+
+Renamed files and updated `url` fields are logged to `LOGFILE`. When not
+provided, logs are written to `log/update-url.txt`. Use `--sort-keys` to write
+YAML mappings with alphabetically sorted keys and `-v` for debug output.
+
+A summary of the number of files checked and modified is written to the log
+after processing.


### PR DESCRIPTION
## Summary
- add update-url helper to rename files and fix URL metadata
- document update-url script in reference docs
- test renaming and URL updates

## Testing
- `pytest app/shell/py/pie/tests/update/test_update_url.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acaee6126483219ecc5958906ab44e