### PR TITLE
Ensure check-author validates doc.author

### DIFF
--- a/app/shell/py/pie/pie/check/author.py
+++ b/app/shell/py/pie/pie/check/author.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify that metadata files define an author."""
+"""Verify that metadata files define ``doc.author``."""
 
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ DEFAULT_LOG = "log/check-author.txt"
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = create_parser(
-        "Check that metadata files include an author field.",
+        "Check that metadata files include a doc.author field.",
         log_default=DEFAULT_LOG,
     )
     parser.add_argument(
@@ -63,12 +63,12 @@ def main(argv: list[str] | None = None) -> int:
     root = Path(args.directory)
     ok = True
     for paths, meta in _iter_metadata(root):
-        author = meta.get("author") if meta else None
+        author = meta.get("doc", {}).get("author") if meta else None
         for path in paths:
             if author:
-                logger.debug("Found author", path=str(path), author=author)
+                logger.debug("Found doc.author", path=str(path), author=author)
             else:
-                logger.error("Missing author", path=str(path))
+                logger.error("Missing doc.author", path=str(path))
                 ok = False
     return 0 if ok else 1
 

--- a/app/shell/py/pie/tests/test_check_author.py
+++ b/app/shell/py/pie/tests/test_check_author.py
@@ -6,7 +6,7 @@ from pie.check import author as check_author
 
 
 def test_main_reports_missing(tmp_path: Path, monkeypatch) -> None:
-    """YAML without author -> exit code 1."""
+    """YAML without doc.author -> exit code 1."""
     src = tmp_path / "src"
     src.mkdir()
     yml = src / "doc.yml"
@@ -21,15 +21,20 @@ def test_main_reports_missing(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_main_passes_and_logs(tmp_path: Path, monkeypatch) -> None:
-    """YAML with author -> exit 0 and write log."""
+    """YAML with doc.author -> exit 0 and write log."""
     src = tmp_path / "src"
     src.mkdir()
     yml = src / "doc.yml"
-    yml.write_text("title: Test\nauthor: Jane Doe\n", encoding="utf-8")
+    yml.write_text("title: Test\ndoc:\n  author: Jane Doe\n", encoding="utf-8")
     md = src / "doc.md"
-    md.write_text("---\ntitle: Test\nauthor: Jane Doe\n---\n", encoding="utf-8")
+    md.write_text(
+        "---\ntitle: Test\ndoc:\n  author: Jane Doe\n---\n",
+        encoding="utf-8",
+    )
     yaml_file = src / "other.yaml"
-    yaml_file.write_text("title: Other\nauthor: Jane Doe\n", encoding="utf-8")
+    yaml_file.write_text(
+        "title: Other\ndoc:\n  author: Jane Doe\n", encoding="utf-8"
+    )
     log = tmp_path / "log.txt"
     monkeypatch.chdir(tmp_path)
     rc = check_author.main(["-l", str(log)])


### PR DESCRIPTION
## Summary
- check for the `doc.author` field when validating metadata
- adjust tests to cover the new `doc.author` requirement

## Testing
- `pytest app/shell/py/pie/tests/test_check_author.py`

------
https://chatgpt.com/codex/tasks/task_e_68bcd28dfc60832198272bdbbd3c092b