### PR TITLE
process_yaml: report line number on YAML and Jinja errors

### DIFF
--- a/app/shell/py/pie/pie/process_yaml.py
+++ b/app/shell/py/pie/pie/process_yaml.py
@@ -10,6 +10,7 @@ from typing import Iterable
 import copy
 
 from ruamel.yaml import YAMLError
+from jinja2 import TemplateSyntaxError
 
 from pie.cli import create_parser
 from pie.filter.emojify import emojify_text
@@ -89,6 +90,16 @@ def main(argv: Iterable[str] | None = None) -> None:
                 metadata = generate_missing_metadata(metadata, str(path))
                 metadata = _render_templates(metadata)
                 metadata = _emojify(metadata)
+        except TemplateSyntaxError as exc:
+            lineno = getattr(exc, "lineno", None)
+            macro = getattr(exc, "name", None)
+            kwargs = {"filename": str(path)}
+            if lineno is not None:
+                kwargs["line"] = lineno
+            if macro:
+                kwargs["macro"] = macro
+            logger.error("Failed to process YAML", **kwargs)
+            raise SystemExit(1) from exc
         except YAMLError as exc:
             line = getattr(getattr(exc, "problem_mark", None), "line", None)
             if line is None:

--- a/app/shell/py/pie/tests/test_process_yaml.py
+++ b/app/shell/py/pie/tests/test_process_yaml.py
@@ -4,6 +4,7 @@ import pytest
 from io import StringIO
 
 from ruamel.yaml import YAML
+from jinja2 import TemplateSyntaxError
 
 yaml = YAML(typ="safe")
 yaml.allow_unicode = True
@@ -135,6 +136,35 @@ def test_main_reports_yaml_line(tmp_path, monkeypatch) -> None:
     assert excinfo.value.code == 1
     assert errors == [
         ("Failed to process YAML", {"filename": str(path), "line": 2})
+    ]
+
+
+def test_main_reports_jinja_line_and_macro(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "bad-jinja.yml"
+    path.write_text("title: T\n", encoding="utf-8")
+
+    def boom(_text: str) -> str:
+        raise TemplateSyntaxError("bad syntax", 3, name="foo")
+
+    monkeypatch.setattr(process_yaml.render_jinja, "render_jinja", boom)
+    monkeypatch.setattr(process_yaml, "configure_logging", lambda *a, **k: None)
+
+    errors: list[tuple[str, dict]] = []
+
+    def fake_error(msg, **kw):
+        errors.append((msg, kw))
+
+    monkeypatch.setattr(process_yaml.logger, "error", fake_error)
+
+    with pytest.raises(SystemExit) as excinfo:
+        process_yaml.main([str(path)])
+
+    assert excinfo.value.code == 1
+    assert errors == [
+        (
+            "Failed to process YAML",
+            {"filename": str(path), "line": 3, "macro": "foo"},
+        )
     ]
 
 


### PR DESCRIPTION
## Summary
- log offending line number when YAML parsing fails
- log line and macro for Jinja TemplateSyntaxError
- test YAML and Jinja failure line reporting

## Testing
- `pytest app/shell/py/pie/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1679c50c88321851625aeb59ddaa8