### PR TITLE
Add check script error report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,5 +180,6 @@ cython_debug/
 dist/app/webp/input
 dist/app/webp/output
 logs
-log/
+log/*
+!log/report.html
 app/*/.init

--- a/app/shell/py/pie/pie/check/report.py
+++ b/app/shell/py/pie/pie/check/report.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Utilities for generating an HTML report of build check errors."""
+
+import html
+
+
+def parse_errors(output: str) -> dict[str, list[str]]:
+    """Return mapping of check names to error lines from *output*.
+
+    Lines beginning with ``==>`` denote the start of a check section.
+    Only lines containing ``" E "`` are recorded as errors.
+    """
+
+    errors: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in output.splitlines():
+        if line.startswith("==>"):
+            current = line[3:].strip()
+        elif " E " in line:
+            key = current or "General"
+            errors.setdefault(key, []).append(line.strip())
+    return errors
+
+
+def render_html(errors: dict[str, list[str]]) -> str:
+    """Return a minimal standalone HTML report for *errors*."""
+
+    parts = [
+        "<!DOCTYPE html>",
+        "<html>",
+        "<head>",
+        '<meta charset="utf-8" />',
+        "<title>Check Error Report</title>",
+        "<style>body{font-family:sans-serif}h2{margin-top:1em}</style>",
+        "</head>",
+        "<body>",
+        "<h1>Check Error Report</h1>",
+    ]
+    for section, lines in errors.items():
+        parts.append(f"<h2>{html.escape(section)}</h2>")
+        parts.append("<ul>")
+        for line in lines:
+            parts.append(f"<li>{html.escape(line)}</li>")
+        parts.append("</ul>")
+    parts.append("</body></html>")
+    return "\n".join(parts) + "\n"

--- a/app/shell/py/pie/tests/test_check_report.py
+++ b/app/shell/py/pie/tests/test_check_report.py
@@ -1,0 +1,21 @@
+from pie.check import report
+
+
+def test_parse_errors_groups_by_check() -> None:
+    sample = (
+        "==> First\n"
+        "10:00 a:b:1 E one\n"
+        "==> Second\n"
+        "10:01 c:d:2 E two\n"
+    )
+    result = report.parse_errors(sample)
+    assert result == {
+        "First": ["10:00 a:b:1 E one"],
+        "Second": ["10:01 c:d:2 E two"],
+    }
+
+
+def test_render_html_includes_sections() -> None:
+    html = report.render_html({"Check": ["oops"]})
+    assert "<h2>Check</h2>" in html
+    assert "oops" in html

--- a/log/report.html
+++ b/log/report.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Check Error Report</title>
+<style>body{font-family:sans-serif}h2{margin-top:1em}</style>
+</head>
+<body>
+<h1>Check Error Report</h1>
+<h2>Check post-build artifacts</h2>
+<ul>
+<li>21:45:07 post_build:main           :54   E Missing artifact {&#x27;path&#x27;: &#x27;build/static/js/indextree.js&#x27;}</li>
+<li>21:45:07 post_build:main           :54   E Missing artifact {&#x27;path&#x27;: &#x27;build/static/js/quiz.js&#x27;}</li>
+<li>21:45:07 post_build:main           :54   E Missing artifact {&#x27;path&#x27;: &#x27;build/sitemap.xml&#x27;}</li>
+</ul>
+<h2>Check sitemap</h2>
+<ul>
+<li>21:45:07 sitemap_ho:main           :37   E Missing sitemap {&#x27;path&#x27;: &#x27;build/sitemap.xml&#x27;}</li>
+</ul>
+</body></html>


### PR DESCRIPTION
## Summary
- generate consolidated HTML error report as part of `check-all`
- remove standalone `check-report` entrypoint
- retain utilities for parsing and rendering reports

## Testing
- `PYTHONPATH=app/shell/py/pie python -m pie.check.all` *(fails: Missing artifact build/static/js/indextree.js, build/static/js/quiz.js, build/sitemap.xml)*
- `PYTHONPATH=app/shell/py/pie pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acc90a7a50832194d7891627373486