### PR TITLE
Add breadcrumbs metadata checker

### DIFF
--- a/app/shell/py/pie/pie/check/all.py
+++ b/app/shell/py/pie/pie/check/all.py
@@ -11,6 +11,7 @@ from pie.check import (
     bad_mathjax,
     unescaped_dollar,
     page_title,
+    breadcrumbs,
     post_build,
     unexpanded_jinja,
     underscores,
@@ -38,6 +39,7 @@ CHECKS: Iterable[tuple[str, CheckFunc]] = (
             "build",
         ]),
     ),
+    ("Check breadcrumbs", lambda: breadcrumbs.main(["src"])),
     (
         "Check post-build artifacts",
         lambda: post_build.main(["-c", "cfg/check-post-build.yml"]),

--- a/app/shell/py/pie/pie/check/breadcrumbs.py
+++ b/app/shell/py/pie/pie/check/breadcrumbs.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Verify that metadata files define breadcrumbs."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+from itertools import chain
+
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
+from pie.metadata import load_metadata_pair
+from pie.utils import load_exclude_file
+
+DEFAULT_LOG = "log/check-breadcrumbs.txt"
+DEFAULT_EXCLUDE = Path("cfg/check-breadcrumbs-exclude.yml")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = create_parser(
+        "Check that metadata files include a breadcrumbs array.",
+        log_default=DEFAULT_LOG,
+    )
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="src",
+        help="Root directory to scan for metadata files",
+    )
+    parser.add_argument(
+        "-x",
+        "--exclude",
+        help=(
+            "YAML file listing metadata files to skip "
+            f"(default: {DEFAULT_EXCLUDE})"
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _iter_metadata(root: Path) -> Iterable[tuple[list[Path], dict | None]]:
+    """Yield ``(paths, metadata)`` pairs for files under *root*.
+
+    Each metadata pair is loaded with :func:`load_metadata_pair` to ensure that
+    companion Markdown/YAML files are merged.
+    """
+
+    processed: set[Path] = set()
+
+    for path in chain(root.rglob("*.md"), root.rglob("*.yml"), root.rglob("*.yaml")):
+        if not path.is_file():
+            continue
+        base = path.with_suffix("")
+        if base in processed:
+            continue
+        processed.add(base)
+        meta = load_metadata_pair(path)
+        if meta and "path" in meta:
+            paths = [Path(p) for p in meta["path"]]
+        else:
+            paths = [path]
+        yield paths, meta
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``check-breadcrumbs`` console script."""
+    args = parse_args(argv)
+    Path(args.log).parent.mkdir(parents=True, exist_ok=True)
+    configure_logging(args.verbose, args.log)
+
+    root = Path(args.directory)
+    if args.exclude:
+        exclude = load_exclude_file(args.exclude, root)
+    elif DEFAULT_EXCLUDE.is_file():
+        exclude = load_exclude_file(DEFAULT_EXCLUDE, root)
+    else:
+        exclude = set()
+
+    ok = True
+    for paths, meta in _iter_metadata(root):
+        breadcrumbs = meta.get("breadcrumbs") if meta else None
+        for path in paths:
+            if path.resolve() in exclude:
+                continue
+            if breadcrumbs:
+                logger.debug("Found breadcrumbs", path=str(path))
+            else:
+                logger.error("Missing breadcrumbs", path=str(path))
+                ok = False
+    if ok:
+        logger.info("All metadata files define breadcrumbs.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -21,6 +21,7 @@ setup(
             'check-author=pie.check.author:main',
             'check-bad-jinja-output=pie.check.bad_jinja_output:main',
             'check-bad-mathjax=pie.check.bad_mathjax:main',
+            'check-breadcrumbs=pie.check.breadcrumbs:main',
             'check-canonical=pie.check.canonical:main',
             'check-unescaped-dollar=pie.check.unescaped_dollar:main',
             'check-page-title=pie.check.page_title:main',

--- a/app/shell/py/pie/tests/test_check_all.py
+++ b/app/shell/py/pie/tests/test_check_all.py
@@ -43,6 +43,7 @@ def test_run_as_script(monkeypatch) -> None:
         "bad_mathjax",
         "unescaped_dollar",
         "page_title",
+        "breadcrumbs",
         "post_build",
         "unexpanded_jinja",
         "underscores",

--- a/app/shell/py/pie/tests/test_check_breadcrumbs.py
+++ b/app/shell/py/pie/tests/test_check_breadcrumbs.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pie.check import breadcrumbs as check_breadcrumbs
+
+
+def test_main_reports_missing(tmp_path: Path, monkeypatch) -> None:
+    """YAML without breadcrumbs -> exit code 1."""
+    src = tmp_path / "src"
+    src.mkdir()
+    yml = src / "doc.yml"
+    yml.write_text("title: Test\n", encoding="utf-8")
+    md = src / "doc.md"
+    md.write_text("---\ntitle: Test\n---\n", encoding="utf-8")
+    yaml_file = src / "other.yaml"
+    yaml_file.write_text("title: Other\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    rc = check_breadcrumbs.main(["-l", str(tmp_path / "log.txt")])
+    assert rc == 1
+
+
+def test_main_passes_and_logs(tmp_path: Path, monkeypatch) -> None:
+    """YAML with breadcrumbs -> exit 0 and write log."""
+    src = tmp_path / "src"
+    src.mkdir()
+    yml = src / "doc.yml"
+    yml.write_text(
+        "title: Test\nbreadcrumbs:\n  - title: Home\n",
+        encoding="utf-8",
+    )
+    md = src / "doc.md"
+    md.write_text(
+        "---\ntitle: Test\nbreadcrumbs:\n  - title: Home\n---\n",
+        encoding="utf-8",
+    )
+    yaml_file = src / "other.yaml"
+    yaml_file.write_text(
+        "title: Other\nbreadcrumbs:\n  - title: Home\n",
+        encoding="utf-8",
+    )
+    log = tmp_path / "log.txt"
+    monkeypatch.chdir(tmp_path)
+    rc = check_breadcrumbs.main(["-l", str(log)])
+    assert rc == 0
+    assert log.exists()
+
+
+def test_main_exclude(tmp_path: Path, monkeypatch) -> None:
+    """exclude.yml skips failing file."""
+    src = tmp_path / "src"
+    src.mkdir()
+    md = src / "doc.md"
+    md.write_text("---\ntitle: Test\n---\n", encoding="utf-8")
+    exclude = tmp_path / "exclude.yml"
+    exclude.write_text("- doc.md\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    assert check_breadcrumbs.main(["-x", str(exclude)]) == 0
+
+
+def test_parse_args_defaults() -> None:
+    """parse_args returns default paths."""
+    args = check_breadcrumbs.parse_args([])
+    assert args.directory == "src"
+    assert args.log == "log/check-breadcrumbs.txt"
+

--- a/cfg/check-breadcrumbs-exclude.yml
+++ b/cfg/check-breadcrumbs-exclude.yml
@@ -1,0 +1,2 @@
+# List metadata files for check-breadcrumbs to skip.
+# Paths may be absolute or relative to the directory being scanned.

--- a/docs/pie/check/README.md
+++ b/docs/pie/check/README.md
@@ -12,4 +12,6 @@ Documentation for Pie's validation scripts.
   delimiters.
 - [check-unescaped-dollar](check-unescaped-dollar.md) – detect unescaped
   dollar signs.
+- [check-breadcrumbs](check-breadcrumbs.md) – ensure metadata defines
+  breadcrumbs.
 

--- a/docs/pie/check/check-breadcrumbs.md
+++ b/docs/pie/check/check-breadcrumbs.md
@@ -1,0 +1,19 @@
+# check-breadcrumbs
+
+`check-breadcrumbs` verifies that each metadata file under `src/` defines a
+`breadcrumbs` array. It exits with a non-zero status when a file lacks the
+field. Messages are logged to `stderr` and written to
+`log/check-breadcrumbs.txt`.
+
+## Usage
+
+```bash
+check-breadcrumbs [directory] [-x EXCLUDE]
+```
+
+If no directory is given, `src/` is assumed. The command logs errors for files
+that fail the check and returns `1` when a problem is found. The default
+exclude file `cfg/check-breadcrumbs-exclude.yml` is used when present. Use
+`-x`/`--exclude` to provide a YAML file listing metadata files to skip. Paths
+may be absolute or relative to the directory being scanned.
+


### PR DESCRIPTION
## Summary
- add `check-breadcrumbs` console script to ensure pages define breadcrumb arrays
- integrate breadcrumbs check into pie's CLI and check-all suite
- document and test the new breadcrumbs validator

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af825f52c88321babee8fb809b3743