### PR TITLE
Include warnings in check report

### DIFF
--- a/app/shell/py/pie/pie/check/report.py
+++ b/app/shell/py/pie/pie/check/report.py
@@ -6,10 +6,10 @@ import html
 
 
 def parse_errors(output: str) -> dict[str, list[str]]:
-    """Return mapping of check names to error lines from *output*.
+    """Return mapping of check names to error or warning lines.
 
     Lines beginning with ``==>`` denote the start of a check section.
-    Only lines containing ``" E "`` are recorded as errors.
+    Lines containing ``" E "`` or ``" W "`` are recorded from *output*.
     """
 
     errors: dict[str, list[str]] = {}
@@ -17,7 +17,7 @@ def parse_errors(output: str) -> dict[str, list[str]]:
     for line in output.splitlines():
         if line.startswith("==>"):
             current = line[3:].strip()
-        elif " E " in line:
+        elif " E " in line or " W " in line:
             key = current or "General"
             errors.setdefault(key, []).append(line.strip())
     return errors

--- a/app/shell/py/pie/tests/test_check_report.py
+++ b/app/shell/py/pie/tests/test_check_report.py
@@ -5,12 +5,13 @@ def test_parse_errors_groups_by_check() -> None:
     sample = (
         "==> First\n"
         "10:00 a:b:1 E one\n"
+        "10:02 e:f:3 W warning\n"
         "==> Second\n"
         "10:01 c:d:2 E two\n"
     )
     result = report.parse_errors(sample)
     assert result == {
-        "First": ["10:00 a:b:1 E one"],
+        "First": ["10:00 a:b:1 E one", "10:02 e:f:3 W warning"],
         "Second": ["10:01 c:d:2 E two"],
     }
 


### PR DESCRIPTION
## Summary
- include warning messages when parsing check output
- test that warnings and errors are grouped correctly by check

## Testing
- `pytest app/shell/py/pie/tests/test_check_report.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ace568ead48321b84fad0d03f08b53