### PR TITLE
test: cover emoji rendering

### DIFF
--- a/app/shell/py/pie/tests/test_render_jinja.py
+++ b/app/shell/py/pie/tests/test_render_jinja.py
@@ -86,3 +86,14 @@ def test_parse_args_parses_values():
     assert args.output == "out"
     assert args.index == "i.json"
     assert args.config == "cfg.yml"
+
+
+def test_render_press_replaces_alias():
+    html = jinja.render_press("Hi :smile:")
+    assert str(html) == "<p>Hi 😄</p>\n"
+
+
+def test_render_press_ignores_unknown_alias():
+    html = jinja.render_press("Hi :does_not_exist:")
+    assert str(html) == "<p>Hi :does_not_exist:</p>\n"
+


### PR DESCRIPTION
## Summary
- add tests for render_press emoji replacement and unknown aliases

## Testing
- `PYTHONPATH=app/shell/py/pie pytest app/shell/py/pie/tests/test_render_jinja.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bce03954a08321bc564b61cda02685