### PR TITLE
feat: add debug logging for index tree scanning

### DIFF
--- a/app/shell/py/pie/pie/index_tree.py
+++ b/app/shell/py/pie/pie/index_tree.py
@@ -43,14 +43,18 @@ def walk(
 ) -> Iterator[Tuple[Mapping[str, Any], Path]]:
     """Yield metadata and path pairs for entries in *directory*."""
     for path in directory.iterdir():
+        logger.debug("Scanning entry", path=str(path))
         try:
             if path.is_dir():
                 index_file = path / "index.yml"
+                logger.debug("Checking for index file", path=str(index_file))
                 if index_file.is_file():
+                    logger.debug("Loading metadata", path=str(index_file))
                     meta = loader(index_file)
                     if meta:
                         yield meta, path
             elif path.is_file() and path.suffix == ".yml" and path.name != "index.yml":
+                logger.debug("Loading metadata", path=str(path))
                 meta = loader(path)
                 if meta:
                     yield meta, path


### PR DESCRIPTION
## Summary
- log each directory entry scanned by `index_tree.walk`
- log when metadata is loaded for index files and YAML files

## Testing
- `pytest app/shell/py/pie/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b15d9ffc83219f2594ecd9d5c9c7