### PR TITLE
Add flatfile parser supporting lists and multi-line values

### DIFF
--- a/app/shell/py/pie/pie/flatfile.py
+++ b/app/shell/py/pie/pie/flatfile.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from os import PathLike
+from typing import Dict, Iterable, Iterator, List, Tuple
+
+SENTINEL = '"""'
+LIST_START = '['
+LIST_END = ']'
+
+
+
+def _set_nested(mapping: Dict, dotted_key: str, value) -> None:
+    parts = dotted_key.split('.')
+    for part in parts[:-1]:
+        mapping = mapping.setdefault(part, {})
+    mapping[parts[-1]] = value
+
+
+def _parse_multiline(it: Iterator[str]) -> str:
+    lines: List[str] = []
+    for line in it:
+        if line == SENTINEL:
+            break
+        lines.append(line)
+    else:
+        raise ValueError("Unterminated multi-line value")
+    return "\n".join(lines)
+
+
+def _parse_list(it: Iterator[str]) -> List:
+    items: List = []
+    for line in it:
+        if line == LIST_END:
+            break
+        items.append(_parse_value(it, line))
+    else:
+        raise ValueError("Unterminated list")
+    return items
+
+
+def _parse_value(it: Iterator[str], first: str):
+    if first == SENTINEL:
+        return _parse_multiline(it)
+    if first == LIST_START:
+        return _parse_list(it)
+    return first
+
+
+def loads(lines: Iterable[str]) -> Dict:
+    """Load a flatfile into a nested dictionary."""
+
+    it = iter(line.rstrip("\n") for line in lines)
+    result: Dict = {}
+    for key in it:
+        try:
+            first = next(it)
+        except StopIteration:
+            raise ValueError(f"Missing value for key '{key}'")
+        _set_nested(result, key, _parse_value(it, first))
+    return result
+
+
+def _flatten(prefix: str, obj) -> Iterable[Tuple[str, object]]:
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            dotted = f"{prefix}.{k}" if prefix else k
+            yield from _flatten(dotted, v)
+    else:
+        yield prefix, obj
+
+
+def _dump_multiline(text: str) -> List[str]:
+    return [SENTINEL, *text.splitlines(), SENTINEL]
+
+
+def _dump_list(items: List) -> List[str]:
+    lines = [LIST_START]
+    for item in items:
+        if isinstance(item, list):
+            lines.extend(_dump_list(item))
+            continue
+        item_str = str(item)
+        if item_str in (SENTINEL, LIST_START, LIST_END) or "\n" in item_str:
+            lines.extend(_dump_multiline(item_str))
+        else:
+            lines.append(item_str)
+    lines.append(LIST_END)
+    return lines
+
+
+def _dump_value(value) -> List[str]:
+    if isinstance(value, list):
+        return _dump_list(value)
+    value_str = str(value)
+    if "\n" in value_str or value_str == SENTINEL:
+        return _dump_multiline(value_str)
+    return [value_str]
+
+
+def dumps(mapping: Dict) -> str:
+    """Serialize a mapping into flatfile format."""
+
+    lines: List[str] = []
+    for key, value in _flatten("", mapping):
+        lines.append(key)
+        lines.extend(_dump_value(value))
+    return "\n".join(lines) + "\n"
+
+
+def load(path: str | PathLike[str]) -> Dict:
+    """Read *path* and return a nested dictionary."""
+
+    with open(path, encoding="utf-8") as fh:
+        return loads(fh)
+
+
+def load_key(path: str | PathLike[str], dotted_key: str) -> str:
+    """Return the string value for *dotted_key* from *path*.
+
+    The file is scanned until the key is found. Multi-line values are
+    supported. Lists raise ``TypeError``.
+    """
+
+    with open(path, encoding="utf-8") as fh:
+        it = iter(line.rstrip("\n") for line in fh)
+        for key in it:
+            try:
+                first = next(it)
+            except StopIteration:
+                raise ValueError(f"Missing value for key '{key}'")
+            if key == dotted_key:
+                value = _parse_value(it, first)
+                if isinstance(value, list):
+                    raise TypeError(f"Value for key '{key}' is a list")
+                return value
+            _parse_value(it, first)
+        raise KeyError(dotted_key)
+

--- a/app/shell/py/pie/tests/test_flatfile.py
+++ b/app/shell/py/pie/tests/test_flatfile.py
@@ -1,0 +1,96 @@
+from textwrap import dedent
+
+from pie import flatfile
+
+
+def test_loads_list_and_multiline_item() -> None:
+    text = dedent(
+        '''\
+        pie.ingredients
+        [
+        flour
+        """
+        sugar
+        cane
+        """
+        ]
+        '''
+    )
+    assert flatfile.loads(text.splitlines()) == {
+        'pie': {'ingredients': ['flour', 'sugar\ncane']}
+    }
+
+
+def test_roundtrip_with_lists() -> None:
+    data = {
+        'pie': {
+            'description': 'A flaky crust\nwith butter',
+            'ingredients': ['flour', 'water', 'butter\nunsalted'],
+        }
+    }
+    dumped = flatfile.dumps(data)
+    assert flatfile.loads(dumped.splitlines()) == data
+
+
+def test_loads_nested_lists() -> None:
+    text = dedent(
+        '''\
+        pie.layers
+        [
+        [
+        crust
+        filling
+        ]
+        [
+        icing
+        ]
+        ]
+        '''
+    )
+    assert flatfile.loads(text.splitlines()) == {
+        'pie': {'layers': [['crust', 'filling'], ['icing']]}
+    }
+
+
+def test_loads_nested_dicts() -> None:
+    text = dedent(
+        '''\
+        desserts.pie.filling.fruit
+        apple
+        desserts.pie.filling.sugar
+        cane
+        '''
+    )
+    assert flatfile.loads(text.splitlines()) == {
+        'desserts': {'pie': {'filling': {'fruit': 'apple', 'sugar': 'cane'}}}
+    }
+
+
+def test_roundtrip_nested_dicts_and_lists() -> None:
+    data = {
+        'desserts': {
+            'pie': {
+                'layers': [['crust', 'filling'], ['icing']],
+                'topping': 'cream',
+            }
+        }
+    }
+    dumped = flatfile.dumps(data)
+    assert flatfile.loads(dumped.splitlines()) == data
+
+
+def test_load_reads_file(tmp_path) -> None:
+    path = tmp_path / 'data.ff'
+    path.write_text('foo.bar\n42\n')
+    assert flatfile.load(path) == {'foo': {'bar': '42'}}
+
+
+def test_load_key(tmp_path) -> None:
+    path = tmp_path / 'data.ff'
+    path.write_text('foo.bar\nbaz\n')
+    assert flatfile.load_key(path, 'foo.bar') == 'baz'
+
+def test_load_key_cast(tmp_path) -> None:
+    path = tmp_path / 'data.ff'
+    path.write_text('foo.bar\n7\n')
+    assert int(flatfile.load_key(path, 'foo.bar')) == 7

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -10,6 +10,7 @@ documents provide context for the task‑oriented
 - [link-globals.md](link-globals.md) – global Jinja helpers for link formatting.
 - [jinja-globals.md](jinja-globals.md) – global variables exposed to templates.
 - [definition.md](definition.md) – render snippets from the `definition` field.
+- [flatfile.md](flatfile.md) – flatfile format and helper functions.
 - [keyterms.md](keyterms.md) – glossary of important terminology.
 - [link-metadata.md](link-metadata.md) – link metadata format and usage.
 - [metadata-fields.md](metadata-fields.md) – description of common metadata fields referenced in

--- a/docs/reference/flatfile.md
+++ b/docs/reference/flatfile.md
@@ -1,0 +1,41 @@
+# Flatfile format
+
+The flatfile format stores nested key and value pairs one entry after another.
+Each key lives on its own line and may use dot notation for nesting. The value
+follows on the next line.
+
+```
+pie.flavor
+apple
+```
+
+`loads` turns this into `{"pie": {"flavor": "apple"}}`.
+
+## Multi-line values
+
+Insert a line containing `"""` immediately after the key. All lines until the
+closing sentinel become the value:
+
+```
+pie.description
+"""
+A flaky crust
+with butter
+"""
+```
+
+## Lists
+
+Values that begin with `[` are treated as lists. Each item is parsed using the
+same rules as top-level values and the list ends at a line containing `]`.
+
+## Working with files
+
+Use `flatfile.load(path)` to read an entire file into a dictionary. To retrieve
+a single value without loading the whole file, call
+`flatfile.load_key(path, "pie.flavor")`. Cast the returned string yourself if
+another type is needed:
+
+```
+age = int(flatfile.load_key("people.ff", "alice.age"))
+```


### PR DESCRIPTION
## Summary
- refactor flatfile parser with recursive helpers
- add tests for nested lists and deep nested dictionaries
- add helpers to load whole files and individual keys; `load_key` now returns raw strings for callers to cast
- document flatfile format with examples and integer guidance

## Testing
- `cd app/shell/py/pie && pytest tests/test_flatfile.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1674fca2c8321a528864e5cdffeb8