### PR TITLE
refactor: switch to ruamel.yaml

### DIFF
--- a/app/shell/py/pie/pie/filter/include.py
+++ b/app/shell/py/pie/pie/filter/include.py
@@ -20,10 +20,12 @@ import sys
 from pathlib import Path
 from typing import IO, Iterable, Callable
 
-import yaml
+from ruamel.yaml import YAML
 from pie.cli import create_parser
 from pie.logging import logger, configure_logging
 from pie.metadata import get_metadata_by_path
+
+yaml = YAML(typ="safe")
 
 MD_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\.md\)")
 
@@ -53,7 +55,7 @@ def parse_metadata_or_print_first_line(f: IO[str]) -> dict | None:
                 if line.strip() == "---":
                     break
                 y += line
-            return yaml.safe_load(y)
+            return yaml.load(y)
         print(line, end="", file=outfile)
         break
 

--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -11,10 +11,12 @@ from urllib.parse import urljoin
 
 import redis
 from flatten_dict import unflatten
-import yaml
+from ruamel.yaml import YAML, YAMLError
 
 from pie.logging import logger
 from pie.utils import read_yaml
+
+yaml = YAML(typ="safe")
 
 
 def get_url(filename: str) -> Optional[str]:
@@ -68,7 +70,7 @@ def get_frontmatter(filename: str) -> Optional[Dict[str, Any]]:
         yaml_lines.append(line)
 
     content = "".join(yaml_lines)
-    return yaml.safe_load(content)
+    return yaml.load(content)
 
 
 def _add_url_if_missing(metadata: dict[str, Any], filepath: str) -> None:
@@ -160,7 +162,7 @@ def read_from_yaml(filepath: str) -> Optional[Dict[str, Any]]:
 
     try:
         return read_yaml(filepath)
-    except yaml.YAMLError as err:
+    except YAMLError as err:
         err.add_note(f"file: {filepath}")
         logger.warning("Failed to parse YAML file {}", filepath)
         raise

--- a/app/shell/py/pie/pie/render/jinja.py
+++ b/app/shell/py/pie/pie/render/jinja.py
@@ -15,12 +15,14 @@ import sys
 import time
 from pathlib import Path
 
-import yaml
+from ruamel.yaml import YAML, YAMLError
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from pie.cli import create_parser
 from pie.logging import logger, configure_logging
 from pie.utils import read_json, read_utf8, write_utf8, read_yaml as load_yaml_file
 from pie import metadata
+
+yaml = YAML(typ="safe")
 
 DEFAULT_CONFIG = Path("cfg/render-jinja-template.yml")
 
@@ -383,8 +385,8 @@ def extract_front_matter(file_path: str) -> dict | None:
 
     if in_block and front_matter_lines:
         try:
-            return yaml.safe_load("".join(front_matter_lines))
-        except yaml.YAMLError:
+            return yaml.load("".join(front_matter_lines))
+        except YAMLError:
             return None
     return None
 
@@ -434,7 +436,7 @@ def to_alpha_index(i):
 def read_yaml(filename):
     """Read ``filename`` as YAML and yield the ``toc`` sequence."""
 
-    y = yaml.safe_load(read_utf8(filename))
+    y = yaml.load(read_utf8(filename))
     yield from y["toc"]
 
 def load_config(path: str | Path = DEFAULT_CONFIG) -> dict:

--- a/app/shell/py/pie/pie/update/author.py
+++ b/app/shell/py/pie/pie/update/author.py
@@ -4,7 +4,7 @@ import argparse
 from pathlib import Path
 from typing import Iterable, Sequence
 
-import yaml
+from ruamel.yaml import YAML
 
 from pie.cli import create_parser
 from pie.logging import configure_logging, logger
@@ -16,12 +16,14 @@ from .common import (
 
 __all__ = ["main"]
 
+yaml = YAML(typ="safe")
+
 
 def load_default_author(cfg_path: Path | None = None) -> str:
     """Return the default author from ``cfg/update-author.yml``."""
     path = cfg_path or Path("cfg") / "update-author.yml"
     try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        data = yaml.load(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return ""
     if isinstance(data, dict):

--- a/app/shell/py/pie/pie/update/indextree.py
+++ b/app/shell/py/pie/pie/update/indextree.py
@@ -6,10 +6,15 @@ import argparse
 from pathlib import Path
 from typing import Iterable, Sequence
 
-import yaml
+from io import StringIO
+from ruamel.yaml import YAML
 
 from pie.cli import create_parser
 from pie.logging import configure_logging, logger
+
+yaml = YAML(typ="safe")
+yaml.allow_unicode = True
+yaml.default_flow_style = False
 
 __all__ = ["main"]
 
@@ -17,12 +22,15 @@ __all__ = ["main"]
 def _upgrade_yaml(path: Path) -> bool:
     """Return ``True`` if *path* was updated."""
 
-    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    data = yaml.load(path.read_text(encoding="utf-8")) or {}
     section = data.pop("gen-markdown-index", None)
     if section is None:
         return False
     data["indextree"] = section
-    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    buf = StringIO()
+    yaml.sort_keys = False
+    yaml.dump(data, buf)
+    path.write_text(buf.getvalue(), encoding="utf-8")
     return True
 
 
@@ -36,12 +44,15 @@ def _upgrade_markdown(path: Path) -> bool:
         end = next(i for i, line in enumerate(lines[1:], start=1) if line.startswith("---"))
     except StopIteration:
         return False
-    front = yaml.safe_load("".join(lines[1:end])) or {}
+    front = yaml.load("".join(lines[1:end])) or {}
     section = front.pop("gen-markdown-index", None)
     if section is None:
         return False
     front["indextree"] = section
-    new_front = yaml.safe_dump(front, sort_keys=False).splitlines(keepends=True)
+    buf = StringIO()
+    yaml.sort_keys = False
+    yaml.dump(front, buf)
+    new_front = buf.getvalue().splitlines(keepends=True)
     path.write_text("".join(["---\n", *new_front, *lines[end:]]), encoding="utf-8")
     return True
 

--- a/app/shell/py/pie/pie/utils/__init__.py
+++ b/app/shell/py/pie/pie/utils/__init__.py
@@ -13,7 +13,12 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-import yaml
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
+yaml.allow_unicode = True
+yaml.sort_keys = False
+yaml.default_flow_style = False
 
 from pie.logging import logger
 
@@ -53,7 +58,7 @@ def read_yaml(filename: str):
 
     logger.debug("Reading YAML", filename=filename)
     with open(filename, "r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
+        return yaml.load(f)
 
 
 def write_yaml(data, filename: str) -> None:
@@ -61,7 +66,7 @@ def write_yaml(data, filename: str) -> None:
 
     logger.debug("Writing YAML", filename=filename)
     with open(filename, "w", encoding="utf-8") as f:
-        yaml.safe_dump(data, f, allow_unicode=True, sort_keys=False)
+        yaml.dump(data, f)
 
 
 def load_exclude_file(filename: str | Path | None, root: Path) -> set[Path]:

--- a/app/shell/py/pie/requirements.txt
+++ b/app/shell/py/pie/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML
+ruamel.yaml
 loguru
 redis
 fakeredis

--- a/app/shell/py/pie/tests/test_create_post.py
+++ b/app/shell/py/pie/tests/test_create_post.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
 
 from pie.create import post
 from pie.utils import get_pubdate
@@ -18,7 +20,7 @@ def test_create_post_creates_files(tmp_path: Path) -> None:
     assert md_file.exists(), "Markdown file should be created"
     assert yml_file.exists(), "YAML file should be created"
 
-    data = yaml.safe_load(yml_file.read_text(encoding="utf-8"))
+    data = yaml.load(yml_file.read_text(encoding="utf-8"))
     assert set(data) == {"author", "pubdate", "title"}
     assert "name" not in data
     assert data["pubdate"] == get_pubdate()

--- a/app/shell/py/pie/tests/test_gen_markdown_index.py
+++ b/app/shell/py/pie/tests/test_gen_markdown_index.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-import yaml
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
 
 import pie.gen_markdown_index as gen_markdown_index
 from pie.gen_markdown_index import generate, main
@@ -21,7 +23,7 @@ def test_show_property(tmp_path, monkeypatch):
     (hidden / "child.yml").write_text("id: child\ntitle: Child\n")
 
     def fake_meta(filepath: str, keypath: str):
-        data = yaml.safe_load(Path(filepath).read_text()) or {}
+        data = yaml.load(Path(filepath).read_text()) or {}
         if "id" not in data:
             data["id"] = Path(filepath).with_suffix("").name
         for key in keypath.split("."):
@@ -37,7 +39,7 @@ def test_show_property(tmp_path, monkeypatch):
     def fake_build(prefix: str):
         doc_id = prefix.rstrip(".")
         for p in tmp_path.rglob("*.yml"):
-            data = yaml.safe_load(p.read_text()) or {}
+            data = yaml.load(p.read_text()) or {}
             if data.get("id", p.with_suffix("").name) == doc_id:
                 return data
         return None
@@ -56,7 +58,7 @@ def test_missing_id_uses_filename(tmp_path, monkeypatch):
     (tmp_path / "foo.yml").write_text("title: Foo\n")
 
     def fake_meta(filepath: str, keypath: str):
-        data = yaml.safe_load(Path(filepath).read_text()) or {}
+        data = yaml.load(Path(filepath).read_text()) or {}
         if "id" not in data:
             data["id"] = Path(filepath).with_suffix("").name
         for key in keypath.split("."):
@@ -72,7 +74,7 @@ def test_missing_id_uses_filename(tmp_path, monkeypatch):
     def fake_build(prefix: str):
         doc_id = prefix.rstrip(".")
         for p in tmp_path.rglob("*.yml"):
-            data = yaml.safe_load(p.read_text()) or {}
+            data = yaml.load(p.read_text()) or {}
             if data.get("id", p.with_suffix("").name) == doc_id:
                 return data
         return None
@@ -123,7 +125,7 @@ def test_numeric_filenames_sort(tmp_path, monkeypatch):
     (tmp_path / "2.yml").write_text("id: two\ntitle: Alpha\n")
 
     def fake_meta(filepath: str, keypath: str):
-        data = yaml.safe_load(Path(filepath).read_text()) or {}
+        data = yaml.load(Path(filepath).read_text()) or {}
         if "id" not in data:
             data["id"] = Path(filepath).with_suffix("").name
         for key in keypath.split("."):
@@ -139,7 +141,7 @@ def test_numeric_filenames_sort(tmp_path, monkeypatch):
     def fake_build(prefix: str):
         doc_id = prefix.rstrip(".")
         for p in tmp_path.rglob("*.yml"):
-            data = yaml.safe_load(p.read_text()) or {}
+            data = yaml.load(p.read_text()) or {}
             if data.get("id", p.with_suffix("").name) == doc_id:
                 return data
         return None

--- a/app/shell/py/pie/tests/test_link_tracking_html.py
+++ b/app/shell/py/pie/tests/test_link_tracking_html.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from bs4 import BeautifulSoup
 
 import pytest
-import yaml
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
 from pie.render import jinja as render_template
 
 
@@ -17,7 +19,7 @@ def _collect_tracking_disabled_urls(src_root: Path) -> list[str]:
     urls: list[str] = []
     for yml in src_root.rglob("*.yml"):
         try:
-            data = yaml.safe_load(yml.read_text(encoding="utf-8"))
+            data = yaml.load(yml.read_text(encoding="utf-8"))
             if isinstance(data, dict):
                 link = data.get("link", {})
                 if isinstance(link, dict) and link.get("tracking") is False:

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -2,7 +2,7 @@ import os
 
 import fakeredis
 import pytest
-import yaml
+import ruamel.yaml as yaml
 
 from pie import metadata
 

--- a/app/shell/py/pie/tests/test_process_yaml.py
+++ b/app/shell/py/pie/tests/test_process_yaml.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
 import pytest
-import yaml
+from io import StringIO
+
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
+yaml.allow_unicode = True
+yaml.sort_keys = False
+yaml.default_flow_style = False
 
 from pie import process_yaml
 
@@ -103,7 +110,9 @@ def test_main_errors_on_read_failure(monkeypatch) -> None:
 
 def test_main_skips_write_when_unchanged(tmp_path, monkeypatch) -> None:
     path = tmp_path / "in.yml"
-    content = yaml.safe_dump({"title": "T"}, allow_unicode=True, sort_keys=False)
+    buf = StringIO()
+    yaml.dump({"title": "T"}, buf)
+    content = buf.getvalue()
     path.write_text(content, encoding="utf-8")
 
     monkeypatch.setattr(

--- a/app/shell/py/pie/tests/test_store_files.py
+++ b/app/shell/py/pie/tests/test_store_files.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
 
 from pie import store_files
 
@@ -43,7 +45,7 @@ def test_process_file_moves_and_creates_metadata(tmp_path: Path, monkeypatch) ->
     assert dest_file.read_text() == "data"
     expected_yaml = store_files.METADATA_TEMPLATE.render(baseurl="", file_id="fixedid")
     assert meta_file.read_text() == expected_yaml
-    meta_data = yaml.safe_load(expected_yaml)
+    meta_data = yaml.load(expected_yaml)
     assert meta_data["id"] == "fixedid"
     assert meta_data["url"] == "/v2/files/0/fixedid"
     assert meta_data["author"] == ""
@@ -61,7 +63,7 @@ def test_process_file_uses_baseurl(tmp_path: Path, monkeypatch) -> None:
 
     store_files.process_file(src, dest, meta, baseurl="https://example.com")
     meta_file = meta / "fixedid.yml"
-    meta_data = yaml.safe_load(meta_file.read_text())
+    meta_data = yaml.load(meta_file.read_text())
     assert meta_data["url"] == "https://example.com/v2/files/0/fixedid"
 
 
@@ -99,7 +101,7 @@ def test_main_uses_config_file(tmp_path: Path, monkeypatch) -> None:
     store_files.main([str(base), "--config", str(cfg)])
 
     meta_file = Path("src") / "static" / "files" / "id1.yml"
-    meta_data = yaml.safe_load(meta_file.read_text())
+    meta_data = yaml.load(meta_file.read_text())
     assert meta_data["url"] == "https://files.example/v2/files/0/id1"
 
 

--- a/app/shell/py/pie/tests/update/test_update_author.py
+++ b/app/shell/py/pie/tests/update/test_update_author.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
-import yaml
+from io import StringIO
+
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
+yaml.allow_unicode = True
+yaml.sort_keys = False
+yaml.default_flow_style = False
 
 from pie.update import author as update_author
 
@@ -133,9 +140,9 @@ def test_author_with_special_characters_is_escaped(
     cfg = tmp_path / "cfg"
     cfg.mkdir()
     special = "Jane: Doe #1"
-    (cfg / "update-author.yml").write_text(
-        yaml.safe_dump({"author": special}, sort_keys=False), encoding="utf-8"
-    )
+    buf = StringIO()
+    yaml.dump({"author": special}, buf)
+    (cfg / "update-author.yml").write_text(buf.getvalue(), encoding="utf-8")
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
@@ -145,7 +152,7 @@ def test_author_with_special_characters_is_escaped(
     update_author.main([])
 
     front = md.read_text(encoding="utf-8").split("---\n")[1]
-    data = yaml.safe_load(front)
+    data = yaml.load(front)
     assert data["author"] == special
 
 

--- a/app/shell/py/pie/tests/update/test_update_metadata.py
+++ b/app/shell/py/pie/tests/update/test_update_metadata.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 import io
-import yaml
+
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
 
 from pie.update import metadata as update_metadata
 
@@ -19,7 +22,7 @@ def test_adds_metadata_from_file(tmp_path: Path, monkeypatch, capsys) -> None:
     monkeypatch.chdir(tmp_path)
     update_metadata.main(["-f", str(data_file), "src/doc.yml"])
 
-    assert yaml.safe_load(yml.read_text(encoding="utf-8")) == {
+    assert yaml.load(yml.read_text(encoding="utf-8")) == {
         "title": "Test",
         "foo": {"bar": "a"},
     }
@@ -43,7 +46,7 @@ def test_reads_yaml_from_stdin(tmp_path: Path, monkeypatch, capsys) -> None:
     )
     update_metadata.main(["src/doc.yml"])
 
-    assert yaml.safe_load(yml.read_text(encoding="utf-8")) == {
+    assert yaml.load(yml.read_text(encoding="utf-8")) == {
         "title": "Test",
         "foo": ["a", "b"],
     }
@@ -64,7 +67,7 @@ def test_conflict_skips_file(tmp_path: Path, monkeypatch, capsys) -> None:
     code = update_metadata.main(["-f", str(data_file), "src/doc.yml"])
 
     assert code == 1
-    assert yaml.safe_load(yml.read_text(encoding="utf-8")) == {"foo": 1}
+    assert yaml.load(yml.read_text(encoding="utf-8")) == {"foo": 1}
     captured = capsys.readouterr()
     assert captured.out == ""
     log_text = (tmp_path / "log/update-metadata.txt").read_text(encoding="utf-8")

--- a/app/shell/py/pie/tests/update/test_update_pubdate.py
+++ b/app/shell/py/pie/tests/update/test_update_pubdate.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-import yaml
+
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
+yaml.default_flow_style = False
 
 from pie.update import pubdate as update_pubdate
 from pie.utils import get_pubdate
@@ -98,7 +102,7 @@ def test_pubdate_with_special_characters_is_escaped(
     update_pubdate.main([])
 
     front = md.read_text(encoding="utf-8").split("---\n")[1]
-    data = yaml.safe_load(front)
+    data = yaml.load(front)
     assert data["pubdate"] == special
 
 


### PR DESCRIPTION
## Summary
- replace PyYAML dependency with ruamel.yaml
- refactor YAML helpers and update scripts to use ruamel's API
- adjust tests for ruamel.yaml

## Testing
- `pytest app/shell/py/pie/tests`


------
https://chatgpt.com/codex/tasks/task_e_68af3448cbe083218205d378f7933cbe