### PR TITLE
test: expect canonical link with base url

### DIFF
--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -135,11 +135,12 @@ def test__add_canonical_link_if_missing_no_url():
     assert "doc" not in info
 
 
-def test__add_canonical_link_if_missing_sets_value():
-    """URL present populates ``doc.link.canonical``."""
+def test__add_canonical_link_if_missing_sets_value(monkeypatch):
+    """URL present populates ``doc.link.canonical`` using ``BASE_URL``."""
+    monkeypatch.setenv("BASE_URL", "http://press.io")
     info = {"url": "/foo"}
     metadata._add_canonical_link_if_missing(info, "doc.md")
-    assert info["doc"]["link"]["canonical"] == "/foo"
+    assert info["doc"]["link"]["canonical"] == "http://press.io/foo"
 
 
 def test__get_redis_value_missing_returns_none():


### PR DESCRIPTION
## Summary
- ensure metadata canonical link honors BASE_URL in tests

## Testing
- `pytest app/shell/py/pie/tests/test_metadata.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcd17dc4308321b32e784af9206c78