### PR TITLE
Clarify script tag handling in Markdown renderer

### DIFF
--- a/app/shell/py/pie/pie/render/html.py
+++ b/app/shell/py/pie/pie/render/html.py
@@ -63,6 +63,8 @@ def render_page(
         render_jinja(md_text),
         options=cmarkgfm.Options.CMARK_OPT_UNSAFE,
     )
+    # cmarkgfm's tagfilter escapes <script> tags even with CMARK_OPT_UNSAFE.
+    # Scripts should be added in templates rather than directly in Markdown.
     ctx["content"] = html_text
     tmpl = env.get_template(template)
     return tmpl.render(**ctx)

--- a/docs/guides/react-index-tree.md
+++ b/docs/guides/react-index-tree.md
@@ -66,13 +66,12 @@ indextree-json docs doc-tree.json
 
 ```markdown
 <div class="indextree-root" data-src="/doc-tree.json"></div>
-<script type="module" src="/static/js/indextree.js" defer></script>
 ```
 
-Any element with the `indextree-root` class marks where a tree renders. Add
-as many as needed on the same page, each with a `data-src` attribute pointing
-to its JSON file. The script loads the JSON and displays a collapsible index
-when the page loads.
+Any element with the `indextree-root` class marks where a tree renders. Add as
+many as needed on the same page, each with a `data-src` attribute pointing to
+its JSON file. Include `indextree.js` in the page template because the Markdown
+renderer escapes `<script>` tags to prevent XSS.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Revert script tag unescaping in `render_page`
- Document that `<script>` tags are escaped by cmarkgfm's tagfilter
- Update IndexTree guide to note scripts must be added via templates

## Testing
- `pytest app/shell/py/pie/tests/test_render_html.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc80cd02e48321b8b8301a2e0bc504