### PR TITLE
feat: allow custom paths for update-url

### DIFF
--- a/app/shell/py/pie/pie/update/author.py
+++ b/app/shell/py/pie/pie/update/author.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import argparse
-import glob
 from pathlib import Path
 from typing import Iterable, Sequence
-from itertools import chain
 
 import yaml
 
 from pie.cli import create_parser
 from pie.logging import configure_logging, logger
-from .common import get_changed_files, update_files as common_update_files
+from .common import (
+    collect_paths,
+    get_changed_files,
+    update_files as common_update_files,
+)
 
 __all__ = ["main"]
 
@@ -79,35 +81,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     configure_logging(args.verbose, args.log)
     logger.debug("Parsed arguments", args=vars(args))
     if args.paths:
-        cwd = Path.cwd()
-        changed: list[Path] = []
-        for pattern in args.paths:
-            matches = glob.glob(pattern, recursive=True) or [pattern]
-            for match in matches:
-                p = Path(match)
-                if not p.exists():
-                    continue
-                if p.is_dir():
-                    for child in chain(
-                        p.rglob("*.md"), p.rglob("*.yml"), p.rglob("*.yaml")
-                    ):
-                        if child.is_file():
-                            changed.append(
-                                child.relative_to(cwd) if child.is_absolute() else child
-                            )
-                else:
-                    if p.suffix in {".md", ".yml", ".yaml"}:
-                        changed.append(
-                            p.relative_to(cwd) if p.is_absolute() else p
-                        )
-        # Remove duplicates while preserving order
-        seen: set[Path] = set()
-        unique_changed: list[Path] = []
-        for p in changed:
-            if p not in seen:
-                unique_changed.append(p)
-                seen.add(p)
-        changed = unique_changed
+        changed = collect_paths(args.paths)
     else:
         changed = get_changed_files()
         changed = list(filter(lambda p: str(p).startswith("src/"), changed))

--- a/app/shell/py/pie/tests/update/test_update_url.py
+++ b/app/shell/py/pie/tests/update/test_update_url.py
@@ -33,3 +33,38 @@ def test_renames_files_and_updates_url(tmp_path: Path, monkeypatch, capsys) -> N
     assert "src/hello_world.yml -> src/hello-world.yml" in log_text
     assert "src/hello-world.yml: /hello_world/ -> /hello-world/" in log_text
     assert "Summary {'checked': 2, 'changed_count': 3}" in log_text
+
+
+def test_scans_multiple_paths(tmp_path: Path, monkeypatch) -> None:
+    """Multiple paths can be files or directories."""
+    src = tmp_path / "src"
+    (src / "a").mkdir(parents=True)
+    (src / "b").mkdir(parents=True)
+    (src / "a" / "hello_world.md").write_text("---\n---\n", encoding="utf-8")
+    (src / "a" / "hello_world.yml").write_text(
+        "url: /hello_world/\n", encoding="utf-8"
+    )
+    (src / "b" / "hello_world.md").write_text("---\n---\n", encoding="utf-8")
+    (src / "b" / "hello_world.yml").write_text(
+        "url: /hello_world/\n", encoding="utf-8"
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    update_url.main(["src/a", "src/b/hello_world.md"])
+
+    for part in ["a", "b"]:
+        new_md = src / part / "hello-world.md"
+        new_yml = src / part / "hello-world.yml"
+        assert new_md.exists()
+        assert new_yml.exists()
+        assert "url: /hello-world/" in new_yml.read_text(encoding="utf-8")
+
+    log_text = (tmp_path / "log/update-url.txt").read_text(encoding="utf-8")
+    assert "src/a/hello_world.md -> src/a/hello-world.md" in log_text
+    assert "src/b/hello_world.md -> src/b/hello-world.md" in log_text
+    assert "src/a/hello_world.yml -> src/a/hello-world.yml" in log_text
+    assert "src/b/hello_world.yml -> src/b/hello-world.yml" in log_text
+    assert "src/a/hello-world.yml: /hello_world/ -> /hello-world/" in log_text
+    assert "src/b/hello-world.yml: /hello_world/ -> /hello-world/" in log_text
+    assert "Summary {'checked': 4, 'changed_count': 6}" in log_text

--- a/docs/reference/update-url.md
+++ b/docs/reference/update-url.md
@@ -7,8 +7,12 @@ substituting `-` for `_`. When a `url` field is present in the metadata, its
 value is updated accordingly.
 
 ```bash
-update-url [--sort-keys] [-l LOGFILE] [-v]
+update-url [--sort-keys] [-l LOGFILE] [-v] [PATH ...]
 ```
+
+When `PATH` arguments are given they may refer to files, directories, or glob
+patterns. Each path is scanned for Markdown or YAML files before processing. If
+no paths are supplied, files changed in git are used instead.
 
 Renamed files and updated `url` fields are logged to `LOGFILE`. When not
 provided, logs are written to `log/update-url.txt`. Use `--sort-keys` to write


### PR DESCRIPTION
## Summary
- allow `update-url` to scan user-provided file paths, directories, and glob patterns
- refactor path scanning into a shared helper used by `update-url` and `update-author`
- test directory, file, and glob path handling for update scripts

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest app/shell/py/pie/tests/update/test_update_url.py app/shell/py/pie/tests/update/test_update_author.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb4cf24408321b0aea90af19945c9