### PR TITLE
Add examples index tree page

### DIFF
--- a/src/examples/index.md
+++ b/src/examples/index.md
@@ -1,0 +1,4 @@
+Explore all examples through the tree below.
+
+<div class="indextree-root" data-src="/examples/index.json"></div>
+<script type="module" src="/static/js/indextree.js" defer></script>

--- a/src/examples/index.yml
+++ b/src/examples/index.yml
@@ -1,6 +1,7 @@
 id: examples
 title: Examples
+description: Demonstrations of Press features
 indextree:
-  link: false
+  link: true
 author: Brian Lee
 pubdate: Aug 12, 2025


### PR DESCRIPTION
## Summary
- show indextree of example pages at `/examples`
- enable linking to example pages in metadata

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af80fc1a4c8321b4400c13593c2faf