### PR TITLE
Centralize YAML helpers and add tests

### DIFF
--- a/app/shell/py/pie/pie/__init__.py
+++ b/app/shell/py/pie/pie/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "render_study_json",
     "gen_markdown_index",
     "process_yaml",
+    "yaml",
     "build",
     "check",
     "update",

--- a/app/shell/py/pie/pie/filter/include.py
+++ b/app/shell/py/pie/pie/filter/include.py
@@ -20,12 +20,10 @@ import sys
 from pathlib import Path
 from typing import IO, Iterable, Callable
 
-from ruamel.yaml import YAML
 from pie.cli import create_parser
 from pie.logging import logger, configure_logging
 from pie.metadata import get_metadata_by_path
-
-yaml = YAML(typ="safe")
+from pie.yaml import yaml
 
 MD_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\.md\)")
 

--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -11,12 +11,10 @@ from urllib.parse import urljoin
 
 import redis
 from flatten_dict import unflatten
-from ruamel.yaml import YAML, YAMLError
+from ruamel.yaml import YAMLError
 
 from pie.logging import logger
-from pie.utils import read_yaml
-
-yaml = YAML(typ="safe")
+from pie.yaml import YAML_EXTS, read_yaml, yaml
 
 
 def get_url(filename: str) -> Optional[str]:
@@ -39,14 +37,14 @@ def get_url(filename: str) -> Optional[str]:
     if filename.startswith(prefix):
         relative_path = filename[len(prefix) :]
         base, ext = os.path.splitext(relative_path)
-        if ext.lower() in (".md", ".yml", ".yaml"):
+        if ext.lower() in {".md"} | YAML_EXTS:
             html_path = base + ".html"
             return "/" + html_path
     prefix = "build" + os.sep
     if filename.startswith(prefix):
         relative_path = filename[len(prefix) :]
         base, ext = os.path.splitext(relative_path)
-        if ext.lower() in (".md", ".yml", ".yaml"):
+        if ext.lower() in {".md"} | YAML_EXTS:
             html_path = base + ".html"
             return "/" + html_path
     logger.warning("Can't create a url.", filename=filename)

--- a/app/shell/py/pie/pie/render/jinja.py
+++ b/app/shell/py/pie/pie/render/jinja.py
@@ -15,14 +15,13 @@ import sys
 import time
 from pathlib import Path
 
-from ruamel.yaml import YAML, YAMLError
+from ruamel.yaml import YAMLError
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from pie.cli import create_parser
 from pie.logging import logger, configure_logging
-from pie.utils import read_json, read_utf8, write_utf8, read_yaml as load_yaml_file
+from pie.utils import read_json, read_utf8, write_utf8
+from pie.yaml import read_yaml as load_yaml_file, yaml
 from pie import metadata
-
-yaml = YAML(typ="safe")
 
 DEFAULT_CONFIG = Path("cfg/render-jinja-template.yml")
 

--- a/app/shell/py/pie/pie/update/author.py
+++ b/app/shell/py/pie/pie/update/author.py
@@ -4,7 +4,7 @@ import argparse
 from pathlib import Path
 from typing import Iterable, Sequence
 
-from ruamel.yaml import YAML
+from pie.yaml import yaml
 
 from pie.cli import create_parser
 from pie.logging import configure_logging, logger
@@ -16,7 +16,6 @@ from .common import (
 
 __all__ = ["main"]
 
-yaml = YAML(typ="safe")
 
 
 def load_default_author(cfg_path: Path | None = None) -> str:

--- a/app/shell/py/pie/pie/update/indextree.py
+++ b/app/shell/py/pie/pie/update/indextree.py
@@ -7,14 +7,9 @@ from pathlib import Path
 from typing import Iterable, Sequence
 
 from io import StringIO
-from ruamel.yaml import YAML
-
 from pie.cli import create_parser
 from pie.logging import configure_logging, logger
-
-yaml = YAML(typ="safe")
-yaml.allow_unicode = True
-yaml.default_flow_style = False
+from pie.yaml import YAML_EXTS, yaml, write_yaml
 
 __all__ = ["main"]
 
@@ -27,10 +22,8 @@ def _upgrade_yaml(path: Path) -> bool:
     if section is None:
         return False
     data["indextree"] = section
-    buf = StringIO()
     yaml.sort_keys = False
-    yaml.dump(data, buf)
-    path.write_text(buf.getvalue(), encoding="utf-8")
+    write_yaml(data, path)
     return True
 
 
@@ -60,7 +53,7 @@ def _upgrade_markdown(path: Path) -> bool:
 def upgrade_file(path: Path) -> bool:
     """Upgrade metadata in *path*."""
 
-    if path.suffix.lower() in {".yml", ".yaml"}:
+    if path.suffix.lower() in YAML_EXTS:
         return _upgrade_yaml(path)
     if path.suffix.lower() == ".md":
         return _upgrade_markdown(path)
@@ -75,7 +68,7 @@ def walk_files(paths: Iterable[Path]) -> Iterable[Path]:
             yield from (
                 child
                 for child in p.rglob("*")
-                if child.is_file() and child.suffix.lower() in {".md", ".yml", ".yaml"}
+                if child.is_file() and child.suffix.lower() in {".md"} | YAML_EXTS
             )
         else:
             yield p

--- a/app/shell/py/pie/pie/utils/__init__.py
+++ b/app/shell/py/pie/pie/utils/__init__.py
@@ -13,14 +13,8 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-from ruamel.yaml import YAML
-
-yaml = YAML(typ="safe")
-yaml.allow_unicode = True
-yaml.sort_keys = False
-yaml.default_flow_style = False
-
 from pie.logging import logger
+from pie.yaml import read_yaml, write_yaml
 
 
 def read_utf8(filename: str) -> str:
@@ -51,22 +45,6 @@ def write_utf8(text: str, filename: str) -> None:
 
     with open(filename, "w", encoding="utf-8") as f:
         f.write(text)
-
-
-def read_yaml(filename: str):
-    """Return YAML-decoded data from *filename*."""
-
-    logger.debug("Reading YAML", filename=filename)
-    with open(filename, "r", encoding="utf-8") as f:
-        return yaml.load(f)
-
-
-def write_yaml(data, filename: str) -> None:
-    """Write *data* as YAML to *filename*."""
-
-    logger.debug("Writing YAML", filename=filename)
-    with open(filename, "w", encoding="utf-8") as f:
-        yaml.dump(data, f)
 
 
 def load_exclude_file(filename: str | Path | None, root: Path) -> set[Path]:

--- a/app/shell/py/pie/pie/yaml.py
+++ b/app/shell/py/pie/pie/yaml.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from pie.logging import logger
+
+# Shared YAML handler configured for project defaults
+yaml = YAML(typ="safe")
+yaml.allow_unicode = True
+yaml.sort_keys = False
+yaml.default_flow_style = False
+
+# Extensions recognised as YAML files
+YAML_EXTS = {".yml", ".yaml"}
+
+
+def read_yaml(filename: str | Path):
+    """Return YAML-decoded data from *filename*."""
+
+    logger.debug("Reading YAML", filename=str(filename))
+    with open(filename, "r", encoding="utf-8") as f:
+        return yaml.load(f)
+
+
+def write_yaml(data: Any, filename: str | Path) -> None:
+    """Write *data* as YAML to *filename*."""
+
+    logger.debug("Writing YAML", filename=str(filename))
+    with open(filename, "w", encoding="utf-8") as f:
+        yaml.dump(data, f)

--- a/app/shell/py/pie/tests/test_yaml_utils.py
+++ b/app/shell/py/pie/tests/test_yaml_utils.py
@@ -1,0 +1,8 @@
+from pie import yaml as pyaml
+
+
+def test_write_yaml_roundtrip(tmp_path):
+    data = {"name": "pie", "value": 42}
+    path = tmp_path / "data.yml"
+    pyaml.write_yaml(data, path)
+    assert pyaml.read_yaml(path) == data

--- a/docs/guides/process-yaml.md
+++ b/docs/guides/process-yaml.md
@@ -3,6 +3,9 @@
 Fill in missing metadata fields in YAML files and replace `:emoji:` codes with
 their Unicode counterparts.
 
+The command relies on the consolidated helpers in `pie.yaml` for consistent
+YAML parsing and writing across tools.
+
 ```
 usage: process-yaml <file.yml> [file.yml ...]
 ```

--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -10,7 +10,8 @@ for details on the structure of this metadata.
 - `render_jinja(snippet)` – render a snippet of text using the same environment.
 - `to_alpha_index(i)` – convert `0`–`3` to `a`–`d`.
 - `read_json(path)` – read and parse a JSON file.
-- `read_yaml(path)` – read YAML and yield the sequence stored under `toc`.
+- `read_yaml(path)` – read YAML via the shared `pie.yaml` helpers and yield the
+  sequence stored under `toc`.
 - `cite(*ids)` – format one or more metadata entries as Chicago style
   citations. When multiple entries share the same author and year their page
   numbers are combined.


### PR DESCRIPTION
## Summary
- consolidate YAML handling into `pie.yaml`
- use shared YAML helpers across update scripts and metadata utilities
- replace manual `StringIO` writes with `write_yaml`
- document YAML helper usage
- cover YAML round-trip with unit tests

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `cd app/shell/py/pie && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af390724bc832197319aae499ac841