### PR TITLE
Add schema version to metadata

### DIFF
--- a/app/shell/py/pie/pie/create/post.py
+++ b/app/shell/py/pie/pie/create/post.py
@@ -6,6 +6,7 @@ from typing import Sequence
 
 from pie.cli import create_parser
 from pie.logging import configure_logging, logger
+from pie.metadata import CURRENT_SCHEMA
 from pie.utils import get_pubdate, write_yaml
 
 
@@ -52,6 +53,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
     breadcrumbs.append({"title": _title_from_slug(rel_parts[-1])})
     metadata = {
+        "schema": CURRENT_SCHEMA,
         "author": "",
         "pubdate": get_pubdate(),
         "title": "",

--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional
 from urllib.parse import urljoin
@@ -14,6 +15,16 @@ from flatten_dict import unflatten
 from pie.logging import logger
 from pie.yaml import YAML_EXTS, read_yaml, yaml
 from ruamel.yaml import YAMLError
+
+
+CURRENT_SCHEMA = "v1"
+
+
+@dataclass
+class MetadataSchema:
+    """Model describing the metadata schema version."""
+
+    schema: str = CURRENT_SCHEMA
 
 
 def get_url(filename: str) -> Optional[str]:
@@ -156,6 +167,7 @@ def generate_missing_metadata(
     _add_canonical_link_if_missing(metadata, filepath)
     _add_citation_if_missing(metadata, filepath)
     _add_id_if_missing(metadata, filepath)
+    _add_if_missing(metadata, 'schema', CURRENT_SCHEMA, filepath)
     _add_empty_if_missing(metadata, 'breadcrumbs', filepath)
     _add_empty_if_missing(metadata, 'description', filepath)
     _add_empty_if_missing(metadata, 'mathjax', filepath)

--- a/app/shell/py/pie/tests/test_create_post.py
+++ b/app/shell/py/pie/tests/test_create_post.py
@@ -8,6 +8,7 @@ yaml = YAML(typ="safe")
 
 from pie.create import post
 from pie.utils import get_pubdate
+from pie.metadata import CURRENT_SCHEMA
 
 
 def test_create_post_creates_files(tmp_path: Path, monkeypatch) -> None:
@@ -22,7 +23,8 @@ def test_create_post_creates_files(tmp_path: Path, monkeypatch) -> None:
     assert yml_file.exists(), "YAML file should be created"
 
     data = yaml.load(yml_file.read_text(encoding="utf-8"))
-    assert set(data) == {"author", "pubdate", "title", "breadcrumbs"}
+    assert set(data) == {"schema", "author", "pubdate", "title", "breadcrumbs"}
+    assert data["schema"] == CURRENT_SCHEMA
     assert data["pubdate"] == get_pubdate()
     assert data["breadcrumbs"] == [
         {"title": "Home", "url": "/"},

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -7,6 +7,11 @@ import ruamel.yaml as yaml
 from pie import metadata
 
 
+def test_metadata_schema_default():
+    model = metadata.MetadataSchema()
+    assert model.schema == metadata.CURRENT_SCHEMA
+
+
 def test_get_url_from_src_md(tmp_path):
     """'src/foo.md' -> '/foo.html'."""
     path = tmp_path / "src" / "foo.md"
@@ -47,6 +52,7 @@ def test__read_from_markdown_generates_fields(tmp_path):
     assert data["url"] == "/doc.html"
     assert data["citation"] == "t"
     assert data["id"] == "doc"
+    assert data["schema"] == metadata.CURRENT_SCHEMA
 
 
 def test_read_from_yaml_generates_fields(tmp_path):
@@ -65,6 +71,7 @@ def test_read_from_yaml_generates_fields(tmp_path):
     assert data["url"] == "/item.html"
     assert data["citation"] == "foo"
     assert data["id"] == "item"
+    assert data["schema"] == metadata.CURRENT_SCHEMA
 
 
 def test_load_metadata_pair_conflict_shows_path(tmp_path, monkeypatch):

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -6,6 +6,7 @@ missing values are automatically generated.
 ## Required
 
 - `title` – Heading shown in the rendered page.
+- `schema` – Schema version string, currently `v1`.
 
 ## Optional Fields
 
@@ -31,6 +32,7 @@ several fields when they are missing:
 | `citation` | Lowercase form of the `title` value            |
 | `url`      | Derived from the source path (e.g. `src/foo.md` → `/foo.html`) |
 | `link.canonical` | Absolute form of the `url` value              |
+| `schema`   | `v1`                                           |
 
 The `citation` value is used as the anchor text when other pages link to this
 document using Jinja globals such as `linktitle`. The helper that assigns these

--- a/src/examples/anchor/index.yml
+++ b/src/examples/anchor/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
 - title: Home

--- a/src/examples/blog/index.yml
+++ b/src/examples/blog/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
 - title: Home

--- a/src/examples/breadcrumbs/index.yml
+++ b/src/examples/breadcrumbs/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 title: Breadcrumb Demo
 author: Ada Lovelace
 id: breadcrumb_demo

--- a/src/examples/breadcrumbs/multi-level/index.yml
+++ b/src/examples/breadcrumbs/multi-level/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 title: Nested Breadcrumb Demo
 author: Ada Lovelace
 id: nested_breadcrumb_demo

--- a/src/examples/chicago-citations.yml
+++ b/src/examples/chicago-citations.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
 - title: Home

--- a/src/examples/custom-template.yml
+++ b/src/examples/custom-template.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
 - title: Home

--- a/src/examples/doe.yml
+++ b/src/examples/doe.yml
@@ -1,3 +1,4 @@
+schema: v1
 title: Example Book
 citation:
   author: Doe

--- a/src/examples/hull.yml
+++ b/src/examples/hull.yml
@@ -1,3 +1,4 @@
+schema: v1
 title: Options, Futures, and Other Derivatives
 citation:
   author: Hull

--- a/src/examples/index.yml
+++ b/src/examples/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
 - title: Home

--- a/src/examples/indextree/index.yml
+++ b/src/examples/indextree/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
 - title: Home

--- a/src/examples/jinja.yml
+++ b/src/examples/jinja.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
   - title: Home

--- a/src/examples/link-globals.yml
+++ b/src/examples/link-globals.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
 - title: Home

--- a/src/examples/mermaid/index.yml
+++ b/src/examples/mermaid/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 id: mermaid-example
 pubdate: Aug 22, 2025

--- a/src/examples/responsive-images.yml
+++ b/src/examples/responsive-images.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
 - title: Home

--- a/src/gen-markdown-index/d1/index.yml
+++ b/src/gen-markdown-index/d1/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 title: d1
 id: d1
 author: Brian Lee

--- a/src/gen-markdown-index/f0.yml
+++ b/src/gen-markdown-index/f0.yml
@@ -1,3 +1,4 @@
+schema: v1
 title: f0
 id: f0
 author: Brian Lee

--- a/src/gen-markdown-index/index.yml
+++ b/src/gen-markdown-index/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 title: gen-markdown-index
 id: dist_gen_markdown_index
 indextree:

--- a/src/include-filter/a.yml
+++ b/src/include-filter/a.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
   - title: Home

--- a/src/include-filter/b.yml
+++ b/src/include-filter/b.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
   - title: Home

--- a/src/include-filter/index.yml
+++ b/src/include-filter/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 title: include-filter
 id: dist_include_filter
 author: Brian Lee

--- a/src/index.yml
+++ b/src/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
 - title: Home

--- a/src/links/citation.yml
+++ b/src/links/citation.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 citation:
   short: short

--- a/src/links/index.yml
+++ b/src/links/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 breadcrumbs:
 - title: Home

--- a/src/links/press_io_home.yml
+++ b/src/links/press_io_home.yml
@@ -1,3 +1,4 @@
+schema: v1
 citation: press.io home
 title: press.io home
 url: https://press.io

--- a/src/magicbar/index.yml
+++ b/src/magicbar/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 title: MagicBar Demo
 id: magicbar
 author: Brian Lee

--- a/src/quickstart.yml
+++ b/src/quickstart.yml
@@ -1,3 +1,4 @@
+schema: v1
 author: Brian Lee
 citation: quickstart
 id: quickstart

--- a/src/quiz/index.yml
+++ b/src/quiz/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 title: Quiz
 id: quiz
 author: Brian Lee


### PR DESCRIPTION
## Summary
- add `schema: v1` to metadata defaults and files
- model metadata schema with a dataclass
- document new schema field

## Testing
- `pytest tests/test_metadata.py tests/test_create_post.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_68bcca044060832185ac3fb64e2380c5