### PR TITLE
feat: migrate title field

### DIFF
--- a/app/shell/py/pie/pie/update/migrate_metadata.py
+++ b/app/shell/py/pie/pie/update/migrate_metadata.py
@@ -13,7 +13,7 @@ from pie.yaml import YAML_EXTS, yaml, write_yaml
 
 __all__ = ["main"]
 
-FIELDS = ("author", "pubdate", "link")
+FIELDS = ("author", "pubdate", "link", "title")
 
 
 def _migrate_mapping(data: dict) -> tuple[dict, bool]:

--- a/app/shell/py/pie/tests/update/test_migrate_metadata.py
+++ b/app/shell/py/pie/tests/update/test_migrate_metadata.py
@@ -24,17 +24,21 @@ def test_moves_fields_under_doc(tmp_path: Path, capsys) -> None:
     migrate_metadata.main([str(src)])
 
     data = yaml.load(yml.read_text(encoding="utf-8"))
+    assert data["doc"]["title"] == "T"
     assert data["doc"]["author"] == "A"
     assert data["doc"]["pubdate"] == "Jan 1, 2020"
     assert data["doc"]["link"] == {"class": "x"}
+    assert "title" not in data
     assert "author" not in data
     assert "pubdate" not in data
     assert "link" not in data
 
     md_data = yaml.load(md.read_text(encoding="utf-8").split("---\n", 2)[1])
+    assert md_data["doc"]["title"] == "T"
     assert md_data["doc"]["author"] == "A"
     assert md_data["doc"]["pubdate"] == "Jan 1, 2020"
     assert md_data["doc"]["link"] == {"tracking": False}
+    assert "title" not in md_data
 
     out_lines = capsys.readouterr().out.strip().splitlines()
     assert f"{yml}: migrated" in out_lines

--- a/docs/reference/migrate-metadata.md
+++ b/docs/reference/migrate-metadata.md
@@ -1,7 +1,7 @@
 # migrate-metadata
 
-Move legacy top-level `author`, `pubdate`, and `link` fields under the `doc`
-mapping. This script scans the provided files or directories and rewrites
+Move legacy top-level `author`, `pubdate`, `link`, and `title` fields under the
+`doc` mapping. This script scans the provided files or directories and rewrites
 Markdown front matter and YAML metadata in place.
 
 ```bash


### PR DESCRIPTION
## Summary
- move top-level `title` into `doc.title` during metadata migration
- document new `title` migration
- test moving `title` under `doc`

## Testing
- `pytest app/shell/py/pie/tests/update/test_migrate_metadata.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcd70adc3883219a3141fba85a2483