### PR TITLE
refactor: move markdown metadata to yaml

### DIFF
--- a/src/examples/jinja.md
+++ b/src/examples/jinja.md
@@ -1,16 +1,3 @@
----
-title: Jinja Examples
-author: Brian Lee
-id: jinja
-citation: jinja
-breadcrumbs:
-  - title: Home
-    url: /
-  - title: Examples
-    url: /examples/
-  - title: Jinja Examples
----
-
 This tutorial introduces the basics of embedding Jinja in Markdown. Each
 snippet shows the template followed by its rendered output.
 

--- a/src/examples/jinja.yml
+++ b/src/examples/jinja.yml
@@ -1,0 +1,10 @@
+author: Brian Lee
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: Examples
+    url: /examples/
+  - title: Jinja Examples
+citation: jinja
+id: jinja
+title: Jinja Examples

--- a/src/include-filter/a.md
+++ b/src/include-filter/a.md
@@ -1,11 +1,1 @@
----
-title: a
-author: Brian Lee
-breadcrumbs:
-  - title: Home
-    url: /
-  - title: include-filter
-    url: /include-filter/
-  - title: a
----
 a is the first letter of the English alphabet.

--- a/src/include-filter/a.yml
+++ b/src/include-filter/a.yml
@@ -1,0 +1,8 @@
+author: Brian Lee
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: include-filter
+    url: /include-filter/
+  - title: a
+title: a

--- a/src/include-filter/b.md
+++ b/src/include-filter/b.md
@@ -1,13 +1,3 @@
----
-title: b
-author: Brian Lee
-breadcrumbs:
-  - title: Home
-    url: /
-  - title: include-filter
-    url: /include-filter/
-  - title: b
----
 b is the second letter of the English alphabet.
 
 It represents the voiced bilabial stop in English and traces its lineage back

--- a/src/include-filter/b.yml
+++ b/src/include-filter/b.yml
@@ -1,0 +1,8 @@
+author: Brian Lee
+breadcrumbs:
+  - title: Home
+    url: /
+  - title: include-filter
+    url: /include-filter/
+  - title: b
+title: b


### PR DESCRIPTION
## Summary
- move YAML metadata blocks from markdown pages into dedicated `.yml` files
- remove front matter from affected markdown files

## Testing
- `pytest` *(fails: test_update_index.py::test_main_inserts_path, test_update_index.py::test_main_inserts_sha1)*

------
https://chatgpt.com/codex/tasks/task_e_68b74fb05a3c832180b3ce558b926c36