### PR TITLE
feat: use header_includes for indextree script

### DIFF
--- a/docs/guides/react-index-tree.md
+++ b/docs/guides/react-index-tree.md
@@ -70,8 +70,8 @@ indextree-json docs doc-tree.json
 
 Any element with the `indextree-root` class marks where a tree renders. Add as
 many as needed on the same page, each with a `data-src` attribute pointing to
-its JSON file. Include `indextree.js` in the page template because the Markdown
-renderer escapes `<script>` tags to prevent XSS.
+its JSON file. Load `indextree.js` through the page's `header_includes`
+metadata; Markdown escapes `<script>` tags to prevent XSS.
 
 ## Usage
 

--- a/src/examples/index.yml
+++ b/src/examples/index.yml
@@ -8,6 +8,7 @@ doc:
   pubdate: Sep 07, 2025
 id: examples
 indextree:
-  include-js: true
   link: true
+header_includes:
+  - '<script type="module" src="/static/js/indextree.js" defer></script>'
 title: Examples

--- a/src/examples/indextree/index.md
+++ b/src/examples/indextree/index.md
@@ -20,5 +20,4 @@ indextree-json -t demo files tagged.json
 
 ## Tagged
 <div class="indextree-root" data-src="/examples/indextree/tagged.json"></div>
-<script type="module" src="/static/js/indextree.js" defer></script>
 {% endblock %}

--- a/src/examples/indextree/index.yml
+++ b/src/examples/indextree/index.yml
@@ -8,4 +8,6 @@ doc:
   author: Brian Lee
   pubdate: Aug 27, 2025
 id: indextree-demo
+header_includes:
+  - '<script type="module" src="/static/js/indextree.js" defer></script>'
 title: IndexTree Demo

--- a/src/index.yml
+++ b/src/index.yml
@@ -5,8 +5,8 @@ doc:
   author: Brian Lee
   pubdate: Sep 07, 2025
 id: home
-indextree:
-  include-js: true
+header_includes:
+  - '<script type="module" src="/static/js/indextree.js" defer></script>'
 og_image: /img/home.png
 title: Home
 toc: false

--- a/src/templates/template.html.jinja
+++ b/src/templates/template.html.jinja
@@ -212,8 +212,6 @@
       </nav>
       {% endif %}
 
-      <!-- Optional scripts and footers can be included similarly -->
-      {% for header_include in header_includes %} {{ header_include | safe }} {% endfor %}
     </main>
 
     <footer class="footer p-5 bg-dark text-white text-center">
@@ -222,6 +220,10 @@
         <small>Published using Press</small>
       </p>
     </footer>
+
+    {% for header_include in header_includes %}
+    {{ header_include | safe }}
+    {% endfor %}
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"></script>
     <script>
@@ -250,9 +252,6 @@
       async
       src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"
     ></script>
-    {% endif %}
-    {% if indextree is defined and indextree.get("include-js") %}
-    <script type="module" src="/static/js/indextree.js" defer></script>
     {% endif %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- render optional indextree script via generic header_includes hook
- add indextree script tag to pages using header_includes metadata
- drop legacy indextree.include-js references in docs and examples

## Testing
- `pip install -r app/shell/py/pie/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcd59096848321ade4747f7da7b5bf