### PR TITLE
feat: reveal page title after hero banner scroll

### DIFF
--- a/src/pandoc-template.html
+++ b/src/pandoc-template.html
@@ -103,8 +103,13 @@
   <body class="fs-5 lh-lg">
     <!-- site nav -->
     <nav class="navbar navbar-expand-lg bg-body-tertiary fixed-top">
-      <div class="container">
+      <div class="container position-relative">
         <a class="navbar-brand" href="/">Home</a>
+        <span
+          class="navbar-text page-title fw-semibold position-absolute top-50 start-50 translate-middle d-none"
+        >
+          $if(page_heading)$ $page_heading$ $else$ $title$ $endif$
+        </span>
         <button
           class="navbar-toggler"
           type="button"
@@ -252,6 +257,24 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const hero = document.querySelector(".hero-header");
+        const titleEl = document.querySelector(".navbar .page-title");
+        if (!titleEl) return;
+        if (!hero) {
+          titleEl.classList.remove("d-none");
+          return;
+        }
+        const observer = new IntersectionObserver(
+          ([entry]) => {
+            titleEl.classList.toggle("d-none", entry.isIntersecting);
+          },
+          { rootMargin: "-56px 0px 0px 0px" }
+        );
+        observer.observe(hero);
+      });
+    </script>
     $if(mathjax)$
     <!-- MATHJAX SUPPORT -->
     <script


### PR DESCRIPTION
## Summary
- show hidden page title within navbar
- reveal title when hero header leaves viewport

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af4b54d2348321bc737d8ec9363397