### PR TITLE
Use pie.logger for metadata conflicts

### DIFF
--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 import os
-import warnings
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional
 from urllib.parse import urljoin
@@ -336,9 +335,10 @@ def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
     if yaml_data:
         for k, v in yaml_data.items():
             if k in combined and combined[k] != v:
-                warnings.warn(
-                    f"Conflict for '{k}', using value from {yaml_file.resolve().relative_to(Path.cwd())}",
-                    UserWarning,
+                logger.warning(
+                    "Conflict for '{}', using value from {}",
+                    k,
+                    yaml_file.resolve().relative_to(Path.cwd()),
                 )
             combined[k] = v
 


### PR DESCRIPTION
## Summary
- log metadata field conflicts with pie.logger instead of emitting UserWarnings
- capture logger warnings in tests expecting conflict messages

## Testing
- `pytest app/shell/py/pie/tests/test_metadata.py -q`
- `pytest app/shell/py/pie/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68acdef4d04c8321b0042e8b80709f13