### PR TITLE
Use cmarkgfm for Markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Press
 
-Press is a static-site generator built on Python (`commonmark` and `Jinja2`)
+Press is a static-site generator built on Python (`cmarkgfm` and `Jinja2`)
 and Docker, orchestrated with `docker compose` and `redo.mk`.
 
 ## Benefits
 
 - Reproducible builds through containerized services and declarative tasks
-- Flexible content formats rendered with commonmark.py and Jinja2
+- Flexible content formats rendered with cmarkgfm and Jinja2
 - Built-in validation keeps pages consistent and free of broken links
 
 ## Key Features

--- a/app/shell/py/pie/pie/create/templates/README.md.jinja
+++ b/app/shell/py/pie/pie/create/templates/README.md.jinja
@@ -6,6 +6,6 @@ Run `docker-compose build` to build the project.
 
 ## Rendering
 
-`render-html` combines Jinja templates with `commonmark.py` to convert Markdown
-sources into HTML pages.
+`render-html` combines Jinja templates with the Python Markdown library to
+convert Markdown sources into HTML pages.
 

--- a/app/shell/py/pie/pie/render/html.py
+++ b/app/shell/py/pie/pie/render/html.py
@@ -4,9 +4,9 @@
 
 The module exposes :func:`render_page` and a small CLI used by the
 ``render-html`` console script. The Markdown source may include YAML front
-matter which is merged into the Jinja context before rendering. The Markdown
-is converted using :mod:`commonmark` and post-processed to match behaviour
-used across the press tooling.
+matter which is merged into the Jinja context before rendering. Markdown is
+converted using the :mod:`cmarkgfm` library which supports GitHub Flavored
+Markdown, including tables, to match behaviour used across the press tooling.
 """
 
 from __future__ import annotations
@@ -16,8 +16,7 @@ import re
 from pathlib import Path
 from typing import Any, Mapping
 
-import commonmark
-from bs4 import BeautifulSoup
+import cmarkgfm
 
 from pie.cli import create_parser
 from pie.logging import configure_logging
@@ -60,8 +59,10 @@ def render_page(
     metadata, md_text = _parse_markdown(markdown_path)
     ctx = dict(context or {})
     ctx.update(metadata)
-    html = commonmark.commonmark(render_jinja(md_text))
-    ctx["content"] = html
+    html_text = cmarkgfm.github_flavored_markdown_to_html(
+        render_jinja(md_text)
+    )
+    ctx["content"] = html_text
     tmpl = env.get_template(template)
     return tmpl.render(**ctx)
 

--- a/app/shell/py/pie/requirements.txt
+++ b/app/shell/py/pie/requirements.txt
@@ -5,7 +5,7 @@ fakeredis
 flatten-dict
 beautifulsoup4
 jinja2
-commonmark
+cmarkgfm
 pytest
 pytest-cov
 emoji

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -4,7 +4,7 @@ setup(
     name="pie",
     version="0.1.0",
     packages=find_packages(),
-    install_requires=["emoji", "commonmark"],
+    install_requires=["emoji", "markdown"],
     author="Brian Lee",
     author_email="",
     description="",

--- a/app/shell/py/pie/tests/test_render_html.py
+++ b/app/shell/py/pie/tests/test_render_html.py
@@ -13,3 +13,20 @@ def test_main_renders_file(tmp_path, monkeypatch):
     html.env = html.create_env()
     html.main([str(md), str(out), "--template", "base.html", "--context", str(ctx)])
     assert "bar" in out.read_text(encoding="utf-8")
+
+
+def test_main_renders_table(tmp_path, monkeypatch):
+    md = tmp_path / "table.md"
+    md.write_text(
+        "---\n---\n| a | b |\n| --- | --- |\n| 1 | 2 |\n",
+        encoding="utf-8",
+    )
+    tmpl = tmp_path / "base.html"
+    tmpl.write_text("{{ content }}", encoding="utf-8")
+    out = tmp_path / "out.html"
+    monkeypatch.setenv("PIE_DATA_DIR", str(tmp_path))
+    html.env = html.create_env()
+    html.main([str(md), str(out), "--template", "base.html"])
+    text = out.read_text(encoding="utf-8")
+    assert "<table>" in text
+    assert "<td>1</td>" in text

--- a/docs/guides/build-process.md
+++ b/docs/guides/build-process.md
@@ -57,9 +57,9 @@ container:
    standalone `mermaid` service, which isolates the third-party CLI from core
    images such as `shell`.
 3. **Markdown rendering** – Pre-processed Markdown is converted to HTML using a
-   shared template powered by `commonmark.py` and `Jinja2`. Table of contents
-   generation, MathJax rendering, and cross-reference resolution are handled in
-   Python.
+   shared template powered by the cmarkgfm library and `Jinja2`. Table of
+   contents generation, MathJax rendering, and cross-reference resolution are
+   handled in Python.
 4. **Asset pipeline** – SCSS stylesheets and other static files are compiled or
    copied into `build/`. The default `src/css/style.css` file supports the full
    SCSS syntax and produces `build/css/style.css`. Additional rules from


### PR DESCRIPTION
## Summary
- replace Python Markdown with cmarkgfm for HTML rendering and table support
- update requirements and docs to reference cmarkgfm

## Testing
- `pytest app/shell/py/pie/tests/test_render_html.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9b0595df8832182a684363a56aa4a