### PR TITLE
Align tests with simplified build tools

### DIFF
--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -18,8 +18,8 @@ def test_generate_rule_basic(tmp_path, monkeypatch):
         "build/foo/bar.yml: src/foo/bar.yml\n"
         "\t$(call status,Preprocess $<)\n"
         "\t$(Q)mkdir -p $(dir build/foo/bar.yml)\n"
-        "\t$(Q)cp $< $@\n"
-        "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml $(HTML_TEMPLATE) $(BUILD_DIR)/.process-yamls\n"
+        "\t$(Q)cp $< $@; process-yaml $@\n"
+        "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml $(HTML_TEMPLATE)\n"
         "\t$(call status,Generate HTML $@)\n"
         "\t$(Q)render-html build/foo/bar.md build/foo/bar.yml $@"
     )
@@ -47,8 +47,9 @@ def test_generate_rule_with_template(tmp_path, monkeypatch):
         "build/foo/bar.yml: src/foo/bar.yml\n"
         "\t$(call status,Preprocess $<)\n"
         "\t$(Q)mkdir -p $(dir build/foo/bar.yml)\n"
-        "\t$(Q)cp $< $@\n"
-        "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml src/templates/blog/template.html.jinja $(BUILD_DIR)/.process-yamls\n"
+        "\t$(Q)cp $< $@; process-yaml $@\n"
+        "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml "
+        "src/templates/blog/template.html.jinja\n"
         "\t$(call status,Generate HTML $@)\n"
         "\t$(Q)render-html build/foo/bar.md build/foo/bar.yml $@"
     )


### PR DESCRIPTION
## Summary
- adjust picasso rule expectations for new preprocess step and template handling
- revise process_yaml tests for simplified metadata processing

## Testing
- `pytest app/shell/py/pie/tests/test_picasso.py::test_generate_rule_basic app/shell/py/pie/tests/test_picasso.py::test_generate_rule_with_template -q`
- `pytest app/shell/py/pie/tests/test_process_yaml.py::test_main_leaves_emoji_codes app/shell/py/pie/tests/test_process_yaml.py::test_main_writes_null_when_no_metadata app/shell/py/pie/tests/test_process_yaml.py::test_main_does_not_invoke_render_jinja app/shell/py/pie/tests/test_process_yaml.py::test_main_raises_yaml_error app/shell/py/pie/tests/test_process_yaml.py::test_main_ignores_template_errors app/shell/py/pie/tests/test_process_yaml.py::test_main_skips_write_when_unchanged app/shell/py/pie/tests/test_process_yaml.py::test_main_skips_write_when_text_diff -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcee5bf0908321bda6f3f0b7b3225b