### PR TITLE
Register anchor macro globally

### DIFF
--- a/app/shell/py/pie/pie/render/jinja.py
+++ b/app/shell/py/pie/pie/render/jinja.py
@@ -21,6 +21,7 @@ from jinja2 import (
     FileSystemLoader,
     StrictUndefined,
     TemplateSyntaxError,
+    TemplateNotFound,
 )
 from pie.cli import create_parser
 from pie.logging import logger, configure_logging
@@ -504,6 +505,10 @@ def create_env():
     env.globals["read_json"] = read_json
     env.globals["read_yaml"] = read_yaml
     env.globals["cite"] = cite
+    try:
+        env.globals["anchor"] = env.get_template("anchor.jinja").module.anchor
+    except TemplateNotFound:
+        logger.warning("Missing anchor.jinja template")
     return env
 
 env = create_env()

--- a/app/shell/py/pie/tests/test_render_jinja.py
+++ b/app/shell/py/pie/tests/test_render_jinja.py
@@ -118,6 +118,15 @@ def test_entry_point_executes_main(tmp_path, monkeypatch):
     assert out.read_text(encoding="utf-8") == "Hi Agent"
 
 
+def test_anchor_macro_available(monkeypatch):
+    data_dir = Path(__file__).resolve().parents[5] / "templates"
+    monkeypatch.setenv("PIE_DATA_DIR", str(data_dir))
+    jinja.env = jinja.create_env()
+    jinja.index_json = {}
+    html = jinja.render_jinja("{{ anchor('test') }}")
+    assert '<a id="test"' in html
+
+
 def test_render_jinja_logs_template_syntax_error(monkeypatch):
     records = []
     handle = jinja.logger.add(records.append, level="ERROR")

--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -15,6 +15,7 @@ for details on the structure of this metadata.
 - `cite(*ids)` – format one or more metadata entries as Chicago style
   citations. When multiple entries share the same author and year their page
   numbers are combined.
+- `anchor(id)` – generate a heading anchor linking to `#id`.
 - `link(desc, anchor=None)` and related helpers `linktitle`, `linkcap`,
   `link_icon_title`, `linkicon`, and `linkshort` – format metadata into HTML
   anchors. See [link-globals.md](link-globals.md) for details.


### PR DESCRIPTION
## Summary
- load `anchor.jinja` macro into Jinja environment globals during `create_env`
- document new `anchor(id)` helper
- verify the `anchor` macro is accessible by default

## Testing
- `pytest app/shell/py/pie/tests/test_render_jinja.py::test_anchor_macro_available -q`
- `pytest app/shell/py/pie/tests -q` *(fails: process_yaml tests mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b89e5caebc832191301eefce14a68f