### PR TITLE
examples: add custom template page

### DIFF
--- a/src/examples/custom-template.html
+++ b/src/examples/custom-template.html
@@ -1,0 +1,14 @@
+{% extends "templates/template.html.jinja" %}
+{#--
+  Macro: note
+  Demonstrates Jinja macros. Macros behave like functions and emit reusable
+  HTML snippets. This macro prints a styled note before the default content.
+--#}
+{% macro note(text) -%}
+  <p class="note">{{ text }}</p>
+{%- endmacro %}
+
+{% block content %}
+  {{ note("This page uses a custom template.") }}
+  {{ super() }}
+{% endblock %}

--- a/src/examples/custom-template.md
+++ b/src/examples/custom-template.md
@@ -1,0 +1,13 @@
+The `template` metadata field renders this page with an alternate HTML layout.
+
+```yaml
+template: src/examples/custom-template.html
+```
+
+The snippet above comes from this page's metadata file.
+
+`custom-template.html` defines a `note` macro that outputs a styled paragraph.
+Macros are Jinja's version of functions: they accept arguments and return HTML
+fragments. The `content` block invokes
+`note("This page uses a custom template.")` to display the message before
+delegating back to the default body with `{{ super() }}`.

--- a/src/examples/custom-template.yml
+++ b/src/examples/custom-template.yml
@@ -1,0 +1,12 @@
+author: Brian Lee
+breadcrumbs:
+- title: Home
+  url: /
+- title: Examples
+  url: /examples/
+- title: Custom Template
+citation: custom template
+id: custom_template
+pubdate: Sep 06, 2025
+title: Custom Template
+template: src/examples/custom-template.html


### PR DESCRIPTION
## Summary
- explain how the custom example template defines and uses a `note` macro
- document macro behavior in the sample's accompanying markdown

## Testing
- `pytest` *(fails: Interrupted: 48 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bc847b27108321ba4ceefa3f730f10