### PR TITLE
style: add bootstrap styling for code blocks

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -261,3 +261,32 @@ th {
 tbody tr:nth-of-type(even) {
   background-color: #f2f2f2;
 }
+
+/* Code blocks */
+pre,
+code {
+  font-family: var(--bs-font-monospace);
+}
+
+pre {
+  padding: 1rem;
+  background-color: var(--bs-light);
+  border: 1px solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  overflow-x: auto;
+}
+
+code {
+  padding: 0.2rem 0.4rem;
+  font-size: 1em;
+  color: var(--bs-code-color);
+  background-color: var(--bs-light);
+  border-radius: var(--bs-border-radius);
+}
+
+pre code {
+  padding: 0;
+  color: inherit;
+  background-color: transparent;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- use Bootstrap variables to style `<pre>` and `<code>` blocks with monospace fonts, padding, and light backgrounds

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'ruamel'; Error: File type "" not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd1592bc083218d61694f2f689939