### PR TITLE
Add tests for index tree and indextree updater

### DIFF
--- a/app/shell/py/pie/tests/test_index_tree_extra.py
+++ b/app/shell/py/pie/tests/test_index_tree_extra.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pie import index_tree
+
+
+def test_load_from_redis_no_doc(monkeypatch, tmp_path):
+    """Return None when metadata id lookup fails."""
+
+    def fake_get_metadata_by_path(filepath: str, key: str) -> str | None:
+        return None
+
+    called = {}
+
+    def fake_debug(msg: str, **kwargs) -> None:
+        called["msg"] = msg
+        called["kwargs"] = kwargs
+
+    monkeypatch.setattr(index_tree, "get_metadata_by_path", fake_get_metadata_by_path)
+    monkeypatch.setattr(index_tree.logger, "debug", fake_debug)
+
+    result = index_tree.load_from_redis(tmp_path / "doc.yml")
+
+    assert result is None
+    assert called["msg"] == "No doc_id found"
+
+
+def test_walk_warns_and_raises(tmp_path: Path):
+    """walk emits a warning and propagates loader exceptions."""
+
+    target = tmp_path / "file.yml"
+    target.write_text("", encoding="utf-8")
+
+    def loader(_path: Path):
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError), pytest.warns(UserWarning, match="Failed to process"):
+        list(index_tree.walk(tmp_path, loader))
+
+
+def test_sort_entries_order_priority():
+    """Explicit ``indextree.order`` is prioritized in sorting."""
+
+    entries = [
+        ({"title": "B", "indextree": {"order": 1}}, Path("b")),
+        ({"title": "A"}, Path("a")),
+    ]
+
+    index_tree.sort_entries(entries)
+
+    assert entries[0][0]["title"] == "B"

--- a/app/shell/py/pie/tests/update/test_indextree_extra.py
+++ b/app/shell/py/pie/tests/update/test_indextree_extra.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pie.update import indextree
+
+
+def test_upgrade_yaml_without_section(tmp_path: Path) -> None:
+    yml = tmp_path / "doc.yml"
+    yml.write_text("title: test\n", encoding="utf-8")
+    assert indextree._upgrade_yaml(yml) is False
+
+
+def test_upgrade_markdown_without_front_matter(tmp_path: Path) -> None:
+    md = tmp_path / "doc.md"
+    md.write_text("content only\n", encoding="utf-8")
+    assert indextree._upgrade_markdown(md) is False
+
+
+def test_upgrade_markdown_missing_end(tmp_path: Path) -> None:
+    md = tmp_path / "doc.md"
+    md.write_text("---\nkey: value\n", encoding="utf-8")
+    assert indextree._upgrade_markdown(md) is False
+
+
+def test_upgrade_markdown_without_section(tmp_path: Path) -> None:
+    md = tmp_path / "doc.md"
+    md.write_text("---\ntitle: test\n---\n", encoding="utf-8")
+    assert indextree._upgrade_markdown(md) is False
+
+
+def test_upgrade_file_other_suffix(tmp_path: Path) -> None:
+    txt = tmp_path / "doc.txt"
+    txt.write_text("", encoding="utf-8")
+    assert indextree.upgrade_file(txt) is False
+
+
+def test_walk_files_with_file(tmp_path: Path) -> None:
+    file_path = tmp_path / "note.md"
+    file_path.write_text("---\n---\n", encoding="utf-8")
+    paths = list(indextree.walk_files([file_path]))
+    assert paths == [file_path]


### PR DESCRIPTION
## Summary
- add coverage for load_from_redis missing id, warning path in walk, and order sorting in index_tree
- exercise YAML/Markdown upgrade edge cases and file walking in update.indextree

## Testing
- `pytest app/shell/py/pie/tests/test_index_tree_extra.py app/shell/py/pie/tests/update/test_indextree_extra.py`


------
https://chatgpt.com/codex/tasks/task_e_68acc95ffaa88321a7cc4eb7aa8b1453