### PR TITLE
feat: support wildcard and regex excludes in pie tools

### DIFF
--- a/app/shell/py/pie/pie/check/bad_mathjax.py
+++ b/app/shell/py/pie/pie/check/bad_mathjax.py
@@ -54,14 +54,15 @@ def main(argv: list[str] | None = None) -> int:
 
     root = Path(args.directory)
     if args.exclude:
-        exclude = load_exclude_file(args.exclude, root)
+        exclude_file = args.exclude
     elif DEFAULT_EXCLUDE.is_file():
-        exclude = load_exclude_file(DEFAULT_EXCLUDE, root)
+        exclude_file = DEFAULT_EXCLUDE
     else:
-        exclude = set()
+        exclude_file = None
+    exclude = load_exclude_file(exclude_file, root)
     ok = True
     for md in root.rglob("*.md"):
-        if md.resolve() in exclude:
+        if md in exclude:
             continue
         text = md.read_text(encoding="utf-8")
         if _has_bad_math(text):

--- a/app/shell/py/pie/pie/check/breadcrumbs.py
+++ b/app/shell/py/pie/pie/check/breadcrumbs.py
@@ -72,17 +72,18 @@ def main(argv: list[str] | None = None) -> int:
 
     root = Path(args.directory)
     if args.exclude:
-        exclude = load_exclude_file(args.exclude, root)
+        exclude_file = args.exclude
     elif DEFAULT_EXCLUDE.is_file():
-        exclude = load_exclude_file(DEFAULT_EXCLUDE, root)
+        exclude_file = DEFAULT_EXCLUDE
     else:
-        exclude = set()
+        exclude_file = None
+    exclude = load_exclude_file(exclude_file, root)
 
     ok = True
     for paths, meta in _iter_metadata(root):
         breadcrumbs = meta.get("breadcrumbs") if meta else None
         for path in paths:
-            if path.resolve() in exclude:
+            if path in exclude:
                 continue
             if breadcrumbs:
                 logger.debug("Found breadcrumbs", path=str(path))

--- a/app/shell/py/pie/pie/check/page_title.py
+++ b/app/shell/py/pie/pie/check/page_title.py
@@ -64,15 +64,16 @@ def main(argv: list[str] | None = None) -> int:
     directory = Path(args.directory).resolve()
     html_files = list(directory.rglob("*.html"))
     if args.exclude:
-        exclude = load_exclude_file(args.exclude, directory)
+        exclude_file = args.exclude
     elif DEFAULT_EXCLUDE.is_file():
-        exclude = load_exclude_file(DEFAULT_EXCLUDE, directory)
+        exclude_file = DEFAULT_EXCLUDE
     else:
-        exclude = set()
+        exclude_file = None
+    exclude = load_exclude_file(exclude_file, directory)
 
     ok = True
     for html_file in html_files:
-        if html_file.resolve() in exclude:
+        if html_file in exclude:
             continue
         if not check_file(html_file):
             ok = False

--- a/app/shell/py/pie/pie/check/unescaped_dollar.py
+++ b/app/shell/py/pie/pie/check/unescaped_dollar.py
@@ -52,14 +52,15 @@ def main(argv: list[str] | None = None) -> int:
 
     root = Path(args.directory)
     if args.exclude:
-        exclude = load_exclude_file(args.exclude, root)
+        exclude_file = args.exclude
     elif DEFAULT_EXCLUDE.is_file():
-        exclude = load_exclude_file(DEFAULT_EXCLUDE, root)
+        exclude_file = DEFAULT_EXCLUDE
     else:
-        exclude = set()
+        exclude_file = None
+    exclude = load_exclude_file(exclude_file, root)
     ok = True
     for md in root.rglob("*.md"):
-        if md.resolve() in exclude:
+        if md in exclude:
             continue
         text = md.read_text(encoding="utf-8")
         if _has_single_dollar(text):

--- a/app/shell/py/pie/tests/test_check_bad_mathjax.py
+++ b/app/shell/py/pie/tests/test_check_bad_mathjax.py
@@ -40,6 +40,24 @@ def test_exclude_file(tmp_path: Path) -> None:
     assert check_bad_mathjax.main([str(tmp_path), "-x", str(exclude)]) == 0
 
 
+def test_exclude_file_wildcard(tmp_path: Path) -> None:
+    """Wildcard patterns in the exclude file are honoured."""
+    bad = tmp_path / "bad-math.md"
+    bad.write_text("text \\(a+b\\)", encoding="utf-8")
+    exclude = tmp_path / "exclude.yml"
+    exclude.write_text("- bad-*\n", encoding="utf-8")
+    assert check_bad_mathjax.main([str(tmp_path), "-x", str(exclude)]) == 0
+
+
+def test_exclude_file_regex(tmp_path: Path) -> None:
+    """Regex patterns in the exclude file are honoured."""
+    bad = tmp_path / "bad-1.md"
+    bad.write_text("text \\(a+b\\)", encoding="utf-8")
+    exclude = tmp_path / "exclude.yml"
+    exclude.write_text("- regex:bad-\\d\\.md\n", encoding="utf-8")
+    assert check_bad_mathjax.main([str(tmp_path), "-x", str(exclude)]) == 0
+
+
 def test_default_exclude_file(tmp_path: Path) -> None:
     """Default exclude YAML is used when present."""
     bad = tmp_path / "bad.md"

--- a/app/shell/py/pie/tests/test_sitemap.py
+++ b/app/shell/py/pie/tests/test_sitemap.py
@@ -52,3 +52,29 @@ def test_excludes_paths(tmp_path):
     assert "keep.html" in text
     assert "skip.html" not in text
 
+
+def test_excludes_wildcard(tmp_path):
+    build = tmp_path / "build"
+    build.mkdir()
+    (build / "keep.html").write_text("", encoding="utf-8")
+    (build / "skip-one.html").write_text("", encoding="utf-8")
+    exclude = tmp_path / "exclude.yml"
+    exclude.write_text("- skip-*.html\n", encoding="utf-8")
+    sitemap.main(["-x", str(exclude), str(build), "http://example.com"])
+    text = (build / "sitemap.xml").read_text(encoding="utf-8")
+    assert "keep.html" in text
+    assert "skip-one.html" not in text
+
+
+def test_excludes_regex(tmp_path):
+    build = tmp_path / "build"
+    build.mkdir()
+    (build / "keep.html").write_text("", encoding="utf-8")
+    (build / "skip-2.html").write_text("", encoding="utf-8")
+    exclude = tmp_path / "exclude.yml"
+    exclude.write_text("- regex:skip-\\d\\.html\n", encoding="utf-8")
+    sitemap.main(["-x", str(exclude), str(build), "http://example.com"])
+    text = (build / "sitemap.xml").read_text(encoding="utf-8")
+    assert "keep.html" in text
+    assert "skip-2.html" not in text
+

--- a/app/shell/py/pie/tests/test_utils.py
+++ b/app/shell/py/pie/tests/test_utils.py
@@ -15,3 +15,15 @@ def test_write_utf8_roundtrip(tmp_path):
     path = tmp_path / "file.txt"
     utils.write_utf8(text, str(path))
     assert utils.read_utf8(str(path)) == text
+
+
+def test_load_exclude_file_patterns(tmp_path):
+    (tmp_path / "a.md").write_text("", encoding="utf-8")
+    (tmp_path / "note.txt").write_text("", encoding="utf-8")
+    (tmp_path / "error.log").write_text("", encoding="utf-8")
+    cfg = tmp_path / "exclude.yml"
+    cfg.write_text("- a.md\n- '*.txt'\n- 'regex:.*\\.log'\n", encoding="utf-8")
+    exclude = utils.load_exclude_file(cfg, tmp_path)
+    assert (tmp_path / "a.md") in exclude
+    assert (tmp_path / "note.txt") in exclude
+    assert (tmp_path / "error.log") in exclude

--- a/docs/pie/check/check-bad-mathjax.md
+++ b/docs/pie/check/check-bad-mathjax.md
@@ -12,5 +12,6 @@ check-bad-mathjax [-x EXCLUDE] [directory]
  
 The optional directory defaults to `src`. When present,
 `cfg/check-bad-mathjax-exclude.yml` is loaded to determine files to skip. Use
-``-x`` to supply a different YAML file. Each file that contains forbidden
+``-x`` to supply a different YAML file. Entries may include wildcards or
+regular expressions prefixed with `regex:`. Each file that contains forbidden
 delimiters is logged for review.

--- a/docs/pie/check/check-breadcrumbs.md
+++ b/docs/pie/check/check-breadcrumbs.md
@@ -15,5 +15,6 @@ If no directory is given, `src/` is assumed. The command logs errors for files
 that fail the check and returns `1` when a problem is found. The default
 exclude file `cfg/check-breadcrumbs-exclude.yml` is used when present. Use
 `-x`/`--exclude` to provide a YAML file listing metadata files to skip. Paths
-may be absolute or relative to the directory being scanned.
+may be absolute or relative to the directory being scanned. Entries may include
+wildcards or regular expressions prefixed with `regex:`.
 

--- a/docs/pie/check/check-page-title.md
+++ b/docs/pie/check/check-page-title.md
@@ -16,6 +16,7 @@ files that fail the check and returns `1` when a problem is found. The
 default exclude file `cfg/check-page-title-exclude.yml` is used when
 present. Use `-x`/`--exclude` to provide a YAML file listing HTML files to
 skip. Paths may be absolute or relative to the directory being scanned.
+Entries may include wildcards or regular expressions prefixed with `regex:`.
 
 ### Example exclude file
 

--- a/docs/pie/check/check-unescaped-dollar.md
+++ b/docs/pie/check/check-unescaped-dollar.md
@@ -12,5 +12,6 @@ check-unescaped-dollar [-x EXCLUDE] [directory]
 
 The optional directory defaults to `src`. When present,
 `cfg/check-unescaped-dollar-exclude.yml` is loaded to determine files to skip.
-Use `-x` to supply a different YAML file. Each file with an unescaped dollar
+Use `-x` to supply a different YAML file. Entries may include wildcards or
+regular expressions prefixed with `regex:`. Each file with an unescaped dollar
 sign is logged for review.

--- a/docs/reference/sitemap.md
+++ b/docs/reference/sitemap.md
@@ -9,7 +9,8 @@ sitemap [-x EXCLUDE] [DIRECTORY] [BASE_URL]
 ```
 
 - `-x EXCLUDE` – YAML file listing HTML files to skip. When omitted,
-  `cfg/sitemap-exclude.yml` is loaded if present.
+  `cfg/sitemap-exclude.yml` is loaded if present. Entries may include
+  wildcards or regular expressions prefixed with `regex:`.
 - `DIRECTORY` – location of the HTML files; defaults to `build`.
 - `BASE_URL` – base URL for absolute links. When omitted, the command reads
   the `BASE_URL` environment variable.


### PR DESCRIPTION
## Summary
- allow exclude YAML entries to contain wildcards or `regex:` expressions
- update check and sitemap console scripts to use flexible pattern matching
- document pattern support and add tests for wildcard and regex exclusions

## Testing
- `pytest app/shell/py/pie/tests/test_check_bad_mathjax.py app/shell/py/pie/tests/test_sitemap.py app/shell/py/pie/tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68af85c4fcfc8321be0219f49056339a