### PR TITLE
feat: show jinja globals in metadata and use index tree on home

### DIFF
--- a/src/examples/link-globals.md
+++ b/src/examples/link-globals.md
@@ -73,3 +73,16 @@ The `link` global combines all the others and is the preferred option:
 Output:
 
 {{ link("quickstart") }}
+
+## Metadata
+
+Jinja globals work inside YAML metadata. The `link-globals.yml` file defines
+`summary` with the `link` global:
+
+```yaml
+{% raw %}summary: '{{ link("quickstart") }}'{% endraw %}
+```
+
+Rendered:
+
+{{ summary }}

--- a/src/examples/link-globals.yml
+++ b/src/examples/link-globals.yml
@@ -9,3 +9,4 @@ citation: link globals
 id: link-globals
 pubdate: Sep 02, 2025
 title: Link Global Examples
+summary: '{{ link("quickstart") }}'

--- a/src/index.md
+++ b/src/index.md
@@ -1,17 +1,8 @@
-Welcome to the demo site for **Press**. Use the links below to explore key
-features.
+Welcome to the demo site for **Press**. The examples index below links to
+key features.
 
-- [Blog Demo](examples/blog/index.md)
-- [Breadcrumb Demo](examples/breadcrumbs/index.md)
-- [Chicago Citation Examples](examples/chicago-citations.md)
-- [Index Tree Demo](examples/indextree/index.md)
-- [Jinja Examples](examples/jinja.md)
-- [Link Global Examples](examples/link-globals.md)
-- [Mermaid Diagram Example](examples/mermaid/index.md)
-- [MagicBar Demo](magicbar/index.md)
-- [Quickstart](quickstart.md)
-- [Quiz Demo](quiz/index.md)
-- [Responsive Image Examples](examples/responsive-images.md)
+<div class="indextree-root" data-src="/static/index/examples.json"></div>
+<script type="module" src="/static/js/indextree.js" defer></script>
 
 ## Emoji Replacement
 


### PR DESCRIPTION
## Summary
- demonstrate use of the `link` Jinja global in YAML metadata via a new `summary` field
- document the metadata example and show rendered output
- replace the top-level link list on the home page with an examples index tree

## Testing
- `make check` *(fails: Missing artifact {'path': 'build/static/js/indextree.js'})*

------
https://chatgpt.com/codex/tasks/task_e_68b87d5fa130832198fd7ad81cd15b91