### PR TITLE
Show build duration in minutes and seconds

### DIFF
--- a/makefile
+++ b/makefile
@@ -80,7 +80,11 @@ everything: | $(BUILD_DIR) $(BUILD_SUBDIRS)
 	$(Q)update-pubdate --sort-keys
 	$(Q)$(MAKE) -s $(BUILD_DIR)/.update-index VERBOSE=$(VERBOSE)
 	$(Q)$(MAKE) -s all VERBOSE=$(VERBOSE)
-	$(Q)END_TIME=$$(date +%s); ELAPSED=$$((END_TIME - START_TIME)); echo "==> Total execution time: $$ELAPSED seconds"
+	$(Q)END_TIME=$$(date +%s); \
+	ELAPSED=$$((END_TIME - START_TIME)); \
+	MIN=$$((ELAPSED / 60)); \
+	SEC=$$((ELAPSED % 60)); \
+	printf "==> Total execution time: %dm %ds\n" $$MIN $$SEC
 
 all: $(HTMLS)
 all: $(CSS)


### PR DESCRIPTION
## Summary
- update build output to report total execution time in minutes and seconds

## Testing
- `make check` *(fails: picasso: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf71623d08321b76a433857b9bc00