### PR TITLE
Switch render-html to template option

### DIFF
--- a/app/shell/py/pie/pie/build/picasso.py
+++ b/app/shell/py/pie/pie/build/picasso.py
@@ -50,7 +50,7 @@ def generate_rule(
             $(Q)cp $< $@
         build/foo/bar.html: build/foo/bar.md build/foo/bar.yml $(HTML_TEMPLATE) $(BUILD_DIR)/.process-yamls
             $(call status,Generate HTML $@)
-            $(Q)render-html $< $(HTML_TEMPLATE) $@ -c build/foo/bar.yml
+            $(Q)render-html --template $(HTML_TEMPLATE) $< $@ -c build/foo/bar.yml
             $(Q)check-bad-jinja-output $@
     """
     # Compute the path of ``input_path`` relative to the source root
@@ -63,11 +63,7 @@ def generate_rule(
 
     preprocess_cmd = "cp $< $@"
     metadata = load_metadata_pair(input_path)
-    tmpl = None
-    if metadata:
-        pandoc_meta = metadata.get("pandoc")
-        if isinstance(pandoc_meta, dict):
-            tmpl = pandoc_meta.get("template")
+    tmpl = metadata.get("template") if metadata else None
     template = Path(tmpl).as_posix() if tmpl else None
 
     template_dep = template or "$(HTML_TEMPLATE)"

--- a/app/shell/py/pie/pie/render/html.py
+++ b/app/shell/py/pie/pie/render/html.py
@@ -82,8 +82,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "Render a Markdown file into an HTML template",
     )
     parser.add_argument("markdown", help="Markdown source file")
-    parser.add_argument("template", help="Jinja template file")
     parser.add_argument("output", help="File to write rendered HTML to")
+    parser.add_argument(
+        "--template",
+        "-t",
+        required=True,
+        help="Jinja template file",
+    )
     parser.add_argument(
         "-c",
         "--context",

--- a/app/shell/py/pie/pie/templates/picasso.rule.mk.jinja
+++ b/app/shell/py/pie/pie/templates/picasso.rule.mk.jinja
@@ -4,5 +4,5 @@
 	$(Q){preprocess_cmd}
 {output_html}: {preprocessed_md} {preprocessed_yml} {template_dep} $(BUILD_DIR)/.process-yamls
 	$(call status,Generate HTML $@)
-	$(Q)render-html $< {template_dep} $@ -c {preprocessed_yml}
+	$(Q)render-html --template {template_dep} $< $@ -c {preprocessed_yml}
 	$(Q)check-bad-jinja-output $@

--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -21,7 +21,7 @@ def test_generate_rule_basic(tmp_path, monkeypatch):
         "\t$(Q)cp $< $@\n"
         "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml $(HTML_TEMPLATE) $(BUILD_DIR)/.process-yamls\n"
         "\t$(call status,Generate HTML $@)\n"
-        "\t$(Q)render-html $< $(HTML_TEMPLATE) $@ -c build/foo/bar.yml\n"
+        "\t$(Q)render-html --template $(HTML_TEMPLATE) $< $@ -c build/foo/bar.yml\n"
         "\t$(Q)check-bad-jinja-output $@"
     )
     assert rule == expected
@@ -29,7 +29,7 @@ def test_generate_rule_basic(tmp_path, monkeypatch):
 
 
 def test_generate_rule_with_template(tmp_path, monkeypatch):
-    """Custom pandoc.template -> rule includes specific template."""
+    """Custom template -> rule includes specific template."""
     src = tmp_path / "src" / "foo"
     src.mkdir(parents=True)
     template = tmp_path / "src" / "blog" / "pandoc-template.html"
@@ -40,7 +40,7 @@ def test_generate_rule_with_template(tmp_path, monkeypatch):
     monkeypatch.setattr(
         picasso,
         "load_metadata_pair",
-        lambda path: {"pandoc": {"template": "src/blog/pandoc-template.html"}},
+        lambda path: {"template": "src/blog/pandoc-template.html"},
     )
     rule = picasso.generate_rule(Path("src/foo/bar.yml")).strip()
     expected = (
@@ -50,7 +50,7 @@ def test_generate_rule_with_template(tmp_path, monkeypatch):
         "\t$(Q)cp $< $@\n"
         "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml src/blog/pandoc-template.html $(BUILD_DIR)/.process-yamls\n"
         "\t$(call status,Generate HTML $@)\n"
-        "\t$(Q)render-html $< src/blog/pandoc-template.html $@ -c build/foo/bar.yml\n"
+        "\t$(Q)render-html --template src/blog/pandoc-template.html $< $@ -c build/foo/bar.yml\n"
         "\t$(Q)check-bad-jinja-output $@"
     )
     assert rule == expected

--- a/app/shell/py/pie/tests/test_render_html.py
+++ b/app/shell/py/pie/tests/test_render_html.py
@@ -29,5 +29,5 @@ def test_main_renders_file(tmp_path, monkeypatch):
     out = tmp_path / "out.html"
     monkeypatch.setenv("PIE_DATA_DIR", str(tmp_path))
     html.env = html.create_env()
-    html.main([str(md), "base.html", str(out), "--context", str(ctx)])
+    html.main([str(md), str(out), "--template", "base.html", "--context", str(ctx)])
     assert "bar" in out.read_text(encoding="utf-8")

--- a/docs/guides/picasso.md
+++ b/docs/guides/picasso.md
@@ -35,7 +35,7 @@ build/index.yml: src/index.yml
     cp $< $@
 build/index.html: build/index.md build/index.yml $(HTML_TEMPLATE) $(BUILD_DIR)/.process-yamls
     $(call status,Generate HTML $@)
-    render-html $< $(HTML_TEMPLATE) $@ -c build/index.yml
+    render-html --template $(HTML_TEMPLATE) $< $@ -c build/index.yml
     check-bad-jinja-output $@
 ```
 
@@ -44,13 +44,12 @@ rendering the final HTML.
 
 ## Custom Templates
 
-`picasso` retrieves per-document metadata from Redis. If a document defines
-`pandoc.template`, that template path is added as a dependency and passed to
-`render-html` when rendering. For example:
+`picasso` retrieves per-document metadata from Redis. If a document defines a
+`template` path, that file is added as a dependency and passed via
+`--template` to `render-html` when rendering. For example:
 
 ```yaml
-pandoc:
-  template: src/blog/pandoc-template.html
+template: src/blog/custom-template.html
 ```
 
 This allows different pages to use specialized templates while falling back to

--- a/docs/reference/keyterms.md
+++ b/docs/reference/keyterms.md
@@ -55,7 +55,7 @@ This rule produces `build/keyterms/index.json` from `src/keyterms/index.json`.
 
 ```
 build/%.html: build/%.md build/%.yml $(HTML_TEMPLATE) | build
-    render-html $< $(HTML_TEMPLATE) $@ -c build/$*.yml
+    render-html --template $(HTML_TEMPLATE) $< $@ -c build/$*.yml
 ```
 
 ## Verification

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -18,6 +18,7 @@ This document lists the common metadata keys used by Press and explains how miss
 - `link.class` – CSS class for rendered links.
 - `link.canonical` – Absolute URL for the page.
 - `name` – **Deprecated.** Former display name used in navigation and indexes.
+- `template` – Optional Jinja template path passed to `render-html`.
 
 ## Auto‑Generated Values
 

--- a/makefile
+++ b/makefile
@@ -146,8 +146,8 @@ $(BUILD_DIR)/%.md: %.md | $(BUILD_DIR)
 
 # Generate HTML from processed Markdown using render-html
 $(BUILD_DIR)/%.html: $(BUILD_DIR)/%.md $(BUILD_DIR)/%.yml $(HTML_TEMPLATE) $(BUILD_DIR)/.process-yamls | $(BUILD_DIR)
-        $(call status,Generate HTML $@)
-        $(Q)render-html $< $(HTML_TEMPLATE) $@ -c $(BUILD_DIR)/$*.yml
+	$(call status,Generate HTML $@)
+	$(Q)render-html --template $(HTML_TEMPLATE) $< $@ -c $(BUILD_DIR)/$*.yml
 
 # Clean the build directory by removing all build artifacts
 .PHONY: clean

--- a/src/examples/blog/index.yml
+++ b/src/examples/blog/index.yml
@@ -4,8 +4,7 @@ id: trendy-blog-template
 pubdate: Jan 1, 2025
 hero_image: https://via.placeholder.com/1200x400/F4A460/FFFFFF?text=Fall+Hero
 preamble: A short intro shows how you might tease readers into the story.
-pandoc:
-  template: src/examples/blog/pandoc-template.html
+template: src/examples/blog/pandoc-template.html
 css:
   - https://cdn.jsdelivr.net/npm/water.css@2/out/water.css
 breadcrumbs:


### PR DESCRIPTION
## Summary
- call `render-html` with `--template` in generated rules
- simplify metadata by replacing `pandoc.template` with top-level `template`
- document new template field and update build instructions

## Testing
- `pytest app/shell/py/pie/tests/test_picasso.py`
- `pytest app/shell/py/pie/tests/test_render_html.py`


------
https://chatgpt.com/codex/tasks/task_e_68b74966087883219a3812cd87b35a47