### PR TITLE
feat: nest citation under doc metadata

### DIFF
--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -79,18 +79,19 @@ def _add_url_if_missing(metadata: dict[str, Any], filepath: str) -> None:
 
 
 def _add_citation_if_missing(metadata: dict[str, Any], filepath: str) -> None:
-    """Derive ``citation`` from ``title`` or deprecated ``name``."""
+    """Derive ``doc.citation`` from ``doc.title`` or deprecated ``name``."""
 
-    if "citation" not in metadata:
-        title = metadata.get("title")
+    doc = metadata.setdefault("doc", {})
+    if "citation" not in doc:
+        title = doc.get("title") or metadata.get("title")
         if title:
-            metadata["citation"] = title.lower()
+            doc["citation"] = title.lower()
         elif "name" in metadata:
             logger.warning(
                 "'name' field is deprecated; use 'title' instead",
                 filename=filepath,
             )
-            metadata["citation"] = metadata["name"].lower()
+            doc["citation"] = metadata["name"].lower()
 
 
 def _add_id_if_missing(metadata: dict[str, Any], filepath: str) -> None:

--- a/app/shell/py/pie/pie/update/migrate_metadata.py
+++ b/app/shell/py/pie/pie/update/migrate_metadata.py
@@ -13,7 +13,7 @@ from pie.yaml import YAML_EXTS, yaml, write_yaml
 
 __all__ = ["main"]
 
-FIELDS = ("author", "pubdate", "link", "title")
+FIELDS = ("author", "pubdate", "link", "title", "citation")
 
 
 def _migrate_mapping(data: dict) -> tuple[dict, bool]:
@@ -89,7 +89,7 @@ def walk_files(paths: Iterable[Path]) -> Iterable[Path]:
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = create_parser(
-        "Move top-level author/pubdate/link fields under doc",
+        "Move top-level author/pubdate/link/title/citation fields under doc",
         log_default="log/migrate-metadata.txt",
     )
     parser.add_argument("paths", nargs="+", help="Files or directories to scan")

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -32,7 +32,7 @@ def test_get_url_invalid_raises(tmp_path):
 
 
 def test__read_from_markdown_generates_fields(tmp_path):
-    """Frontmatter {'title': 'T'} -> url/id/citation added."""
+    """Frontmatter {'title': 'T'} -> url/id/doc.citation added."""
     md = tmp_path / "src" / "doc.md"
     md.parent.mkdir(parents=True)
     md.write_text("---\n{\"title\": \"T\"}\n---\nbody")
@@ -45,13 +45,13 @@ def test__read_from_markdown_generates_fields(tmp_path):
         os.chdir("/tmp")
     assert data["title"] == "T"
     assert data["url"] == "/doc.html"
-    assert data["citation"] == "t"
+    assert data["doc"]["citation"] == "t"
     assert data["id"] == "doc"
     assert data["schema"] == "v1"
 
 
 def test_read_from_yaml_generates_fields(tmp_path):
-    """YAML {'title': 'Foo'} -> metadata with url/id/citation."""
+    """YAML {'title': 'Foo'} -> metadata with url/id/doc.citation."""
     yml = tmp_path / "src" / "item.yml"
     yml.parent.mkdir(parents=True)
     yml.write_text('{"title": "Foo"}')
@@ -64,7 +64,7 @@ def test_read_from_yaml_generates_fields(tmp_path):
         os.chdir("/tmp")
     assert data["title"] == "Foo"
     assert data["url"] == "/item.html"
-    assert data["citation"] == "foo"
+    assert data["doc"]["citation"] == "foo"
     assert data["id"] == "item"
     assert data["schema"] == "v1"
 
@@ -124,10 +124,10 @@ def test_get_url_from_build_md(tmp_path):
 
 
 def test__add_citation_if_missing_from_name():
-    """Deprecated 'name' populates 'citation'."""
+    """Deprecated 'name' populates 'doc.citation'."""
     info = {"name": "Example"}
     metadata._add_citation_if_missing(info, "doc.md")
-    assert info["citation"] == "example"
+    assert info["doc"]["citation"] == "example"
 
 
 def test__add_canonical_link_if_missing_existing():

--- a/app/shell/py/pie/tests/test_render_jinja.py
+++ b/app/shell/py/pie/tests/test_render_jinja.py
@@ -10,7 +10,7 @@ from jinja2 import FileSystemLoader, TemplateSyntaxError
 from pie.render import jinja
 
 def test_resolve_citation_pages_list():
-    desc = {"citation": {"author": "smith", "year": 1999, "page": [1, 2]}}
+    desc = {"doc": {"citation": {"author": "smith", "year": 1999, "page": [1, 2]}}}
     text, needs_parens = jinja._resolve_citation(desc, "citation")
     assert text == "Smith 1999, 1, 2"
     assert needs_parens is True
@@ -69,7 +69,7 @@ def test_definition_missing_snippet_returns_empty():
     assert jinja.definition({}) == ""
 
 def test_cite_with_simple_string_citation(monkeypatch):
-    desc = {"citation": "Simple", "url": "u", "title": "T"}
+    desc = {"doc": {"citation": "Simple"}, "url": "u", "title": "T"}
 
     def fake_get(name: str):
         return desc

--- a/app/shell/py/pie/tests/test_render_template.py
+++ b/app/shell/py/pie/tests/test_render_template.py
@@ -5,14 +5,14 @@ from pie import metadata
 
 
 def test_default_class():
-    desc = {"citation": "foo", "url": "/f"}
+    desc = {"doc": {"citation": "foo"}, "url": "/f"}
     html = render_template.render_link(desc, style="title")
     assert 'class="internal-link"' in html
 
 
 def test_override_class():
     """link.class overrides default."""
-    desc = {"citation": "foo", "url": "/f", "link": {"class": "external"}}
+    desc = {"doc": {"citation": "foo"}, "url": "/f", "link": {"class": "external"}}
     html = render_template.render_link(desc, style="title")
     assert 'class="external"' in html
 
@@ -33,7 +33,7 @@ def test_tracking_true_returns_empty():
 
 def test_no_link_returns_empty():
     """No link section -> empty options."""
-    desc = {"citation": "foo"}
+    desc = {"doc": {"citation": "foo"}}
     opts = render_template.get_tracking_options(desc)
     assert opts == ""
 
@@ -48,7 +48,7 @@ def test_missing_tracking_returns_empty():
 def test_linktitle_uses_redis(monkeypatch):
     """Redis provides citation and url."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("item.citation", "Item")
+    fake.set("item.doc.citation", "Item")
     fake.set("item.url", "/i")
     monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
@@ -70,7 +70,7 @@ def test_linktitle_missing_raises(monkeypatch):
 
 def test_linktitle_skips_small_words():
     """Title style capitalizes but skips small words."""
-    desc = {"citation": "movement in a circle", "url": "/c"}
+    desc = {"doc": {"citation": "movement in a circle"}, "url": "/c"}
     html = render_template.render_link(desc, style="title")
     assert ">Movement in a Circle<" in html
 
@@ -78,7 +78,7 @@ def test_linktitle_skips_small_words():
 def test_link_uses_redis_tracking_and_ignores_icon(monkeypatch):
     """Redis data with tracking adds attrs, icon skipped."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("entry.citation", "link text")
+    fake.set("entry.doc.citation", "link text")
     fake.set("entry.url", "/link")
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
@@ -96,7 +96,7 @@ def test_link_uses_redis_tracking_and_ignores_icon(monkeypatch):
 def test_linkcap_includes_icon_and_capitalizes(monkeypatch):
     """style='cap' prepends icon and capitalizes first word."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("entry.citation", "foo bar")
+    fake.set("entry.doc.citation", "foo bar")
     fake.set("entry.url", "/link")
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
@@ -113,7 +113,7 @@ def test_linkcap_includes_icon_and_capitalizes(monkeypatch):
 def test_linkicon_includes_icon_without_capitalization(monkeypatch):
     """Default style shows icon; citation unchanged."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("entry.citation", "foo bar")
+    fake.set("entry.doc.citation", "foo bar")
     fake.set("entry.url", "/link")
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
@@ -130,7 +130,7 @@ def test_linkicon_includes_icon_without_capitalization(monkeypatch):
 def test_link_icon_title_capitalizes_each_word_and_includes_icon(monkeypatch):
     """style='title' capitalizes all words and shows icon."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("entry.citation", "foo bar")
+    fake.set("entry.doc.citation", "foo bar")
     fake.set("entry.url", "/link")
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
@@ -146,7 +146,7 @@ def test_link_icon_title_capitalizes_each_word_and_includes_icon(monkeypatch):
 def test_linkshort_uses_short_citation_and_ignores_icon(monkeypatch):
     """citation='short' uses short text without icon."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("entry.citation.short", "Short")
+    fake.set("entry.doc.citation.short", "Short")
     fake.set("entry.url", "/link")
     fake.set("entry.icon", "ICON")
     fake.set("entry.link.tracking", "false")
@@ -162,9 +162,9 @@ def test_linkshort_uses_short_citation_and_ignores_icon(monkeypatch):
 def test_link_handles_citation_metadata(monkeypatch):
     """Bibliographic citation dict -> formatted text."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("hull.citation.author", "hull")
-    fake.set("hull.citation.year", "2016")
-    fake.set("hull.citation.page", "307")
+    fake.set("hull.doc.citation.author", "hull")
+    fake.set("hull.doc.citation.year", "2016")
+    fake.set("hull.doc.citation.page", "307")
     fake.set("hull.url", "/hull")
     monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
@@ -175,7 +175,7 @@ def test_link_handles_citation_metadata(monkeypatch):
 
 def test_render_link_with_anchor():
     """anchor='bar' -> href endswith '#bar'."""
-    desc = {"citation": "foo", "url": "/f"}
+    desc = {"doc": {"citation": "foo"}, "url": "/f"}
     html = render_template.render_link(desc, anchor="bar")
     assert '<a href="/f#bar"' in html
 
@@ -183,7 +183,7 @@ def test_render_link_with_anchor():
 def test_wrapper_accepts_anchor(monkeypatch):
     """link() adds anchor to href."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("entry.citation", "Foo")
+    fake.set("entry.doc.citation", "Foo")
     fake.set("entry.url", "/link")
     monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
@@ -195,9 +195,9 @@ def test_wrapper_accepts_anchor(monkeypatch):
 def test_cite_single(monkeypatch):
     """Single citation renders with parentheses inside the link."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("hull.citation.author", "hull")
-    fake.set("hull.citation.year", "2016")
-    fake.set("hull.citation.page", "307")
+    fake.set("hull.doc.citation.author", "hull")
+    fake.set("hull.doc.citation.year", "2016")
+    fake.set("hull.doc.citation.page", "307")
     fake.set("hull.url", "/hull")
     monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
@@ -210,13 +210,13 @@ def test_cite_single(monkeypatch):
 def test_cite_combines_pages(monkeypatch):
     """Multiple pages for same source are grouped into one link."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("hull1.citation.author", "hull")
-    fake.set("hull1.citation.year", "2016")
-    fake.set("hull1.citation.page", "307")
+    fake.set("hull1.doc.citation.author", "hull")
+    fake.set("hull1.doc.citation.year", "2016")
+    fake.set("hull1.doc.citation.page", "307")
     fake.set("hull1.url", "/hull")
-    fake.set("hull2.citation.author", "hull")
-    fake.set("hull2.citation.year", "2016")
-    fake.set("hull2.citation.page", "311")
+    fake.set("hull2.doc.citation.author", "hull")
+    fake.set("hull2.doc.citation.year", "2016")
+    fake.set("hull2.doc.citation.page", "311")
     fake.set("hull2.url", "/hull")
     monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}
@@ -229,13 +229,13 @@ def test_cite_combines_pages(monkeypatch):
 def test_cite_multiple_sources(monkeypatch):
     """Different sources produce multiple links separated by ';'."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("hull.citation.author", "hull")
-    fake.set("hull.citation.year", "2016")
-    fake.set("hull.citation.page", "307")
+    fake.set("hull.doc.citation.author", "hull")
+    fake.set("hull.doc.citation.year", "2016")
+    fake.set("hull.doc.citation.page", "307")
     fake.set("hull.url", "/hull")
-    fake.set("x.citation.author", "x")
-    fake.set("x.citation.year", "2016")
-    fake.set("x.citation.page", "311")
+    fake.set("x.doc.citation.author", "x")
+    fake.set("x.doc.citation.year", "2016")
+    fake.set("x.doc.citation.page", "311")
     fake.set("x.url", "/x")
     monkeypatch.setattr(metadata, "redis_conn", fake)
     render_template.index_json = {}

--- a/app/shell/py/pie/tests/test_render_template_extra.py
+++ b/app/shell/py/pie/tests/test_render_template_extra.py
@@ -43,14 +43,14 @@ def test_get_redis_value_error(monkeypatch):
 def test_build_from_redis_initialises(monkeypatch):
     """_build_from_redis lazy-loads connection."""
     fake = fakeredis.FakeRedis(decode_responses=True)
-    fake.set("entry.citation", '"Foo"')
+    fake.set("entry.doc.citation", '"Foo"')
     fake.set("entry.url", '"/foo"')
     monkeypatch.setattr(metadata, "redis_conn", None)
     monkeypatch.setattr(
         metadata.redis, "Redis", lambda host, port, decode_responses: fake
     )
     assert metadata.build_from_redis("entry.") == {
-        "citation": "Foo",
+        "doc": {"citation": "Foo"},
         "url": "/foo",
     }
 
@@ -78,26 +78,26 @@ def test_get_cached_metadata_caches(monkeypatch):
 
 def test_render_link_uses_citation_dict():
     """citation dict with 'alt' renders that text."""
-    desc = {"citation": {"citation": "Foo", "alt": "Alt"}, "url": "/f"}
+    desc = {"doc": {"citation": {"citation": "Foo", "alt": "Alt"}}, "url": "/f"}
     html = render_template.render_link(desc, citation="alt", use_icon=False)
     assert ">Alt<" in html
 
 
 def test_render_link_handles_citation_metadata():
     """citation with author/year/page formats like cite."""
-    desc = {"citation": {"author": "hull", "year": "2016", "page": "307"}, "url": "/h"}
+    desc = {"doc": {"citation": {"author": "hull", "year": "2016", "page": "307"}}, "url": "/h"}
     html = render_template.render_link(desc, use_icon=False)
     assert ">(Hull 2016, 307)<" in html
 
 
 def test_wrapper_functions():
     """Wrapper helpers render variants of links."""
-    desc = {"citation": "foo bar", "url": "/f", "icon": "I"}
+    desc = {"doc": {"citation": "foo bar"}, "url": "/f", "icon": "I"}
     assert "Foo Bar" in render_template.linktitle(desc)
     assert "I Foo Bar" in render_template.link_icon_title(desc)
     assert "Foo bar" in render_template.linkcap(desc)
     assert "I foo bar" in render_template.linkicon(desc)
-    short_desc = {"citation": {"short": "S"}, "url": "/s", "icon": "I"}
+    short_desc = {"doc": {"citation": {"short": "S"}}, "url": "/s", "icon": "I"}
     html = render_template.linkshort(short_desc)
     assert ">S<" in html and "I" not in html
 
@@ -114,7 +114,7 @@ def test_wrapper_functions():
     ],
 )
 def test_wrapper_functions_override_citation(func, expected):
-    desc = {"citation": "ignored", "url": "/f", "icon": "I"}
+    desc = {"doc": {"citation": "ignored"}, "url": "/f", "icon": "I"}
     html = func(desc, citation="custom citation")
     assert expected in html
     assert "ignored" not in html

--- a/app/shell/py/pie/tests/update/test_migrate_metadata.py
+++ b/app/shell/py/pie/tests/update/test_migrate_metadata.py
@@ -11,13 +11,17 @@ def test_moves_fields_under_doc(tmp_path: Path, capsys) -> None:
 
     yml = src / "doc.yml"
     yml.write_text(
-        "title: T\nauthor: A\npubdate: Jan 1, 2020\nlink:\n  class: x\n",
+        "title: T\nauthor: A\npubdate: Jan 1, 2020\n"
+        "link:\n  class: x\n"
+        "citation: C\n",
         encoding="utf-8",
     )
 
     md = src / "doc.md"
     md.write_text(
-        "---\ntitle: T\nauthor: A\npubdate: Jan 1, 2020\nlink:\n  tracking: false\n---\n",
+        "---\ntitle: T\nauthor: A\npubdate: Jan 1, 2020\n"
+        "link:\n  tracking: false\n"
+        "citation: C\n---\n",
         encoding="utf-8",
     )
 
@@ -28,17 +32,21 @@ def test_moves_fields_under_doc(tmp_path: Path, capsys) -> None:
     assert data["doc"]["author"] == "A"
     assert data["doc"]["pubdate"] == "Jan 1, 2020"
     assert data["doc"]["link"] == {"class": "x"}
+    assert data["doc"]["citation"] == "C"
     assert "title" not in data
     assert "author" not in data
     assert "pubdate" not in data
     assert "link" not in data
+    assert "citation" not in data
 
     md_data = yaml.load(md.read_text(encoding="utf-8").split("---\n", 2)[1])
     assert md_data["doc"]["title"] == "T"
     assert md_data["doc"]["author"] == "A"
     assert md_data["doc"]["pubdate"] == "Jan 1, 2020"
     assert md_data["doc"]["link"] == {"tracking": False}
+    assert md_data["doc"]["citation"] == "C"
     assert "title" not in md_data
+    assert "citation" not in md_data
 
     out_lines = capsys.readouterr().out.strip().splitlines()
     assert f"{yml}: migrated" in out_lines

--- a/docs/guides/process-yaml.md
+++ b/docs/guides/process-yaml.md
@@ -41,4 +41,4 @@ $(BUILD_DIR)/.process-yamls: $(BUILD_YAMLS)
 ```
 
 Running the script ensures each document has a complete metadata block so
-rendering tools can rely on fields like `id` or `citation`.
+rendering tools can rely on fields like `id` or `doc.citation`.

--- a/docs/guides/reading-notes.md
+++ b/docs/guides/reading-notes.md
@@ -10,7 +10,7 @@ It follows the structure used in
 2. Create `src/books/<slug>` and switch into it.
 3. Add an `index.yml` file with metadata:
    - `title` – full book title.
-   - `citation` – text used when citing the book.
+   - `doc.citation` – text used when citing the book.
    - `url` – base URL, e.g. `/books/hull-2016/`.
    - `id` – unique identifier using underscores, e.g. `hull_2016`.
    - `doc.author`, `doc.pubdate`, `description`.
@@ -40,11 +40,11 @@ definitions.
 
    ```yaml
    title: Topic (Book, page)
-   citation: (Book, page)
    description: 'Brief plain text summary.'
    id: book_page
    partof: '{{linktitle("<slug>")}}'
    doc:
+     citation: (Book, page)
      author: Your Name
      pubdate: Jun 1, 2024
    ```

--- a/docs/reference/link-globals.md
+++ b/docs/reference/link-globals.md
@@ -2,8 +2,8 @@
 
 Several build scripts provide custom Jinja globals that convert metadata
 descriptions into HTML anchors. Each dictionary is pulled from
-`index.json` and must include a `citation` field which supplies the anchor
-text, along with a `url` field. Optional keys like `icon`,
+`index.json` and must include a `doc.citation` field which supplies the
+anchor text, along with a `url` field. Optional keys like `icon`,
 `doc.link.tracking`, and `doc.link.class` customize the output. For an
 overview of these metadata fields, see
 [Metadata Fields](metadata-fields.md).
@@ -19,11 +19,12 @@ accepts a few optional parameters to control the output:
 - `use_icon` – when `True` (default) any `icon` field in the metadata is
   prefixed to the link text.  Set to `False` to suppress icons.
 - `anchor` – appends a fragment identifier (`#anchor`) to the URL when provided.
-- `citation` – selects which citation field to render or overrides the link text.
-  The default `"citation"` uses the main citation value; pass `"short"` to use
-  `citation.short` or provide a custom string to replace the citation entirely.
+- `citation` – selects which citation field to render or overrides the link
+  text. The default `"citation"` uses the main `doc.citation` value; pass
+  `"short"` to use `doc.citation.short` or provide a custom string to replace
+  the citation entirely.
 
-When the `citation` field is itself a mapping with `author`, `year`, and an
+When the `doc.citation` field is itself a mapping with `author`, `year`, and an
 optional `page`, the helper formats the text using Chicago style
 (`"Author Year, Page"`) and encloses it in parentheses, matching the behaviour
 of the `cite` global.
@@ -31,7 +32,7 @@ of the `cite` global.
 Example:
 
 ```jinja
-{{ link({"citation": "deltoid tuberosity", "url": "/humerus.html"},
+{{ link({"doc": {"citation": "deltoid tuberosity"}, "url": "/humerus.html"},
          style="title", anchor="deltoid_tuberosity") }}
 ```
 
@@ -50,7 +51,8 @@ You can also override the citation text:
 Bibliographic citations render similarly:
 
 ```jinja
-{{ link({"citation": {"author": "hull", "year": 2016, "page": 307}, "url": "/hull"}) }}
+{{ link({"doc": {"citation": {"author": "hull", "year": 2016, "page": 307}},
+         "url": "/hull"}) }}
 ```
 
 produces:
@@ -74,8 +76,8 @@ attributes off.
 Example:
 
 ```jinja
-{{ link({"citation": "press.io", "url": "https://press.io",
-         "doc": {"link": {"tracking": false}}}) }}
+{{ link({"url": "https://press.io", "doc": {"citation": "press.io",
+         "link": {"tracking": false}}}) }}
 ```
 
 renders as:
@@ -94,8 +96,8 @@ wrappers around `link`.  They will be removed in a future release.
 Example:
 
 ```jinja
-{{ linktitle({"citation": "deltoid tuberosity", "url": "/humerus.html"},
-             anchor="deltoid_tuberosity") }}
+{{ linktitle({"doc": {"citation": "deltoid tuberosity"},
+             "url": "/humerus.html"}, anchor="deltoid_tuberosity") }}
 ```
 
 renders as:

--- a/docs/reference/link-metadata.md
+++ b/docs/reference/link-metadata.md
@@ -6,7 +6,7 @@ the build scripts interpret them. A list of all metadata keys can be found in
 
 ## Creating a Metadata File
 
-Place YAML files under `src/links/`. Each file defines at least a `citation`
+Place YAML files under `src/links/`. Each file defines at least a `doc.citation`
 and a `url` for the destination. Any additional fields become part of the build
 index. When the file does not specify an `id`, it is derived from the
 filename.
@@ -14,12 +14,12 @@ filename.
 Example `src/links/press_io_home.yml`:
 
 ```yaml
-citation: press.io home
-url: https://press.io
 doc:
+  citation: press.io home
   link:
     tracking: false
     class: external-link
+url: https://press.io
 ```
 
 This file generates an entry with the `id` `press_io_home` because the

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -30,21 +30,21 @@ several fields when they are missing:
 | ---------- | ---------------------------------------------- |
 | `schema`   | Current metadata schema version (`"v1"`)       |
 | `id`       | Filename without the extension                 |
-| `citation` | Lowercase form of the `title` value            |
+| `doc.citation` | Lowercase form of the `title` value            |
 | `url`      | Derived from the source path (e.g. `src/foo.md` → `/foo.html`) |
 | `doc.link.canonical` | Absolute form of the `url` value          |
 
-The `citation` value is used as the anchor text when other pages link to this
-document using Jinja globals such as `linktitle`. The helper that assigns these
-defaults lives in `generate_missing_metadata` within `pie.metadata`.
+The `doc.citation` value is used as the anchor text when other pages link to
+this document using Jinja globals such as `linktitle`. The helper that assigns
+these defaults lives in `generate_missing_metadata` within `pie.metadata`.
 
 The canonical URL is recorded under `doc.link.canonical`, replacing the legacy
 top-level `link.canonical` field.
 
-For bibliographic references the `citation` field may instead be a mapping with
-`author`, `year`, and `page` keys. This structure is consumed by the `cite`
-Jinja global and by the link-formatting helpers to render Chicago style text in
-parentheses.
+For bibliographic references the `doc.citation` field may instead be a mapping
+with `author`, `year`, and `page` keys. This structure is consumed by the
+`cite` Jinja global and by the link-formatting helpers to render Chicago style
+text in parentheses.
 
 `doc.link.tracking` defaults to `true`, meaning links open in the same tab.
 `doc.link.class` defaults to `internal-link`.

--- a/docs/reference/migrate-metadata.md
+++ b/docs/reference/migrate-metadata.md
@@ -1,7 +1,8 @@
 # migrate-metadata
 
-Move legacy top-level `author`, `pubdate`, `link`, and `title` fields under the
-`doc` mapping. This script scans the provided files or directories and rewrites
+Move legacy top-level `author`, `pubdate`, `link`, `title`, and `citation`
+fields under the `doc` mapping. This script scans the provided files or
+directories and rewrites
 Markdown front matter and YAML metadata in place.
 
 ```bash

--- a/src/examples/chicago-citations.md
+++ b/src/examples/chicago-citations.md
@@ -6,18 +6,19 @@ Demonstrates Chicago-style citations using the `cite` and `link` globals.
 ## Creating citation metadata
 
 Each source is stored in a small YAML file that includes the title,
-citation details, and URL. Save the file somewhere under `src/` so it gets
+`doc.citation` details, and URL. Save the file somewhere under `src/` so it gets
 indexed during the build.
 
 Example metadata file:
 
 ```yaml
 # hull.yml
-title: Options, Futures, and Other Derivatives
-citation:
-  author: Hull
-  year: 2016
-  page: 307
+doc:
+  title: Options, Futures, and Other Derivatives
+  citation:
+    author: Hull
+    year: 2016
+    page: 307
 url: https://example.com/hull
 ```
 
@@ -25,11 +26,12 @@ Add as many sources as you need.  A second entry might look like:
 
 ```yaml
 # doe.yml
-title: Example Book
-citation:
-  author: Doe
-  year: 2019
-  page: 42
+doc:
+  title: Example Book
+  citation:
+    author: Doe
+    year: 2019
+    page: 42
 url: https://example.com/doe
 ```
 
@@ -61,10 +63,10 @@ To override metadata—for example, to cite a different page—you can pass a
 dictionary directly:
 
 ```jinja
-{% raw %}{{ cite({"citation": {"author": "Hull", "year": 2016, "page": 350}, "url": "/"}) }}{% endraw %}
+{% raw %}{{ cite({"doc": {"citation": {"author": "Hull", "year": 2016, "page": 350}}, "url": "/"}) }}{% endraw %}
 ```
 
-{{ cite({"citation": {"author": "Hull", "year": 2016, "page": 350}, "url": "/"}) }}
+{{ cite({"doc": {"citation": {"author": "Hull", "year": 2016, "page": 350}}, "url": "/"}) }}
 
 ## link global
 
@@ -73,12 +75,12 @@ The `link` global turns metadata dictionaries or IDs into HTML anchors.
 Using a dictionary:
 
 ```jinja
-{% raw %}{{ link({"citation": {"author": "hull", "year": 2016, "page": 307}, "url": "/"}) }}{% endraw %}
+{% raw %}{{ link({"doc": {"citation": {"author": "hull", "year": 2016, "page": 307}}, "url": "/"}) }}{% endraw %}
 ```
 
 renders as:
 
-{{ link({"citation": {"author": "hull", "year": 2016, "page": 307}, "url": "/"}) }}
+{{ link({"doc": {"citation": {"author": "hull", "year": 2016, "page": 307}}, "url": "/"}) }}
 
 Passing an ID fetches the metadata automatically:
 

--- a/src/examples/chicago-citations.yml
+++ b/src/examples/chicago-citations.yml
@@ -4,8 +4,8 @@ breadcrumbs:
 - title: Examples
   url: /examples/
 - title: Chicago Citation Examples
-citation: chicago citations
 doc:
+  citation: chicago citations
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: Chicago Citation Examples

--- a/src/examples/custom-template.yml
+++ b/src/examples/custom-template.yml
@@ -4,8 +4,8 @@ breadcrumbs:
 - title: Examples
   url: /examples/
 - title: Custom Template
-citation: custom template
 doc:
+  citation: custom template
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: Custom Template

--- a/src/examples/doe.yml
+++ b/src/examples/doe.yml
@@ -1,8 +1,8 @@
-citation:
-  author: Doe
-  page: 42
-  year: 2019
 doc:
+  citation:
+    author: Doe
+    page: 42
+    year: 2019
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: Example Book

--- a/src/examples/hull.yml
+++ b/src/examples/hull.yml
@@ -1,8 +1,8 @@
-citation:
-  author: Hull
-  page: 307
-  year: 2016
 doc:
+  citation:
+    author: Hull
+    page: 307
+    year: 2016
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: Options, Futures, and Other Derivatives

--- a/src/examples/jinja.md
+++ b/src/examples/jinja.md
@@ -59,11 +59,11 @@ Output:
 Custom globals work the same way. The `link` global turns metadata into an anchor tag:
 
 ```jinja
-{% raw %}{{ link({"citation": "Quickstart", "url": "/quickstart.html"}) }}{% endraw %}
+{% raw %}{{ link({"doc": {"citation": "Quickstart"}, "url": "/quickstart.html"}) }}{% endraw %}
 ```
 
 Output:
 
-{{ link({"citation": "Quickstart", "url": "/quickstart.html"}) }}
+{{ link({"doc": {"citation": "Quickstart"}, "url": "/quickstart.html"}) }}
 
 {% endblock %}

--- a/src/examples/jinja.yml
+++ b/src/examples/jinja.yml
@@ -4,8 +4,8 @@ breadcrumbs:
 - title: Examples
   url: /examples/
 - title: Jinja Examples
-citation: jinja
 doc:
+  citation: jinja
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: Jinja Examples

--- a/src/examples/link-globals.md
+++ b/src/examples/link-globals.md
@@ -3,7 +3,7 @@
 {% block content %}
 Press provides custom Jinja globals for formatting links. Each example shows
 the template followed by its rendered result. Globals accept either a
-metadata ID string or a dictionary with at least `citation` and `url`.
+metadata ID string or a dictionary with at least `doc.citation` and `url`.
 
 ## linktitle
 
@@ -18,12 +18,12 @@ Output:
 ## linktitle with anchor
 
 ```jinja
-{% raw %}{{ linktitle({"citation": "home", "url": "/"}, anchor="#example") }}{% endraw %}
+{% raw %}{{ linktitle({"doc": {"citation": "home"}, "url": "/"}, anchor="#example") }}{% endraw %}
 ```
 
 Output:
 
-{{ linktitle({"citation": "home", "url": "/"}, anchor="#example") }}
+{{ linktitle({"doc": {"citation": "home"}, "url": "/"}, anchor="#example") }}
 
 ## linktitle with custom citation
 
@@ -48,22 +48,22 @@ Output:
 ## linkicon
 
 ```jinja
-{% raw %}{{ linkicon({"citation": "Quickstart", "url": "/quickstart.html", "icon": "👉"}) }}{% endraw %}
+{% raw %}{{ linkicon({"doc": {"citation": "Quickstart"}, "url": "/quickstart.html", "icon": "👉"}) }}{% endraw %}
 ```
 
 Output:
 
-{{ linkicon({"citation": "Quickstart", "url": "/quickstart.html", "icon": "👉"}) }}
+{{ linkicon({"doc": {"citation": "Quickstart"}, "url": "/quickstart.html", "icon": "👉"}) }}
 
 ## link_icon_title
 
 ```jinja
-{% raw %}{{ link_icon_title({"citation": "Quickstart", "url": "/quickstart.html", "icon": "👉"}) }}{% endraw %}
+{% raw %}{{ link_icon_title({"doc": {"citation": "Quickstart"}, "url": "/quickstart.html", "icon": "👉"}) }}{% endraw %}
 ```
 
 Output:
 
-{{ link_icon_title({"citation": "Quickstart", "url": "/quickstart.html", "icon": "👉"}) }}
+{{ link_icon_title({"doc": {"citation": "Quickstart"}, "url": "/quickstart.html", "icon": "👉"}) }}
 
 ## link
 

--- a/src/examples/link-globals.yml
+++ b/src/examples/link-globals.yml
@@ -4,8 +4,8 @@ breadcrumbs:
 - title: Examples
   url: /examples/
 - title: Link Global Examples
-citation: link globals
 doc:
+  citation: link globals
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: Link Global Examples

--- a/src/examples/responsive-images.yml
+++ b/src/examples/responsive-images.yml
@@ -4,8 +4,8 @@ breadcrumbs:
 - title: Examples
   url: /examples/
 - title: Responsive Images
-citation: responsive-images
 doc:
+  citation: responsive-images
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: Responsive Images

--- a/src/links/citation.yml
+++ b/src/links/citation.yml
@@ -1,6 +1,6 @@
-citation:
-  short: short
 doc:
+  citation:
+    short: short
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: citation

--- a/src/links/press_io_home.yml
+++ b/src/links/press_io_home.yml
@@ -1,5 +1,5 @@
-citation: press.io home
 doc:
+  citation: press.io home
   author: Brian Lee
   link:
     class: external-link

--- a/src/quickstart.yml
+++ b/src/quickstart.yml
@@ -2,8 +2,8 @@ breadcrumbs:
 - title: Home
   url: /
 - title: Quickstart
-citation: quickstart
 doc:
+  citation: quickstart
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: Quickstart


### PR DESCRIPTION
## Summary
- move citation metadata under `doc.citation`
- update templates, tests, examples, and docs for new structure
- extend `migrate-metadata` to rewrite legacy citation fields

## Testing
- `pytest`
- `PYTHONPATH=app/shell/py/pie python -m pie.check.all` *(fails: Missing artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdf2faa808321acc5b2fb2938c3ce