### PR TITLE
feat: scan flatfiles with picasso

### DIFF
--- a/app/shell/py/pie/pie/templates/picasso.rule.mk.jinja
+++ b/app/shell/py/pie/pie/templates/picasso.rule.mk.jinja
@@ -1,7 +1,7 @@
 {preprocessed_yml}: {input_path}
 	$(call status,Preprocess $<)
 	$(Q)mkdir -p $(dir {preprocessed_yml})
-	$(Q)cp $< $@
+	$(Q){preprocess_cmd}
 {output_html}: {preprocessed_md} {preprocessed_yml} {template_dep} $(BUILD_DIR)/.process-yamls
 	$(call status,Generate HTML $@)
 	$(Q)$(PANDOC_CMD) $(PANDOC_OPTS) {template_arg} --metadata-file={preprocessed_yml} -o $@ $<

--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -27,6 +27,27 @@ def test_generate_rule_basic(tmp_path, monkeypatch):
     assert rule == expected
 
 
+def test_generate_rule_flatfile(tmp_path, monkeypatch):
+    """generate_rule('src/foo/bar.flatfile') -> build/foo/bar.yml rule."""
+    src = tmp_path / "src" / "foo"
+    src.mkdir(parents=True)
+    (src / "bar.flatfile").write_text("title\nT\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(picasso, "load_metadata_pair", lambda path: None)
+    rule = picasso.generate_rule(Path("src/foo/bar.flatfile")).strip()
+    expected = (
+        "build/foo/bar.yml: src/foo/bar.flatfile\n"
+        "\t$(call status,Preprocess $<)\n"
+        "\t$(Q)mkdir -p $(dir build/foo/bar.yml)\n"
+        "\t$(Q)flatfile-to-yml $< $@\n"
+        "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml $(PANDOC_TEMPLATE) $(BUILD_DIR)/.process-yamls\n"
+        "\t$(call status,Generate HTML $@)\n"
+        "\t$(Q)$(PANDOC_CMD) $(PANDOC_OPTS) --template=$(PANDOC_TEMPLATE) --metadata-file=build/foo/bar.yml -o $@ $<\n"
+        "\t$(Q)check-bad-jinja-output $@"
+    )
+    assert rule == expected
+
+
 def test_generate_rule_with_template(tmp_path, monkeypatch):
     """Custom pandoc.template -> rule includes specific template."""
     src = tmp_path / "src" / "foo"
@@ -66,6 +87,20 @@ def test_main_prints_rules(tmp_path, capsys, monkeypatch):
     picasso.main(["--src", str(src), "--build", str(build)])
     out = capsys.readouterr().out.strip()
     expected = picasso.generate_rule(src / "doc.yml", src_root=src, build_root=build).strip()
+    assert out == expected
+
+
+def test_main_prints_rules_flatfile(tmp_path, capsys, monkeypatch):
+    """CLI prints rule for doc.flatfile."""
+    src = tmp_path / "src"
+    build = tmp_path / "build"
+    src.mkdir()
+    (src / "doc.flatfile").write_text("title\nT\n")
+
+    monkeypatch.setattr(picasso, "load_metadata_pair", lambda path: None)
+    picasso.main(["--src", str(src), "--build", str(build)])
+    out = capsys.readouterr().out.strip()
+    expected = picasso.generate_rule(src / "doc.flatfile", src_root=src, build_root=build).strip()
     assert out == expected
 
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -9,7 +9,7 @@ concepts and data formats, see the
 - [build-process.md](build-process.md) – overview of the build pipeline for new engineers.
 - [build-index.md](build-index.md) – generate a JSON index of document
   metadata. See the [metadata fields reference](../reference/metadata-fields.md).
-- [picasso.md](picasso.md) – create Makefile rules from YAML metadata.
+- [picasso.md](picasso.md) – create Makefile rules from metadata files.
 - [preprocess.md](preprocess.md) – run custom pre‑processing steps.
 - [update-index.md](update-index.md) – keep the index in sync after edits.
 

--- a/docs/guides/picasso.md
+++ b/docs/guides/picasso.md
@@ -1,10 +1,11 @@
 # picasso Makefile Generator
 
-`picasso` scans the `src/` directory for YAML metadata files and emits Makefile
-rules that convert them to HTML using Pandoc. The generated rules are
-written to `build/picasso.mk` and included by the `makefile` during the
-build. Refer to [Metadata Fields](../reference/metadata-fields.md) for the
-supported metadata keys.
+`picasso` scans the `src/` directory for metadata files (`.yml`, `.yaml`, and
+`.flatfile`) and emits Makefile rules that convert them to HTML using Pandoc.
+The generated rules are written to `build/picasso.mk` and included by the
+`makefile` during the build. Refer to
+[Metadata Fields](../reference/metadata-fields.md) for the supported metadata
+keys.
 
 ## Usage
 
@@ -14,8 +15,8 @@ Run the command and redirect its output to `build/picasso.mk`:
 picasso > build/picasso.mk
 ```
 
-This happens automatically in the `makefile` whenever any `.yml` file under
-`src/` changes.
+This happens automatically in the `makefile` whenever any `.yml`, `.yaml`, or
+`.flatfile` file under `src/` changes.
 
 You can override the source or build directories using `--src` and `--build`:
 
@@ -38,8 +39,9 @@ build/index.html: build/index.md build/index.yml $(PANDOC_TEMPLATE) $(BUILD_DIR)
     check-bad-jinja-output $@
 ```
 
-Each `.yml` file produces similar targets for preprocessing the metadata and
-rendering the final HTML.
+Each metadata file produces similar targets for preprocessing the metadata and
+rendering the final HTML. Flatfiles are converted to YAML before further
+processing.
 
 ## Custom Pandoc Templates
 

--- a/docs/guides/process-yaml.md
+++ b/docs/guides/process-yaml.md
@@ -27,8 +27,9 @@ process-yaml foo.yml bar.yml --log build.log
 
 `process-yaml` is typically invoked automatically during a build. The
 [`picasso`](picasso.md) tool scans metadata files and emits Makefile rules. The
-YAML files are copied to the build tree and then processed in batch. A
-`find`/`xargs` pipeline keeps the command line short even with many files:
+metadata files are copied or converted to YAML in the build tree and then
+processed in batch. A `find`/`xargs` pipeline keeps the command line short even
+with many files:
 
 ```make
 build/foo/bar.yml: src/foo/bar.yml

--- a/makefile
+++ b/makefile
@@ -198,7 +198,7 @@ clean:
 # Optionally include user dependencies
 -include src/dep.mk
 
-$(BUILD_DIR)/picasso.mk: $(YAMLS) | $(BUILD_DIR)
+$(BUILD_DIR)/picasso.mk: $(YAMLS) $(FLATFILES) | $(BUILD_DIR)
 	$(call status,Generate picasso rules)
 	$(Q)picasso --src $(SRC_DIR) --build $(BUILD_DIR) > $@
 


### PR DESCRIPTION
## Summary
- allow picasso to scan `.flatfile` metadata alongside YAML
- regenerate picasso rules when flatfiles change
- document flatfile support and cover with tests

## Testing
- `pytest app/shell/py/pie/tests/test_picasso.py`

------
https://chatgpt.com/codex/tasks/task_e_68b20f452c388321b21345292f286931