### PR TITLE
Add bootstrap breadcrumb navigation

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -42,5 +42,6 @@ concepts and data formats, see the
 Refer to the individual files for additional guides not listed here.
 
 ## Content features
+- [breadcrumbs.md](breadcrumbs.md) – show hierarchical navigation at the page top.
 - [responsive-images.md](responsive-images.md) – render responsive images with the figure helper.
 - [reading-notes.md](reading-notes.md) – add reading notes for a book.

--- a/docs/guides/breadcrumbs.md
+++ b/docs/guides/breadcrumbs.md
@@ -1,0 +1,26 @@
+# Breadcrumb Navigation
+
+Add a `breadcrumbs` array to a page's metadata to show hierarchical links at
+the top of the page. Each breadcrumb item has a `title` and optional `url`.
+When `url` is omitted, the item renders as the current page.
+
+```yaml
+breadcrumbs:
+  - title: Examples
+    url: /examples/
+  - title: Breadcrumb Demo
+```
+
+For deeper hierarchies, add more items:
+
+```yaml
+breadcrumbs:
+  - title: Examples
+    url: /examples/
+  - title: Breadcrumb Demo
+    url: /examples/breadcrumbs/
+  - title: Nested Demo
+```
+
+See `src/examples/breadcrumbs` for a simple demo and
+`src/examples/breadcrumbs/multi-level` for a three-level example.

--- a/src/examples/breadcrumbs/index.md
+++ b/src/examples/breadcrumbs/index.md
@@ -1,0 +1,5 @@
+This page shows the breadcrumb trail rendered by the default pandoc
+template. Define a `breadcrumbs` array in the page metadata and each item
+appears in a Bootstrap-styled navigation list above the byline.
+
+See the [nested demo](multi-level/) for a breadcrumb trail with three levels.

--- a/src/examples/breadcrumbs/index.yml
+++ b/src/examples/breadcrumbs/index.yml
@@ -1,0 +1,9 @@
+title: Breadcrumb Demo
+author: Ada Lovelace
+id: breadcrumb_demo
+pubdate: Jan 2, 2025
+description: Demonstrates breadcrumb navigation.
+breadcrumbs:
+  - title: Examples
+    url: /examples/
+  - title: Breadcrumb Demo

--- a/src/examples/breadcrumbs/multi-level/index.md
+++ b/src/examples/breadcrumbs/multi-level/index.md
@@ -1,0 +1,2 @@
+This nested page shows a breadcrumb trail with three levels. It adds a
+link back to the main breadcrumb demo, illustrating a deeper hierarchy.

--- a/src/examples/breadcrumbs/multi-level/index.yml
+++ b/src/examples/breadcrumbs/multi-level/index.yml
@@ -1,0 +1,11 @@
+title: Nested Breadcrumb Demo
+author: Ada Lovelace
+id: nested_breadcrumb_demo
+pubdate: Jan 3, 2025
+description: Demonstrates a three-level breadcrumb trail.
+breadcrumbs:
+  - title: Examples
+    url: /examples/
+  - title: Breadcrumb Demo
+    url: /examples/breadcrumbs/
+  - title: Nested Demo

--- a/src/index.md
+++ b/src/index.md
@@ -2,6 +2,7 @@ Welcome to the demo site for **Press**. Use the links below to explore key
 features.
 
 - [Blog Demo](examples/blog/index.md)
+- [Breadcrumb Demo](examples/breadcrumbs/index.md)
 - [Chicago Citation Examples](examples/chicago-citations.md)
 - [Index Tree Demo](examples/indextree/index.md)
 - [Jinja Examples](examples/jinja.md)

--- a/src/pandoc-template.html
+++ b/src/pandoc-template.html
@@ -189,6 +189,19 @@
     </style>
 
     <main class="container mb-5" style="max-width: 65ch">
+      $if(breadcrumbs)$
+      <nav style="--bs-breadcrumb-divider: '>'" aria-label="breadcrumb">
+        <ol class="breadcrumb pt-3">
+          $for(breadcrumbs)$
+          $if(breadcrumbs.url)$
+          <li class="breadcrumb-item"><a href="$breadcrumbs.url$">$breadcrumbs.title$</a></li>
+          $else$
+          <li class="breadcrumb-item active" aria-current="page">$breadcrumbs.title$</li>
+          $endif$
+          $endfor$
+        </ol>
+      </nav>
+      $endif$
       <div class="metablock">
         $if(author)$ $author$<br />
         $endif$ $if(pubdate)$ $pubdate$<br />


### PR DESCRIPTION
## Summary
- add optional bootstrap breadcrumb navigation at top of page in pandoc template
- document breadcrumb metadata and provide example demo page
- include nested example to demonstrate multi-level breadcrumb trails
- link home page to breadcrumb demo

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af75621a308321826fb14e2fe7bed5