### PR TITLE
indextree-json: add debug logs for scanning and tag matching

### DIFF
--- a/app/shell/py/pie/pie/indextree_json.py
+++ b/app/shell/py/pie/pie/indextree_json.py
@@ -18,7 +18,7 @@ def process_dir(directory: Path, tag: str | None = None) -> Iterator[dict]:
     exact string are included. Directories are kept when they match or have
     matching descendants.
     """
-
+    logger.debug("Scanning directory %s", directory)
     entries = list(walk(directory))
     for meta, path in entries:
         if "title" not in meta:
@@ -32,7 +32,19 @@ def process_dir(directory: Path, tag: str | None = None) -> Iterator[dict]:
         entry_show = getopt_show(meta)
         tags = meta.get("tags") or []
         include_current = tag is None or tag in tags
+        if tag:
+            if include_current:
+                logger.debug(
+                    "Tag '%s' matched entry %s with tags %s", tag, path, tags
+                )
+            else:
+                logger.debug(
+                    "Tag '%s' did not match entry %s with tags %s", tag, path, tags
+                )
+        else:
+            logger.debug("Processing entry %s with tags %s", path, tags)
         if path.is_dir():
+            logger.debug("Descending into directory %s", path)
             children = list(process_dir(path, tag))
             if entry_show and (include_current or children):
                 node: dict[str, object] = {"id": entry_id, "label": entry_title}


### PR DESCRIPTION
## Summary
- log directories as they are scanned
- log tag match results and directory descent during index generation

## Testing
- `python -m pip install -r app/shell/py/pie/requirements.txt`
- `pytest app/shell/py/pie/tests/test_indextree_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68acbac267a88321b16a3e9d20411835