### PR TITLE
docs: add logging reference

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -13,6 +13,7 @@ formatting.
 - [definition.md](definition.md) – render snippets from the `definition` field.
 - [keyterms.md](keyterms.md) – glossary of important terminology.
 - [link-metadata.md](link-metadata.md) – link metadata format and usage.
+- [logging.md](logging.md) – centralized logging helpers and configuration.
 - [metadata-fields.md](metadata-fields.md) – description of common metadata
 fields referenced in
   [build-index](../guides/build-index.md).

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -1,0 +1,34 @@
+# Logging
+
+The `pie.logging` module centralizes logging for command line helpers. It
+configures a `loguru.Logger` instance named `logger` at import time so all
+tools share the same behavior.
+
+## Logger Configuration
+
+Default handlers provided by `loguru` are removed to allow explicit control
+over sinks. `LOG_FORMAT` defines a consistent layout:
+
+```
+{time:HH:mm:ss} {module:>10.10}:{function:<15.15}:{line:<4} {level:.1s} {message} {extra}
+```
+
+A console sink targeting `sys.stderr` is added at level `INFO`.
+
+## `configure_logging(verbose, log_path)`
+
+Rebuild the logger configuration for a command line tool. When `verbose` is
+`True` the console sink uses level `DEBUG`; otherwise it uses `INFO`. Existing
+sinks are cleared, a new console sink is added with the chosen level, and
+`setup_file_logger` adds a file sink when `log_path` is provided.
+
+## `add_file_logger(filename, level="DEBUG")`
+
+Add a sink that writes to `filename` using `LOG_FORMAT`. The sink defaults to
+the `DEBUG` level, capturing detailed traces while leaving console output less
+noisy.
+
+## `disable_logging()`
+
+Remove all configured sinks to silence the logger entirely. Call this when a
+tool must suppress log output.


### PR DESCRIPTION
## Summary
- document centralized logging helpers and configuration
- reference logging page from the reference index

## Testing
- `pytest` *(fails: 47 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ddc5d5648321b253417159bbf906