### PR TITLE
Ensure JSON dump preserves Unicode and key order

### DIFF
--- a/app/shell/py/pie/pie/utils/__init__.py
+++ b/app/shell/py/pie/pie/utils/__init__.py
@@ -40,7 +40,7 @@ def write_json(data, filename: str) -> None:
 
     logger.debug("Writing JSON", filename=filename)
     with open(filename, "w", encoding="utf-8") as f:
-        json.dump(data, f)
+        json.dump(data, f, ensure_ascii=False, sort_keys=True)
 
 
 def write_utf8(text: str, filename: str) -> None:

--- a/app/shell/py/pie/tests/test_utils.py
+++ b/app/shell/py/pie/tests/test_utils.py
@@ -4,10 +4,13 @@ from pie import utils
 
 
 def test_write_json_roundtrip(tmp_path):
-    data = {"name": "pie", "value": 42}
+    data = {"name": "π", "value": 42}
     path = tmp_path / "data.json"
     utils.write_json(data, str(path))
     assert utils.read_json(str(path)) == data
+    text = path.read_text(encoding="utf-8")
+    assert "π" in text
+    assert "\\u03c0" not in text
 
 
 def test_write_utf8_roundtrip(tmp_path):


### PR DESCRIPTION
## Summary
- prevent ASCII escaping and enforce key order when writing JSON
- test that JSON roundtrip keeps Unicode characters unescaped

## Testing
- `pytest app/shell/py/pie/tests/test_utils.py::test_write_json_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8905777908321b97c9edd574894d1