### PR TITLE
feat: support multiple indextree instances

### DIFF
--- a/app/indextree/index.html
+++ b/app/indextree/index.html
@@ -7,7 +7,8 @@
     <title>IndexTree Demo</title>
   </head>
   <body>
-    <div id="indextree-root" data-src="/example-tree.json"></div>
+    <div id="indextree-demo" class="indextree-root" data-src="/example-tree.json"></div>
+    <div id="indextree-demo-2" class="indextree-root" data-src="/example-tree.json"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/app/indextree/src/index.css
+++ b/app/indextree/src/index.css
@@ -1,6 +1,8 @@
 /* Ensure the IndexTree demo uses the site's base styling */
 #indextree-root,
-#indextree-root * {
+#indextree-root *,
+.indextree-root,
+.indextree-root * {
   font-family: var(--font-base, "minion-pro", serif);
   color: var(--color-text);
 }

--- a/app/indextree/src/main.jsx
+++ b/app/indextree/src/main.jsx
@@ -1,7 +1,8 @@
 /**
  * Entry point for the IndexTree React demo.
- * Finds the #indextree-root element and renders the IndexTree component
- * using the element's data-src attribute as the JSON source.
+ * Finds all elements with the `indextree-root` class and renders the
+ * IndexTree component for each, using the element's data-src attribute as the
+ * JSON source.
  */
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -9,25 +10,27 @@ import { ThemeProvider, createTheme } from '@mui/material/styles';
 import './index.css';
 import IndexTree from './IndexTree';
 
-function initializeIndexTree() {
-  const mount = document.getElementById('indextree-root');
-  if (!mount) {
+function initializeIndexTrees() {
+  const mounts = document.querySelectorAll('.indextree-root, #indextree-root');
+  if (mounts.length === 0) {
     return;
   }
   const fontBase =
     getComputedStyle(document.documentElement).getPropertyValue('--font-base') ||
     '"minion-pro", serif';
   const theme = createTheme({
-      typography: { fontFamily: fontBase.trim(), fontSize: "1em" },
+    typography: { fontFamily: fontBase.trim(), fontSize: '1em' },
   });
-  const root = createRoot(mount);
-  root.render(
-    <StrictMode>
-      <ThemeProvider theme={theme}>
-        <IndexTree src={mount.getAttribute('data-src')} />
-      </ThemeProvider>
-    </StrictMode>
-  );
+  mounts.forEach((mount) => {
+    const root = createRoot(mount);
+    root.render(
+      <StrictMode>
+        <ThemeProvider theme={theme}>
+          <IndexTree src={mount.getAttribute('data-src')} />
+        </ThemeProvider>
+      </StrictMode>
+    );
+  });
 }
 
-window.addEventListener('DOMContentLoaded', initializeIndexTree);
+window.addEventListener('DOMContentLoaded', initializeIndexTrees);

--- a/docs/guides/react-index-tree.md
+++ b/docs/guides/react-index-tree.md
@@ -58,12 +58,14 @@ indextree-json docs doc-tree.json
 ```
 
 ```markdown
-<div id="indextree-root" data-src="/doc-tree.json"></div>
+<div class="indextree-root" data-src="/doc-tree.json"></div>
 <script type="module" src="/static/js/indextree.js" defer></script>
 ```
 
-The `div` marks where the tree renders. The script loads the JSON and
-displays a collapsible index when the page loads.
+Any element with the `indextree-root` class marks where a tree renders. Add
+as many as needed on the same page, each with a `data-src` attribute pointing
+to its JSON file. The script loads the JSON and displays a collapsible index
+when the page loads.
 
 ## Usage
 

--- a/src/examples/indextree/index.md
+++ b/src/examples/indextree/index.md
@@ -5,5 +5,5 @@ the `indextree-json` console script:
 indextree-json files demo.json
 ```
 
-<div id="indextree-root" data-src="/examples/indextree/demo.json"></div>
+<div class="indextree-root" data-src="/examples/indextree/demo.json"></div>
 <script type="module" src="/static/js/indextree.js" defer></script>


### PR DESCRIPTION
## Summary
- render IndexTree for every `.indextree-root` element to allow multiple trees per page
- update styling, demo markup, and docs for class-based mounts

## Testing
- `npm --prefix app/indextree run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acb25416148321bcfb9d2fa3cd7052