### PR TITLE
Add flatfile metadata support to update-index

### DIFF
--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -15,6 +15,7 @@ from ruamel.yaml import YAMLError
 
 from pie.logging import logger
 from pie.yaml import YAML_EXTS, read_yaml, yaml
+from pie import flatfile
 
 
 def get_url(filename: str) -> Optional[str]:
@@ -37,14 +38,14 @@ def get_url(filename: str) -> Optional[str]:
     if filename.startswith(prefix):
         relative_path = filename[len(prefix) :]
         base, ext = os.path.splitext(relative_path)
-        if ext.lower() in {".md"} | YAML_EXTS:
+        if ext.lower() in {".md", ".flatfile"} | YAML_EXTS:
             html_path = base + ".html"
             return "/" + html_path
     prefix = "build" + os.sep
     if filename.startswith(prefix):
         relative_path = filename[len(prefix) :]
         base, ext = os.path.splitext(relative_path)
-        if ext.lower() in {".md"} | YAML_EXTS:
+        if ext.lower() in {".md", ".flatfile"} | YAML_EXTS:
             html_path = base + ".html"
             return "/" + html_path
     logger.warning("Can't create a url.", filename=filename)
@@ -292,12 +293,13 @@ def get_metadata_by_path(filepath: str, keypath: str) -> Any | None:
 
 
 def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
-    """Load metadata from ``path`` and a sibling Markdown/YAML file.
+    """Load metadata from ``path`` and a sibling Markdown or metadata file.
 
-    If both a ``.md`` and ``.yml``/``.yaml`` exist for the same base name,
-    the metadata from each file is combined. Values from YAML override those
-    from Markdown when keys conflict and a :class:`UserWarning` is emitted.
-    Returns ``None`` if neither file contains metadata.
+    If both a ``.md`` and ``.yml``/``.yaml``/``.flatfile`` exist for the same base
+    name, the metadata from each file is combined. Values from YAML or flatfile
+    override those from Markdown when keys conflict and a
+    :class:`UserWarning` is emitted. Returns ``None`` if neither file contains
+    metadata.
 
     Example
     -------
@@ -313,46 +315,50 @@ def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
     md_path = base.with_suffix(".md")
     yml_path = base.with_suffix(".yml")
     yaml_path = base.with_suffix(".yaml")
+    flatfile_path = base.with_suffix(".flatfile")
 
     md_data = None
     if md_path.exists():
         md_data = _read_from_markdown(str(md_path))
 
-    yaml_data = None
-    yaml_file: Path | None = None
+    meta_data = None
+    meta_file: Path | None = None
     if yml_path.exists():
-        yaml_file = yml_path
-        yaml_data = read_from_yaml(str(yml_path))
+        meta_file = yml_path
+        meta_data = read_from_yaml(str(yml_path))
     elif yaml_path.exists():
-        yaml_file = yaml_path
-        yaml_data = read_from_yaml(str(yaml_path))
+        meta_file = yaml_path
+        meta_data = read_from_yaml(str(yaml_path))
+    elif flatfile_path.exists():
+        meta_file = flatfile_path
+        meta_data = flatfile.load(flatfile_path)
 
-    if md_data is None and yaml_data is None:
+    if md_data is None and meta_data is None:
         return None
 
     combined: dict[str, Any] = {}
     if md_data:
         combined.update(md_data)
-    if yaml_data:
-        for k, v in yaml_data.items():
+    if meta_data:
+        for k, v in meta_data.items():
             if k in combined and combined[k] != v:
                 logger.warning(
                     "Conflict for '{}', using value from {}",
                     k,
-                    yaml_file.resolve().relative_to(Path.cwd()),
+                    meta_file.resolve().relative_to(Path.cwd()),
                 )
             combined[k] = v
 
     files: list[Path] = []
-    if yaml_file:
-        files.append(yaml_file)
+    if meta_file:
+        files.append(meta_file)
     if md_path.exists():
         files.append(md_path)
 
     if files:
         combined["path"] = [str(p.resolve().relative_to(Path.cwd())) for p in files]
     # Populate any missing metadata fields based on the source path.
-    source = md_path if md_path.exists() else yaml_file or path
+    source = md_path if md_path.exists() else meta_file or path
     combined = generate_missing_metadata(combined, str(source))
 
     logger.debug('returning', combined=combined)

--- a/app/shell/py/pie/pie/update/index.py
+++ b/app/shell/py/pie/pie/update/index.py
@@ -95,15 +95,15 @@ def update_redis(conn: redis.Redis, index: Mapping[str, Mapping[str, Any]]) -> N
 def load_directory_index(path: Path) -> tuple[dict[str, dict[str, Any]], int]:
     """Return an index built from all metadata files under *path*.
 
-    The directory is scanned for ``.md``/``.yml`` files. Each pair of files
-    is loaded with :func:`load_metadata_pair` using a thread pool. The returned
-    tuple contains the combined index and the number of files that were
-    processed.
+    The directory is scanned for ``.md``, ``.yml``, ``.yaml``, and ``.flatfile``
+    files. Each pair of files is loaded with :func:`load_metadata_pair` using
+    a thread pool. The returned tuple contains the combined index and the
+    number of files that were processed.
     """
 
     processed: set[Path] = set()
     paths: list[Path] = []
-    exts = {".md", ".yml", ".yaml"}
+    exts = {".md", ".yml", ".yaml", ".flatfile"}
 
     for root, _, files in os.walk(path):
         root_path = Path(root)
@@ -136,7 +136,7 @@ def load_index_from_path(path: Path) -> tuple[dict[str, dict[str, Any]], int]:
     if path.suffix.lower() == ".json":
         return load_index(path), 1
 
-    if path.suffix.lower() in {".md", ".yml", ".yaml"}:
+    if path.suffix.lower() in {".md", ".yml", ".yaml", ".flatfile"}:
         metadata = load_metadata_pair(path)
         if metadata is None:
             logger.error("No metadata found", filename=str(path))

--- a/app/shell/py/pie/tests/test_flatfile.py
+++ b/app/shell/py/pie/tests/test_flatfile.py
@@ -80,17 +80,17 @@ def test_roundtrip_nested_dicts_and_lists() -> None:
 
 
 def test_load_reads_file(tmp_path) -> None:
-    path = tmp_path / 'data.ff'
+    path = tmp_path / 'data.flatfile'
     path.write_text('foo.bar\n42\n')
     assert flatfile.load(path) == {'foo': {'bar': '42'}}
 
 
 def test_load_key(tmp_path) -> None:
-    path = tmp_path / 'data.ff'
+    path = tmp_path / 'data.flatfile'
     path.write_text('foo.bar\nbaz\n')
     assert flatfile.load_key(path, 'foo.bar') == 'baz'
 
 def test_load_key_cast(tmp_path) -> None:
-    path = tmp_path / 'data.ff'
+    path = tmp_path / 'data.flatfile'
     path.write_text('foo.bar\n7\n')
     assert int(flatfile.load_key(path, 'foo.bar')) == 7

--- a/app/shell/py/pie/tests/test_flatfile_to_yaml.py
+++ b/app/shell/py/pie/tests/test_flatfile_to_yaml.py
@@ -3,7 +3,7 @@ from pie.yaml import read_yaml
 
 
 def test_flatfile_to_yaml(tmp_path):
-    src = tmp_path / "data.ff"
+    src = tmp_path / "data.flatfile"
     out = tmp_path / "out.yml"
     src.write_text("pie.answer\n{{ 3 + 4 }}\n", encoding="utf-8")
     main([str(src), str(out)])

--- a/app/shell/py/pie/tests/update/test_update_index.py
+++ b/app/shell/py/pie/tests/update/test_update_index.py
@@ -81,6 +81,28 @@ def test_main_directory_processes_yamls(tmp_path, monkeypatch):
     assert fake.get("b.url") == "/b.html"
 
 
+def test_main_directory_processes_flatfiles(tmp_path, monkeypatch):
+    """Directory of flatfile -> Redis entries for each."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.flatfile").write_text("title\nFoo\n")
+    (src / "b.flatfile").write_text("title\nBar\n")
+
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(update_index.redis, "Redis", lambda *a, **kw: fake)
+
+    os.chdir(tmp_path)
+    try:
+        update_index.main(["src"])
+    finally:
+        os.chdir("/tmp")
+
+    assert fake.get("a.title") == "Foo"
+    assert fake.get("a.url") == "/a.html"
+    assert fake.get("b.title") == "Bar"
+    assert fake.get("b.url") == "/b.html"
+
+
 def test_main_single_yaml_file(tmp_path, monkeypatch):
     """Single YAML file populates Redis."""
     src = tmp_path / "src"
@@ -94,6 +116,26 @@ def test_main_single_yaml_file(tmp_path, monkeypatch):
     os.chdir(tmp_path)
     try:
         update_index.main(["src/item.yml"])
+    finally:
+        os.chdir("/tmp")
+
+    assert fake.get("item.title") == "Foo"
+    assert fake.get("item.url") == "/item.html"
+
+
+def test_main_single_flatfile(tmp_path, monkeypatch):
+    """Single flatfile populates Redis."""
+    src = tmp_path / "src"
+    src.mkdir()
+    flatfile_path = src / "item.flatfile"
+    flatfile_path.write_text("title\nFoo\n")
+
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(update_index.redis, "Redis", lambda *a, **kw: fake)
+
+    os.chdir(tmp_path)
+    try:
+        update_index.main(["src/item.flatfile"])
     finally:
         os.chdir("/tmp")
 

--- a/docs/guides/update-index.md
+++ b/docs/guides/update-index.md
@@ -28,4 +28,11 @@ from pie.update import index
 index.main(["index.json"])
 ```
 
-When a directory is given, `update-index` scans recursively for `.md`, `.yml`, and `.yaml` files, processing each Markdown/YAML pair only once. A single metadata file may also be supplied and is processed directly. When an index JSON file is provided, it should be produced by [`build-index`](build-index.md). Entries are written to the configured Redis instance using pipelined batch writes, with each value stored under its own key, including `id.path` entries pointing to the original files.
+When a directory is given, `update-index` scans recursively for `.md`, `.yml`,
+`.yaml`, and `.flatfile` files, processing each Markdown and metadata pair only
+once.
+A single metadata file may also be supplied and is processed directly. When an
+index JSON file is provided, it should be produced by
+[`build-index`](build-index.md). Entries are written to the configured Redis
+instance using pipelined batch writes, with each value stored under its own
+key, including `id.path` entries pointing to the original files.

--- a/docs/reference/flatfile.md
+++ b/docs/reference/flatfile.md
@@ -215,5 +215,5 @@ single value without loading the whole file, call `flatfile.load_key(path,
 "pie.flavor")`. Cast the returned string yourself if another type is needed:
 
 ```
-age = int(flatfile.load_key("people.ff", "alice.age"))
+age = int(flatfile.load_key("people.flatfile", "alice.age"))
 ```

--- a/docs/reference/update-index.md
+++ b/docs/reference/update-index.md
@@ -2,10 +2,11 @@
 
 Insert index values into DragonflyDB or Redis.
 
-The console script loads `index.json`, a metadata file, or scans a directory of
-metadata files and flattens each document into `<id>.<property>` keys. Complex
-values are stored as JSON strings. Source paths are recorded under
-`<id>.path` and each path also maps back to the document `id`.
+The console script loads `index.json`, a metadata file (`.md`, `.yml`, `.yaml`,
+or `.flatfile`), or scans a directory of metadata files and flattens each document
+into `<id>.<property>` keys. Complex values are stored as JSON strings. Source
+paths are recorded under `<id>.path` and each path also maps back to the
+document `id`.
 
 ```bash
 update-index PATH [--host HOST] [--port PORT] [-l LOGFILE]

--- a/makefile
+++ b/makefile
@@ -81,6 +81,7 @@ VPATH := $(SRC_DIR)
 # Find all Markdown files excluding specified directories
 MARKDOWNS := $(shell find $(SRC_DIR)/ -name '*.md')
 YAMLS := $(shell find $(SRC_DIR) -name "*.yml")
+FLATFILES := $(shell find $(SRC_DIR) -name "*.flatfile")
 BUILD_YAMLS := $(patsubst $(SRC_DIR)/%,$(BUILD_DIR)/%,$(YAMLS))
 
 # Define the corresponding HTML and PDF output files
@@ -119,11 +120,11 @@ $(BUILD_DIR)/sitemap.xml: $(HTMLS)
 	$(call status,Generate sitemap)
 	$(Q)sitemap $(BUILD_DIR)
 
-$(PERMALINKS_CONF): $(MARKDOWNS) $(YAMLS) | $(BUILD_DIR) $(LOG_DIR)
+$(PERMALINKS_CONF): $(MARKDOWNS) $(YAMLS) $(FLATFILES) | $(BUILD_DIR) $(LOG_DIR)
 	$(call status,Generate permalink redirects)
 	$(Q)nginx-permalinks $(SRC_DIR) -o $@ --log $(LOG_DIR)/nginx-permalinks.txt
 
-$(BUILD_DIR)/.update-index: $(MARKDOWNS) $(YAMLS)
+$(BUILD_DIR)/.update-index: $(MARKDOWNS) $(YAMLS) $(FLATFILES)
 	$(call status,Updating Redis Index)
 	$(Q)update-index --host $(REDIS_HOST) --port $(REDIS_PORT) src
 	$(Q)touch $@


### PR DESCRIPTION
## Summary
- allow `update-index` to load flatfile (`.flatfile`) metadata alongside YAML
- watch `.flatfile` files in build scripts and docs
- document and test flatfile indexing

## Testing
- `pytest app/shell/py/pie/tests/update/test_update_index.py app/shell/py/pie/tests/test_flatfile.py app/shell/py/pie/tests/test_flatfile_to_yaml.py -q`
- `PYTHONPATH=app/shell/py/pie python -m pie.check.all` *(fails: Missing artifact build/static/js/indextree.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b17fc3a30c8321a2e2998ae7e34ad8