### PR TITLE
Add bootstrap breadcrumb navigation

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -42,5 +42,6 @@ concepts and data formats, see the
 Refer to the individual files for additional guides not listed here.
 
 ## Content features
+- [breadcrumbs.md](breadcrumbs.md) – show hierarchical navigation at the page top.
 - [responsive-images.md](responsive-images.md) – render responsive images with the figure helper.
 - [reading-notes.md](reading-notes.md) – add reading notes for a book.

--- a/docs/guides/breadcrumbs.md
+++ b/docs/guides/breadcrumbs.md
@@ -1,0 +1,31 @@
+# Breadcrumb Navigation
+
+Add a `breadcrumbs` array to a page's metadata to show hierarchical links at
+the top of the page. Each breadcrumb item has a `title` and optional `url`.
+When `url` is omitted, the item renders as the current page.
+Start the array with a `Home` entry that links to the site root.
+
+```yaml
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples
+    url: /examples/
+  - title: Breadcrumb Demo
+```
+
+For deeper hierarchies, add more items:
+
+```yaml
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples
+    url: /examples/
+  - title: Breadcrumb Demo
+    url: /examples/breadcrumbs/
+  - title: Nested Demo
+```
+
+See `src/examples/breadcrumbs` for a simple demo and
+`src/examples/breadcrumbs/multi-level` for a three-level example.

--- a/src/examples/blog/index.yml
+++ b/src/examples/blog/index.yml
@@ -8,3 +8,9 @@ pandoc:
   template: src/examples/blog/pandoc-template.html
 css:
   - https://cdn.jsdelivr.net/npm/water.css@2/out/water.css
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples
+    url: /examples/
+  - title: Trendy Blog Template Demo

--- a/src/examples/breadcrumbs/index.md
+++ b/src/examples/breadcrumbs/index.md
@@ -1,0 +1,5 @@
+This page shows the breadcrumb trail rendered by the default pandoc
+template. Define a `breadcrumbs` array in the page metadata and each item
+appears in a Bootstrap-styled navigation list above the byline.
+
+See the [nested demo](multi-level/) for a breadcrumb trail with three levels.

--- a/src/examples/breadcrumbs/index.yml
+++ b/src/examples/breadcrumbs/index.yml
@@ -1,0 +1,11 @@
+title: Breadcrumb Demo
+author: Ada Lovelace
+id: breadcrumb_demo
+pubdate: Jan 2, 2025
+description: Demonstrates breadcrumb navigation.
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples
+    url: /examples/
+  - title: Breadcrumb Demo

--- a/src/examples/breadcrumbs/multi-level/index.md
+++ b/src/examples/breadcrumbs/multi-level/index.md
@@ -1,0 +1,2 @@
+This nested page shows a breadcrumb trail with three levels. It adds a
+link back to the main breadcrumb demo, illustrating a deeper hierarchy.

--- a/src/examples/breadcrumbs/multi-level/index.yml
+++ b/src/examples/breadcrumbs/multi-level/index.yml
@@ -1,0 +1,13 @@
+title: Nested Breadcrumb Demo
+author: Ada Lovelace
+id: nested_breadcrumb_demo
+pubdate: Jan 3, 2025
+description: Demonstrates a three-level breadcrumb trail.
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples
+    url: /examples/
+  - title: Breadcrumb Demo
+    url: /examples/breadcrumbs/
+  - title: Nested Demo

--- a/src/examples/chicago-citations.md
+++ b/src/examples/chicago-citations.md
@@ -3,6 +3,12 @@ title: Chicago Citation Examples
 author: Brian Lee
 id: chicago-citations
 citation: chicago citations
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples
+    url: /examples/
+  - title: Chicago Citation Examples
 ---
 
 Demonstrates Chicago-style citations using the `cite` and `link`

--- a/src/examples/index.yml
+++ b/src/examples/index.yml
@@ -4,3 +4,7 @@ indextree:
   link: false
 author: Brian Lee
 pubdate: Aug 12, 2025
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples

--- a/src/examples/indextree/index.yml
+++ b/src/examples/indextree/index.yml
@@ -2,3 +2,9 @@ title: IndexTree Demo
 id: indextree-demo
 author: Brian Lee
 pubdate: Aug 12, 2025
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples
+    url: /examples/
+  - title: IndexTree Demo

--- a/src/examples/jinja.md
+++ b/src/examples/jinja.md
@@ -3,6 +3,12 @@ title: Jinja Examples
 author: Brian Lee
 id: jinja
 citation: jinja
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples
+    url: /examples/
+  - title: Jinja Examples
 ---
 
 This tutorial introduces the basics of embedding Jinja in Markdown. Each

--- a/src/examples/link-globals.md
+++ b/src/examples/link-globals.md
@@ -3,6 +3,12 @@ title: Link Global Examples
 author: Brian Lee
 id: link-globals
 citation: link globals
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples
+    url: /examples/
+  - title: Link Global Examples
 ---
 
 Press provides custom Jinja globals for formatting links. Each example

--- a/src/examples/mermaid/index.yml
+++ b/src/examples/mermaid/index.yml
@@ -2,3 +2,9 @@ author: Brian Lee
 id: mermaid-example
 pubdate: Aug 22, 2025
 title: Mermaid Diagram Example
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples
+    url: /examples/
+  - title: Mermaid Diagram Example

--- a/src/examples/responsive-images.md
+++ b/src/examples/responsive-images.md
@@ -3,6 +3,12 @@ title: Responsive Images
 author: Brian Lee
 id: responsive-images
 citation: responsive-images
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples
+    url: /examples/
+  - title: Responsive Images
 ---
 
 This example shows how to build a responsive image using the `figure` Jinja macro.

--- a/src/gen-markdown-index/d1/index.yml
+++ b/src/gen-markdown-index/d1/index.yml
@@ -2,3 +2,9 @@ title: d1
 id: d1
 author: Brian Lee
 pubdate: Aug 12, 2025
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: gen-markdown-index
+    url: /gen-markdown-index/
+  - title: d1

--- a/src/gen-markdown-index/f0.yml
+++ b/src/gen-markdown-index/f0.yml
@@ -2,3 +2,9 @@ title: f0
 id: f0
 author: Brian Lee
 pubdate: Aug 12, 2025
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: gen-markdown-index
+    url: /gen-markdown-index/
+  - title: f0

--- a/src/gen-markdown-index/index.yml
+++ b/src/gen-markdown-index/index.yml
@@ -5,3 +5,7 @@ indextree:
   show: true
 author: Brian Lee
 pubdate: Aug 12, 2025
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: gen-markdown-index

--- a/src/include-filter/a.md
+++ b/src/include-filter/a.md
@@ -1,5 +1,11 @@
 ---
 title: a
 author: Brian Lee
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: include-filter
+    url: /include-filter/
+  - title: a
 ---
 a is the first letter of the English alphabet.

--- a/src/include-filter/b.md
+++ b/src/include-filter/b.md
@@ -1,6 +1,12 @@
 ---
 title: b
 author: Brian Lee
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: include-filter
+    url: /include-filter/
+  - title: b
 ---
 b is the second letter of the English alphabet.
 

--- a/src/include-filter/index.yml
+++ b/src/include-filter/index.yml
@@ -2,3 +2,7 @@ title: include-filter
 id: dist_include_filter
 author: Brian Lee
 pubdate: Aug 12, 2025
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: include-filter

--- a/src/index.md
+++ b/src/index.md
@@ -2,6 +2,7 @@ Welcome to the demo site for **Press**. Use the links below to explore key
 features.
 
 - [Blog Demo](examples/blog/index.md)
+- [Breadcrumb Demo](examples/breadcrumbs/index.md)
 - [Chicago Citation Examples](examples/chicago-citations.md)
 - [Index Tree Demo](examples/indextree/index.md)
 - [Jinja Examples](examples/jinja.md)

--- a/src/index.yml
+++ b/src/index.yml
@@ -22,3 +22,5 @@ pubdate: Aug 21, 2025
 title: Home
 toc: false
 url: /
+breadcrumbs:
+  - title: Home

--- a/src/links/index.md
+++ b/src/links/index.md
@@ -1,5 +1,9 @@
 ---
 title: Links
 author: Brian Lee
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Links
 ---
 {{ linkshort("citation_1") }}

--- a/src/magicbar/index.yml
+++ b/src/magicbar/index.yml
@@ -2,3 +2,7 @@ title: MagicBar Demo
 id: magicbar
 author: Brian Lee
 pubdate: Jan 1, 2025
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: MagicBar Demo

--- a/src/pandoc-template.html
+++ b/src/pandoc-template.html
@@ -189,6 +189,19 @@
     </style>
 
     <main class="container mb-5" style="max-width: 65ch">
+      $if(breadcrumbs)$
+      <nav style="--bs-breadcrumb-divider: '>'" aria-label="breadcrumb">
+        <ol class="breadcrumb pt-3">
+          $for(breadcrumbs)$
+          $if(breadcrumbs.url)$
+          <li class="breadcrumb-item"><a href="$breadcrumbs.url$">$breadcrumbs.title$</a></li>
+          $else$
+          <li class="breadcrumb-item active" aria-current="page">$breadcrumbs.title$</li>
+          $endif$
+          $endfor$
+        </ol>
+      </nav>
+      $endif$
       <div class="metablock">
         $if(author)$ $author$<br />
         $endif$ $if(pubdate)$ $pubdate$<br />

--- a/src/quickstart.yml
+++ b/src/quickstart.yml
@@ -4,3 +4,7 @@ id: quickstart
 permalink: /q
 pubdate: Aug 15, 2025
 title: Quickstart
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Quickstart

--- a/src/quiz/index.yml
+++ b/src/quiz/index.yml
@@ -2,3 +2,7 @@ title: Quiz
 id: quiz
 author: Brian Lee
 pubdate: Aug 12, 2025
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Quiz


### PR DESCRIPTION
## Summary
- add optional bootstrap breadcrumb navigation at top of page in pandoc template
- document breadcrumb metadata and provide example demo page
- include nested example to demonstrate multi-level breadcrumb trails
- link home page to breadcrumb demo
- add breadcrumbs metadata to all pages

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af75621a308321826fb14e2fe7bed5