### PR TITLE
test: cover jinja macro lines in flatfile

### DIFF
--- a/app/shell/py/pie/tests/test_flatfile.py
+++ b/app/shell/py/pie/tests/test_flatfile.py
@@ -81,6 +81,18 @@ def test_loads_dict_braces() -> None:
     }
 
 
+def test_loads_jinja_macro_value() -> None:
+    text = dedent(
+        '''\
+        foo.bar
+        {{"abcd"}}
+        '''
+    )
+    assert flatfile.loads(text.splitlines()) == {
+        'foo': {'bar': '{{"abcd"}}'}
+    }
+
+
 def test_roundtrip_nested_dicts_and_lists() -> None:
     data = {
         'desserts': {


### PR DESCRIPTION
## Summary
- verify flatfile handles Jinja macro values without misinterpreting them as dicts

## Testing
- `pytest app/shell/py/pie/tests/test_flatfile.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1d8efe6c88321b6b8a3eb84aaddd0