### PR TITLE
refactor: log page title check results

### DIFF
--- a/app/shell/py/pie/pie/check/page_title.py
+++ b/app/shell/py/pie/pie/check/page_title.py
@@ -9,36 +9,25 @@ level heading.  It mirrors the behaviour of the legacy
 from __future__ import annotations
 
 import argparse
-import os
-import sys
 from pathlib import Path
 
 from bs4 import BeautifulSoup
 from pie.cli import create_parser
-from pie.logging import configure_logging
+from pie.logging import configure_logging, logger
 from pie.utils import load_exclude_file
 
 
-# Detect whether we should emit ANSI colour codes. We only use colours when
-# stdout is a TTY and the TERM environment variable is not set to "dumb".
-USE_COLOR = sys.stdout.isatty() and os.environ.get("TERM") != "dumb"
-
-GREEN = "\x1b[32m" if USE_COLOR else ""
-REVERSE = "\x1b[7m" if USE_COLOR else ""
-RESET = "\x1b[0m" if USE_COLOR else ""
+DEFAULT_LOG = "log/check-page-title.txt"
+DEFAULT_EXCLUDE = Path("cfg/check-page-title-exclude.yml")
 
 
 def check_file(path: Path) -> bool:
     """Return ``True`` if ``path`` contains a non-empty ``<h1>`` tag."""
-    with open(path, "r", encoding="utf-8") as f:
+    with path.open("r", encoding="utf-8") as f:
         soup = BeautifulSoup(f, "html.parser")
     h1 = soup.find("h1")
     if h1 is None or not h1.get_text(strip=True):
-        message = f"Missing or empty <h1> in {path}"
-        if USE_COLOR:
-            print(f"{REVERSE}{message}{RESET}")
-        else:
-            print(message)
+        logger.error("Missing or empty <h1>", path=str(path))
         return False
     return True
 
@@ -46,7 +35,8 @@ def check_file(path: Path) -> bool:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = create_parser(
-        "Verify that HTML files contain non-empty <h1> tags."
+        "Verify that HTML files contain non-empty <h1> tags.",
+        log_default=DEFAULT_LOG,
     )
     parser.add_argument(
         "directory",
@@ -57,7 +47,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "-x",
         "--exclude",
-        help="YAML file listing HTML files to skip",
+        help=(
+            "YAML file listing HTML files to skip "
+            f"(default: {DEFAULT_EXCLUDE})"
+        ),
     )
     return parser.parse_args(argv)
 
@@ -65,10 +58,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     """Entry point used by the ``check-page-title`` console script."""
     args = parse_args(argv)
+    Path(args.log).parent.mkdir(parents=True, exist_ok=True)
     configure_logging(args.verbose, args.log)
+
     directory = Path(args.directory).resolve()
     html_files = list(directory.rglob("*.html"))
-    exclude = load_exclude_file(args.exclude, directory)
+    if args.exclude:
+        exclude = load_exclude_file(args.exclude, directory)
+    elif DEFAULT_EXCLUDE.is_file():
+        exclude = load_exclude_file(DEFAULT_EXCLUDE, directory)
+    else:
+        exclude = set()
+
     ok = True
     for html_file in html_files:
         if html_file.resolve() in exclude:
@@ -76,15 +77,10 @@ def main(argv: list[str] | None = None) -> int:
         if not check_file(html_file):
             ok = False
     if ok:
-        message = "All pages have <h1> titles."
-        if USE_COLOR:
-            print(f"{GREEN}{message}{RESET}")
-        else:
-            print(message)
-        return 0
-    return 1
+        logger.info("All pages have <h1> titles.")
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    raise SystemExit(main())
 

--- a/app/shell/py/pie/tests/test_check_page_title.py
+++ b/app/shell/py/pie/tests/test_check_page_title.py
@@ -18,7 +18,7 @@ def test_main_fail(tmp_path: Path, capsys) -> None:
     html.write_text("<html></html>", encoding="utf-8")
     assert check_page_title.main([str(tmp_path)]) == 1
     captured = capsys.readouterr()
-    assert "Missing or empty <h1>" in captured.out
+    assert "Missing or empty <h1>" in captured.err
 
 
 def test_main_exclude(tmp_path: Path) -> None:

--- a/docs/pie/check/check-page-title.md
+++ b/docs/pie/check/check-page-title.md
@@ -1,18 +1,20 @@
 # check-page-title
 
 `check-page-title` verifies that each HTML file under `build/` contains a
-non-empty first level heading. It exits with a non-zero status if any
-file is missing a `<h1>` tag or the tag contains no text.
+non-empty first level heading. It exits with a non-zero status if any file
+is missing a `<h1>` tag or the tag contains no text. Messages are logged
+to `stderr` and written to `log/check-page-title.txt`.
 
 ## Usage
 
 ```bash
-check-page-title [directory] [-x exclude.yml]
+check-page-title [directory] [-x EXCLUDE]
 ```
 
-If no directory is given, `build/` is assumed. The command prints
-messages for files that fail the check and returns `1` when a problem is
-found. Use `-x`/`--exclude` to provide a YAML file listing HTML files to
+If no directory is given, `build/` is assumed. The command logs errors for
+files that fail the check and returns `1` when a problem is found. The
+default exclude file `cfg/check-page-title-exclude.yml` is used when
+present. Use `-x`/`--exclude` to provide a YAML file listing HTML files to
 skip. Paths may be absolute or relative to the directory being scanned.
 
 ### Example exclude file


### PR DESCRIPTION
## Summary
- use pie.logging logger in check-page-title
- capture stderr in tests
- document default logging and exclude behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acdeb80e6483219b96988fc81537f4