### PR TITLE
refactor: drop pandoc in favor of markdown2/jinja2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Press
 
-Press is a static-site generator built on Pandoc and Docker, orchestrated with `docker compose` and `redo.mk`.
+Press is a static-site generator built on Python (`markdown2` and `Jinja2`)
+and Docker, orchestrated with `docker compose` and `redo.mk`.
 
 ## Benefits
 
 - Reproducible builds through containerized services and declarative tasks
-- Flexible content formats processed by Pandoc
+- Flexible content formats rendered with markdown2 and Jinja2
 - Built-in validation keeps pages consistent and free of broken links
 
 ## Key Features
@@ -16,13 +17,15 @@ Press is a static-site generator built on Pandoc and Docker, orchestrated with `
 
 ## Styling
 
-Site styles live under `src/css/` and are compiled with the Python `libsass` library into
-`build/css/`. Edit `src/css/style.css` or add additional files in that
-directory using SCSS syntax to customize the site appearance.
+Site styles live under `src/css/` and are compiled with the Python `libsass`
+library into `build/css/`. Edit `src/css/style.css` or add additional files in
+that directory using SCSS syntax to customize the site appearance.
 
 ## Documentation
 
-All project documentation lives under [docs/](docs/). Start with the [guides](docs/guides/README.md) for step-by-step workflows and see the [reference](docs/reference/README.md) for technical details.
+All project documentation lives under [docs/](docs/). Start with the
+[guides](docs/guides/README.md) for step-by-step workflows and see the
+[reference](docs/reference/README.md) for technical details.
 
 ## Testing
 

--- a/app/shell/Dockerfile
+++ b/app/shell/Dockerfile
@@ -6,8 +6,8 @@
 # containers required to build a site.
 # -------------------------------------------------------------------
 
-# Base image: pandoc with extra scripts on Ubuntu
-FROM pandoc/extra:latest-ubuntu
+# Base image: lightweight Python runtime
+FROM python:3.11-slim
 
 # -------------------------------------------------------------------
 # System preparation
@@ -42,11 +42,14 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
 # -------------------------------------------------------------------
-# Python filters and backends
+# Python dependencies
+# -------------------------------------------------------------------
+RUN pip install --no-cache-dir --break-system-packages \
+        markdown2 \
+        jinja2
+
 # Copy Press Python libraries into the image. Users can override by mounting
 # /press/py
-# -------------------------------------------------------------------
-# Install library under development.
 COPY ./py/pie /press/py/pie
 
 RUN pip install --no-cache-dir --break-system-packages \

--- a/app/shell/README.md
+++ b/app/shell/README.md
@@ -5,7 +5,7 @@ environment for Press.
 
 ## Layout
 
-- `Dockerfile` – base image with build tools like Pandoc and Make.
+- `Dockerfile` – base image with build tools like Python and Make.
 - `mk/` – Makefiles executed inside the container.
 - `bin/` – helper scripts invoked during the build.
 - `py/` – Python utilities and their tests.

--- a/app/shell/py/pie/pie/filter/include.py
+++ b/app/shell/py/pie/pie/filter/include.py
@@ -7,7 +7,8 @@ file.  Available helper functions include ``include()`` for inserting other
 Markdown files and ``mermaid()`` for converting Mermaid diagrams to images.
 
 Links that end with ``.md`` are rewritten to ``.html`` so the output can be fed
-directly to Pandoc.  The command is primarily driven via ``preprocess`` and the
+directly to downstream rendering.  The command is primarily driven via
+``preprocess`` and the
 repository root ``makefile``.
 """
 
@@ -207,7 +208,7 @@ def main(argv: list[str] | None = None) -> None:
 
     ``include-filter`` is primarily used by the build scripts.  It executes any
     ``python`` fenced blocks in the input and writes the resulting Markdown to
-    ``outfile``.  Links ending in ``.md`` are rewritten so that Pandoc can
+    ``outfile``.  Links ending in ``.md`` are rewritten so the renderer can
     convert the file directly to HTML.
     """
 

--- a/docs/guides/build-process.md
+++ b/docs/guides/build-process.md
@@ -51,14 +51,15 @@ container:
    recorded in the `dragonfly` key-value store. Each document's source paths are
    stored under `<id>.path` and each path maps back to its owning ID. The build
    uses this index to resolve cross references and dependency relationships.
-2. **Pre-processing** – Custom filters convert assets before Pandoc sees them.
-   Examples include `preprocess` for macro expansion, YAML normalization, and
-   rules that turn Mermaid diagrams into SVG. Diagram rendering delegates to the
+2. **Pre-processing** – Custom filters convert assets before rendering. Examples
+   include `preprocess` for macro expansion, YAML normalization, and rules that
+   turn Mermaid diagrams into SVG. Diagram rendering delegates to the
    standalone `mermaid` service, which isolates the third-party CLI from core
    images such as `shell`.
-3. **Pandoc rendering** – Pre-processed Markdown is converted to HTML and PDF
-   using a shared template. The command enables table of contents generation,
-   MathJax rendering, and cross-reference resolution.
+3. **Markdown rendering** – Pre-processed Markdown is converted to HTML using a
+   shared template powered by `markdown2` and `Jinja2`. Table of contents
+   generation, MathJax rendering, and cross-reference resolution are handled in
+   Python.
 4. **Asset pipeline** – SCSS stylesheets and other static files are compiled or
    copied into `build/`. The default `src/css/style.css` file supports the full
    SCSS syntax and produces `build/css/style.css`. Additional rules from

--- a/docs/guides/include-filter.md
+++ b/docs/guides/include-filter.md
@@ -3,7 +3,7 @@
 `include-filter` processes Markdown files and expands inline Python directives.
 
 Typical usage chains the command multiple times in the project `makefile` to
-resolve nested includes before Pandoc.
+resolve nested includes before rendering.
 
 It resolves custom `include()` calls and renders Mermaid diagrams during
 preprocessing. Any links ending with `.md` are automatically rewritten to

--- a/docs/guides/preprocess.md
+++ b/docs/guides/preprocess.md
@@ -1,6 +1,6 @@
 # preprocess Script
 
-`preprocess` prepares Markdown files for Pandoc. It expands includes, renders
+`preprocess` prepares Markdown files for rendering. It expands includes,
 internal links, and emojifies the text. The output mirrors the directory
 structure under `build/` so that `src/foo/bar.md` becomes
 `build/foo/bar.md`.
@@ -30,5 +30,5 @@ build/%.md: %.md | build
 ```
 
 Running `preprocess src/guide/intro.md` will create
-`build/guide/intro.md` ready for Pandoc.
+`build/guide/intro.md` ready for rendering.
 

--- a/docs/guides/process-yaml.md
+++ b/docs/guides/process-yaml.md
@@ -41,4 +41,4 @@ $(BUILD_DIR)/.process-yamls: $(BUILD_YAMLS)
 ```
 
 Running the script ensures each document has a complete metadata block so
-Pandoc and other tools can rely on fields like `id` or `citation`.
+rendering tools can rely on fields like `id` or `citation`.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,10 +1,10 @@
 # Architecture
 
 ## Overview
-Press is a static-site generator that wraps Pandoc tooling in a
+Press is a static-site generator that wraps Markdown tooling in a
 containerized build and runtime environment. Docker Compose services and
-Makefiles coordinate building Markdown content into HTML or PDF and
-serving the generated site.
+Makefiles coordinate building Markdown content into HTML and serving the
+generated site.
 
 ## Repository Layout
 - `app/` – Dockerfiles, Docker Compose templates, and build scripts used

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -1,6 +1,7 @@
 # Metadata Fields
 
-This document lists the common metadata keys used by Press and explains how missing values are automatically generated.
+This document lists the common metadata keys used by Press and explains how
+missing values are automatically generated.
 
 ## Required
 
@@ -8,11 +9,11 @@ This document lists the common metadata keys used by Press and explains how miss
 
 ## Optional Fields
 
-- `author` – Author string passed to Pandoc.
+- `author` – Author string used in metadata.
 - `definition` – Markdown snippet rendered through the `definition` global
   and used for meta tags.
 - `og_image` – OpenGraph image path.
-- `meta` – Array of additional `<meta>` tag definitions for Pandoc.
+- `meta` – Array of additional `<meta>` tag definitions.
 - `icon` – Emoji or icon displayed by link globals.
 - `link.tracking` – Boolean controlling external link behaviour.
 - `link.class` – CSS class for rendered links.
@@ -22,7 +23,8 @@ This document lists the common metadata keys used by Press and explains how miss
 
 ## Auto‑Generated Values
 
-During indexing, `generate_missing_metadata` in `pie.metadata` fills in several fields when they are missing:
+During indexing, `generate_missing_metadata` in `pie.metadata` fills in
+several fields when they are missing:
 
 | Field      | Default value                                  |
 | ---------- | ---------------------------------------------- |
@@ -31,13 +33,15 @@ During indexing, `generate_missing_metadata` in `pie.metadata` fills in several 
 | `url`      | Derived from the source path (e.g. `src/foo.md` → `/foo.html`) |
 | `link.canonical` | Absolute form of the `url` value              |
 
-The `citation` value is used as the anchor text when other pages link to this document using Jinja globals such as `linktitle`.
-The helper that assigns these defaults lives in `generate_missing_metadata` within `pie.metadata`.
+The `citation` value is used as the anchor text when other pages link to this
+document using Jinja globals such as `linktitle`. The helper that assigns these
+defaults lives in `generate_missing_metadata` within `pie.metadata`.
 
 For bibliographic references the `citation` field may instead be a mapping with
-`author`, `year`, and `page` keys.  This structure is consumed by the `cite`
+`author`, `year`, and `page` keys. This structure is consumed by the `cite`
 Jinja global and by the link-formatting helpers to render Chicago style text in
 parentheses.
 
-`link.tracking` defaults to `true`, meaning links open in the same tab. `link.class` defaults to `internal-link`.
+`link.tracking` defaults to `true`, meaning links open in the same tab.
+`link.class` defaults to `internal-link`.
 

--- a/src/template.html.jinja
+++ b/src/template.html.jinja
@@ -36,7 +36,7 @@
     <meta name="twitter:image" content="{{ og_image }}" />
     {% endif %}
     <!--
-        Example metadata block for social tags used by Pandoc:
+        Example metadata block for social tags:
         ---
         title: "Example Page"
         description: "Page description."


### PR DESCRIPTION
## Summary
- build shell image from python:3.11-slim and install markdown2 & jinja2
- remove pandoc references across code and docs

## Testing
- `pytest` *(fails: 2 failed, 283 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8599fedec8321ace848be0a884416