### PR TITLE
Scaffold Jinja template and update README

### DIFF
--- a/app/shell/py/pie/pie/create/site.py
+++ b/app/shell/py/pie/pie/create/site.py
@@ -36,6 +36,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "src/index.md": "index.md.jinja",
         "src/index.yml": "index.yml.jinja",
         "src/css/style.css": "style.css.jinja",
+        # Base HTML template used by render-html
         "src/template.html.jinja": "template.html.jinja",
         "src/dep.mk": "dep.mk.jinja",
         "src/robots.txt": "robots.txt.jinja",
@@ -47,8 +48,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     for rel_path, template_name in files.items():
         target = root / rel_path
         target.parent.mkdir(parents=True, exist_ok=True)
-        template_text = (template_dir / template_name).read_text(encoding="utf-8")
-        content = env.from_string(template_text).render()
+        template_text = (template_dir / template_name).read_text(
+            encoding="utf-8"
+        )
+        if rel_path.endswith(".jinja"):
+            # Preserve Jinja templates without rendering
+            content = template_text
+        else:
+            content = env.from_string(template_text).render()
         target.write_text(content, encoding="utf-8")
 
     logger.info("Created project scaffolding", path=str(root))

--- a/app/shell/py/pie/pie/create/templates/README.md.jinja
+++ b/app/shell/py/pie/pie/create/templates/README.md.jinja
@@ -4,3 +4,8 @@
 
 Run `docker-compose build` to build the project.
 
+## Rendering
+
+`render-html` combines Jinja templates with `markdown2` to convert Markdown
+sources into HTML pages.
+


### PR DESCRIPTION
## Summary
- preserve Jinja HTML templates during site scaffolding
- refresh scaffolded README to describe Jinja + markdown2 rendering

## Testing
- `pytest app/shell/py/pie/tests/test_create.py -q`
- `pytest app/shell/py/pie/tests -q` *(fails: No module named 'bs4', No module named 'redis', No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68b75803fda88321aa2aa3dc865f7205