### PR TITLE
docs: update render-html usage

### DIFF
--- a/docs/guides/picasso.md
+++ b/docs/guides/picasso.md
@@ -35,24 +35,11 @@ build/index.yml: src/index.yml
     cp $< $@
 build/index.html: build/index.md build/index.yml $(HTML_TEMPLATE) $(BUILD_DIR)/.process-yamls
     $(call status,Generate HTML $@)
-    render-html --template $(HTML_TEMPLATE) $< $@ -c build/index.yml
+    render-html $< build/index.yml $@
 ```
 
 Each metadata file produces similar targets for preprocessing the metadata and
 rendering the final HTML.
-
-## Custom Templates
-
-`picasso` retrieves per-document metadata from Redis. If a document defines a
-`template` path, that file is added as a dependency and passed via
-`--template` to `render-html` when rendering. For example:
-
-```yaml
-template: src/blog/custom-template.html
-```
-
-This allows different pages to use specialized templates while falling back to
-`$(HTML_TEMPLATE)` when no custom template is provided.
 
 The command also inspects Markdown files for cross-document links and any
 `include-filter` Python blocks.  Links added via Jinja globals such as
@@ -63,5 +50,4 @@ of the including document.
 
 If these dependencies form a cycle, `picasso` logs a warning and drops the
 minimum number of rules required to break the loop. The build continues with
-the
-remaining rules.
+the remaining rules.

--- a/docs/reference/keyterms.md
+++ b/docs/reference/keyterms.md
@@ -1,10 +1,14 @@
 # Key Terms Data Flow
 
-This document explains how the `keyterms.json` file is transformed into the final `keyterms.html` page. See [Metadata Fields](metadata-fields.md) for a description of the metadata associated with each term.
+This document explains how the `keyterms.json` file is transformed into the
+final `keyterms.html` page. See
+[Metadata Fields](metadata-fields.md) for a description of the metadata
+associated with each term.
 
 ## Source JSON
 
-The canonical list of terms lives at `src/keyterms/index.json`. Each entry maps an identifier to metadata about the term:
+The canonical list of terms lives at `src/keyterms/index.json`. Each entry maps
+an identifier to metadata about the term:
 
 ```json
 {
@@ -28,7 +32,8 @@ build/%.json: %.json
 
 This rule produces `build/keyterms/index.json` from `src/keyterms/index.json`.
 
-2. **Render Markdown** – The Markdown file `src/keyterms/index.md` loads the JSON data with `read_json` and iterates over each term:
+2. **Render Markdown** – The Markdown file `src/keyterms/index.md` loads the
+JSON data with `read_json` and iterates over each term:
 
 ```
 {% set keyterms = read_json("build/keyterms/index.json") %}
@@ -55,7 +60,7 @@ This rule produces `build/keyterms/index.json` from `src/keyterms/index.json`.
 
 ```
 build/%.html: build/%.md build/%.yml $(HTML_TEMPLATE) | build
-    render-html --template $(HTML_TEMPLATE) $< $@ -c build/$*.yml
+    render-html $< build/$*.yml $@
 ```
 
 ## Verification

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -19,7 +19,6 @@ missing values are automatically generated.
 - `link.class` – CSS class for rendered links.
 - `link.canonical` – Absolute URL for the page.
 - `name` – **Deprecated.** Former display name used in navigation and indexes.
-- `template` – Optional Jinja template path passed to `render-html`.
 
 ## Auto‑Generated Values
 


### PR DESCRIPTION
## Summary
- align picasso guide with current render-html CLI
- update key terms reference example for new render-html syntax
- remove obsolete template metadata field

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest` *(fails: test_picasso, test_render_html)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc4ee95b48321b161df4ba06e9785