### PR TITLE
refactor: use YAML helpers

### DIFF
--- a/app/shell/py/pie/pie/filter/include.py
+++ b/app/shell/py/pie/pie/filter/include.py
@@ -20,7 +20,7 @@ import sys
 from pathlib import Path
 from typing import IO, Iterable, Callable
 
-import yaml
+from pie.utils import yaml
 from pie.cli import create_parser
 from pie.logging import logger, configure_logging
 from pie.metadata import get_metadata_by_path
@@ -53,7 +53,7 @@ def parse_metadata_or_print_first_line(f: IO[str]) -> dict | None:
                 if line.strip() == "---":
                     break
                 y += line
-            return yaml.safe_load(y)
+            return yaml.load(y)
         print(line, end="", file=outfile)
         break
 

--- a/app/shell/py/pie/pie/update/author.py
+++ b/app/shell/py/pie/pie/update/author.py
@@ -4,10 +4,9 @@ import argparse
 from pathlib import Path
 from typing import Iterable, Sequence
 
-import yaml
-
 from pie.cli import create_parser
 from pie.logging import configure_logging, logger
+from pie.utils import read_yaml
 from .common import (
     collect_paths,
     get_changed_files,
@@ -21,7 +20,7 @@ def load_default_author(cfg_path: Path | None = None) -> str:
     """Return the default author from ``cfg/update-author.yml``."""
     path = cfg_path or Path("cfg") / "update-author.yml"
     try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        data = read_yaml(str(path))
     except FileNotFoundError:
         return ""
     if isinstance(data, dict):


### PR DESCRIPTION
## Summary
- replace direct PyYAML usage with pie.utils read_yaml and yaml helpers
- maintain YAML key order and unicode support across update scripts
- validate malformed YAML when extracting front matter or loading metadata

## Testing
- `cd app/shell/py/pie && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af2f1c00608321a77ea6723907567f