### PR TITLE
Add flatfile to YAML conversion script

### DIFF
--- a/app/shell/py/pie/pie/flatfile_to_yaml.py
+++ b/app/shell/py/pie/pie/flatfile_to_yaml.py
@@ -1,0 +1,47 @@
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from pie.cli import create_parser
+from pie.logging import logger, configure_logging
+from pie.render import jinja as render_jinja
+from pie import flatfile
+from pie.utils import read_utf8, write_yaml
+
+__all__ = ["parse_args", "main"]
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Return parsed CLI arguments."""
+
+    parser = create_parser("Convert a flatfile to YAML")
+    parser.add_argument("input", help="Path to the input flatfile")
+    parser.add_argument("output", help="Path to write the YAML output")
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+def _convert(src: Path, dst: Path) -> None:
+    """Read *src* flatfile, render templates and write YAML to *dst*."""
+
+    text = read_utf8(str(src))
+    rendered = render_jinja.render_jinja(text)
+    data = flatfile.loads(rendered.splitlines())
+    write_yaml(data, dst)
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """Entry point for ``flatfile-to-yml`` console script."""
+
+    args = parse_args(argv)
+    configure_logging(args.verbose, args.log)
+    render_jinja.index_json = {}
+    try:
+        _convert(Path(args.input), Path(args.output))
+    except Exception as exc:  # pragma: no cover - propagate message
+        logger.error(
+            "Failed to convert flatfile", input=str(args.input), output=str(args.output)
+        )
+        raise SystemExit(1) from exc
+
+if __name__ == "__main__":
+    main()

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -33,6 +33,7 @@ setup(
             'create-post=pie.create.post:main',
             'create-site=pie.create.site:main',
             'emojify=pie.filter.emojify:main',
+            'flatfile-to-yml=pie.flatfile_to_yaml:main',
             'gen-markdown-index=pie.gen_markdown_index:main',
             'include-filter=pie.filter.include:main',
             'indextree-json=pie.indextree_json:main',

--- a/app/shell/py/pie/tests/test_flatfile_to_yaml.py
+++ b/app/shell/py/pie/tests/test_flatfile_to_yaml.py
@@ -1,0 +1,10 @@
+from pie.flatfile_to_yaml import main
+from pie.yaml import read_yaml
+
+
+def test_flatfile_to_yaml(tmp_path):
+    src = tmp_path / "data.ff"
+    out = tmp_path / "out.yml"
+    src.write_text("pie.answer\n{{ 3 + 4 }}\n", encoding="utf-8")
+    main([str(src), str(out)])
+    assert read_yaml(out) == {"pie": {"answer": "7"}}


### PR DESCRIPTION
## Summary
- add `flatfile-to-yml` console script to render Jinja and convert flatfile input to YAML
- register new console script entry point
- test flatfile to YAML conversion with Jinja template

## Testing
- `PYTHONPATH=app/shell/py/pie pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b17824a81883219975bf805ae061fe