### PR TITLE
Update tests for render-html scaffolding and markdown2

### DIFF
--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -32,7 +32,9 @@ def test_create_scaffolding(tmp_path: Path) -> None:
     assert (target / "redo.mk").exists()
 
     assert (target / "src/css/style.css").exists()
-    assert (target / "src/template.html.jinja").exists()
+    template = target / "src/template.html.jinja"
+    assert template.exists()
+    assert not (target / "src/template.html").exists()
 
     shell_dockerfile = target / "app/shell/Dockerfile"
     assert shell_dockerfile.exists()

--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -25,6 +25,7 @@ def test_generate_rule_basic(tmp_path, monkeypatch):
         "\t$(Q)check-bad-jinja-output $@"
     )
     assert rule == expected
+    assert "render-html" in rule
 
 
 
@@ -54,6 +55,7 @@ def test_generate_rule_with_template(tmp_path, monkeypatch):
         "\t$(Q)check-bad-jinja-output $@"
     )
     assert rule == expected
+    assert "render-html" in rule
 
 
 def test_main_prints_rules(tmp_path, capsys, monkeypatch):

--- a/app/shell/py/pie/tests/test_render_html.py
+++ b/app/shell/py/pie/tests/test_render_html.py
@@ -5,7 +5,8 @@ from pie.render import html
 def test_render_page_converts_markdown_and_merges_metadata(tmp_path, monkeypatch):
     md = tmp_path / "page.md"
     md.write_text(
-        "---\ntitle: Sample\n---\n\n# Heading\n\nBody text.", encoding="utf-8"
+        "---\ntitle: Sample\n---\n\n# Heading\n\n- [ ] Open\n- [x] Closed\n",
+        encoding="utf-8"
     )
     tmpl = tmp_path / "base.html"
     tmpl.write_text(
@@ -15,6 +16,14 @@ def test_render_page_converts_markdown_and_merges_metadata(tmp_path, monkeypatch
     html.env = html.create_env()
     result = html.render_page(md, "base.html", {"extra": "X"})
     assert "<h1 id=\"heading\">Heading</h1>" in result
+    assert (
+        '<input type="checkbox" class="task-list-item-checkbox" disabled> Open'
+        in result
+    )
+    assert (
+        '<input type="checkbox" class="task-list-item-checkbox" checked disabled> Closed'
+        in result
+    )
     assert "<title>Sample</title>" in result
     assert "X" in result
 


### PR DESCRIPTION
## Summary
- Ensure project scaffolding creates `template.html.jinja` and not legacy `template.html`
- Validate `picasso.generate_rule` outputs rules invoking the `render-html` command
- Extend HTML rendering tests for markdown2 header IDs and task lists

## Testing
- `pytest app/shell/py/pie/tests/test_create.py app/shell/py/pie/tests/test_picasso.py app/shell/py/pie/tests/test_render_html.py`

------
https://chatgpt.com/codex/tasks/task_e_68b85cfca1ac832187d7a420b265c2cb