### PR TITLE
feat: add metadata schema

### DIFF
--- a/app/shell/py/pie/pie/__init__.py
+++ b/app/shell/py/pie/pie/__init__.py
@@ -32,6 +32,7 @@ __all__ = [
     "render_study_json",
     "gen_markdown_index",
     "process_yaml",
+    "schema",
     "yaml",
     "build",
     "check",

--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -14,6 +14,7 @@ from flatten_dict import unflatten
 from pie.logging import logger
 from pie.yaml import YAML_EXTS, read_yaml, yaml
 from ruamel.yaml import YAMLError
+from pie.schema import DEFAULT_SCHEMA
 
 
 def get_url(filename: str) -> Optional[str]:
@@ -176,6 +177,7 @@ def generate_missing_metadata(
     _add_empty_if_missing(metadata, 'twitter_card', filepath)
     _add_empty_if_missing(metadata, 'twitter_image', filepath)
     _add_empty_if_missing(metadata, 'pubdate', filepath)
+    _add_if_missing(metadata, 'schema', DEFAULT_SCHEMA, filepath)
     _add_if_missing(metadata, 'css', ['/css/style.css'], filepath)
     _add_if_missing(metadata, 'header', {'header':None}, filepath)
     _add_if_missing(metadata, 'header_includes', [], filepath)

--- a/app/shell/py/pie/pie/schema.py
+++ b/app/shell/py/pie/pie/schema.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Data model for metadata schema versioning."""
+
+from dataclasses import dataclass
+
+DEFAULT_SCHEMA = "v1"
+
+__all__ = ["Schema", "DEFAULT_SCHEMA"]
+
+
+@dataclass
+class Schema:
+    """Metadata schema information."""
+
+    schema: str = DEFAULT_SCHEMA

--- a/app/shell/py/pie/pie/templates/metadata.yml.jinja
+++ b/app/shell/py/pie/pie/templates/metadata.yml.jinja
@@ -1,3 +1,4 @@
+schema: v1
 id: {{ file_id }}
 doc:
   author: ""

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -47,6 +47,7 @@ def test__read_from_markdown_generates_fields(tmp_path):
     assert data["url"] == "/doc.html"
     assert data["citation"] == "t"
     assert data["id"] == "doc"
+    assert data["schema"] == "v1"
 
 
 def test_read_from_yaml_generates_fields(tmp_path):
@@ -65,6 +66,14 @@ def test_read_from_yaml_generates_fields(tmp_path):
     assert data["url"] == "/item.html"
     assert data["citation"] == "foo"
     assert data["id"] == "item"
+    assert data["schema"] == "v1"
+
+
+def test_schema_default():
+    """Schema dataclass defaults to current version."""
+    from pie.schema import Schema
+
+    assert Schema().schema == "v1"
 
 
 def test_load_metadata_pair_conflict_shows_path(tmp_path, monkeypatch):

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -28,6 +28,7 @@ several fields when they are missing:
 
 | Field      | Default value                                  |
 | ---------- | ---------------------------------------------- |
+| `schema`   | Current metadata schema version (`"v1"`)       |
 | `id`       | Filename without the extension                 |
 | `citation` | Lowercase form of the `title` value            |
 | `url`      | Derived from the source path (e.g. `src/foo.md` → `/foo.html`) |

--- a/src/examples/anchor/index.yml
+++ b/src/examples/anchor/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/examples/blog/index.yml
+++ b/src/examples/blog/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/examples/breadcrumbs/index.yml
+++ b/src/examples/breadcrumbs/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/examples/breadcrumbs/multi-level/index.yml
+++ b/src/examples/breadcrumbs/multi-level/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/examples/chicago-citations.yml
+++ b/src/examples/chicago-citations.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/examples/custom-template.yml
+++ b/src/examples/custom-template.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/examples/doe.yml
+++ b/src/examples/doe.yml
@@ -1,3 +1,4 @@
+schema: v1
 citation:
   author: Doe
   page: 42

--- a/src/examples/hull.yml
+++ b/src/examples/hull.yml
@@ -1,3 +1,4 @@
+schema: v1
 citation:
   author: Hull
   page: 307

--- a/src/examples/index.yml
+++ b/src/examples/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/examples/indextree/index.yml
+++ b/src/examples/indextree/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/examples/jinja.yml
+++ b/src/examples/jinja.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/examples/link-globals.yml
+++ b/src/examples/link-globals.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/examples/mermaid/index.yml
+++ b/src/examples/mermaid/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/examples/responsive-images.yml
+++ b/src/examples/responsive-images.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/gen-markdown-index/d1/index.yml
+++ b/src/gen-markdown-index/d1/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/gen-markdown-index/f0.yml
+++ b/src/gen-markdown-index/f0.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/gen-markdown-index/index.yml
+++ b/src/gen-markdown-index/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/include-filter/a.yml
+++ b/src/include-filter/a.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/include-filter/b.yml
+++ b/src/include-filter/b.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/include-filter/index.yml
+++ b/src/include-filter/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/index.yml
+++ b/src/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
 description: Example home page

--- a/src/links/citation.yml
+++ b/src/links/citation.yml
@@ -1,3 +1,4 @@
+schema: v1
 citation:
   short: short
 doc:

--- a/src/links/index.yml
+++ b/src/links/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/links/press_io_home.yml
+++ b/src/links/press_io_home.yml
@@ -1,3 +1,4 @@
+schema: v1
 citation: press.io home
 doc:
   author: Brian Lee

--- a/src/magicbar/index.yml
+++ b/src/magicbar/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/quickstart.yml
+++ b/src/quickstart.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /

--- a/src/quiz/index.yml
+++ b/src/quiz/index.yml
@@ -1,3 +1,4 @@
+schema: v1
 breadcrumbs:
 - title: Home
   url: /


### PR DESCRIPTION
## Summary
- add dataclass to model metadata schema version
- include schema field in metadata generation and templates
- document schema usage and add to existing metadata files

## Testing
- `pytest app/shell/py/pie/tests/test_metadata.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'emoji')*

------
https://chatgpt.com/codex/tasks/task_e_68bcd6b530188321a69090c778cbbb0c