### PR TITLE
refactor: nest header includes under html extras

### DIFF
--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -180,8 +180,7 @@ def generate_missing_metadata(
     _add_empty_if_missing(metadata, 'pubdate', filepath)
     _add_if_missing(metadata, 'schema', DEFAULT_SCHEMA, filepath)
     _add_if_missing(metadata, 'css', ['/css/style.css'], filepath)
-    _add_if_missing(metadata, 'header', {'header':None}, filepath)
-    _add_if_missing(metadata, 'header_includes', [], filepath)
+    _add_if_missing(metadata, 'header', {'header': None}, filepath)
     logger.debug("returning", metadata=metadata)
     return metadata
 

--- a/app/shell/py/pie/pie/update/migrate_metadata.py
+++ b/app/shell/py/pie/pie/update/migrate_metadata.py
@@ -1,4 +1,4 @@
-"""Move legacy metadata fields under ``doc``."""
+"""Move legacy metadata fields under ``doc`` and ``html.extras``."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ FIELDS = ("author", "pubdate", "link", "title", "citation")
 
 
 def _migrate_mapping(data: dict) -> tuple[dict, bool]:
-    """Move legacy fields into ``doc`` and return ``(data, changed)``."""
+    """Move legacy fields into ``doc`` and ``html.extras``."""
     changed = False
     doc = data.get("doc")
     if not isinstance(doc, dict):
@@ -31,6 +31,27 @@ def _migrate_mapping(data: dict) -> tuple[dict, bool]:
     if doc:
         if data.get("doc") != doc:
             data["doc"] = doc
+            changed = True
+    if "header_includes" in data:
+        html = data.get("html")
+        if not isinstance(html, dict):
+            html = {}
+        else:
+            html = dict(html)
+        extras = html.get("extras")
+        if extras is None:
+            extras = []
+        else:
+            extras = list(extras)
+        header_includes = data.pop("header_includes")
+        if not isinstance(header_includes, list):
+            header_includes = [header_includes]
+        extras.extend(header_includes)
+        if html.get("extras") != extras:
+            html["extras"] = extras
+            changed = True
+        if data.get("html") != html:
+            data["html"] = html
             changed = True
     return data, changed
 
@@ -89,7 +110,8 @@ def walk_files(paths: Iterable[Path]) -> Iterable[Path]:
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = create_parser(
-        "Move top-level author/pubdate/link/title/citation fields under doc",
+        "Move top-level author/pubdate/link/title/citation fields under doc "
+        "and header_includes under html.extras",
         log_default="log/migrate-metadata.txt",
     )
     parser.add_argument("paths", nargs="+", help="Files or directories to scan")

--- a/app/shell/py/pie/tests/update/test_migrate_metadata.py
+++ b/app/shell/py/pie/tests/update/test_migrate_metadata.py
@@ -53,3 +53,30 @@ def test_moves_fields_under_doc(tmp_path: Path, capsys) -> None:
     assert f"{md}: migrated" in out_lines
     assert "2 files checked" in out_lines[-2]
     assert "2 files changed" in out_lines[-1]
+
+
+def test_moves_header_includes_to_html_extras(
+    tmp_path: Path, capsys
+) -> None:
+    """`header_includes` moves under `html.extras`."""
+    src = tmp_path / "src"
+    src.mkdir()
+
+    yml = src / "doc.yml"
+    yml.write_text(
+        "header_includes:\n- <script src=\"app.js\"></script>\n",
+        encoding="utf-8",
+    )
+
+    migrate_metadata.main([str(src)])
+
+    data = yaml.load(yml.read_text(encoding="utf-8"))
+    assert data["html"]["extras"] == [
+        "<script src=\"app.js\"></script>"
+    ]
+    assert "header_includes" not in data
+
+    out_lines = capsys.readouterr().out.strip().splitlines()
+    assert f"{yml}: migrated" in out_lines
+    assert "1 file checked" in out_lines[-2]
+    assert "1 file changed" in out_lines[-1]

--- a/docs/guides/react-index-tree.md
+++ b/docs/guides/react-index-tree.md
@@ -70,8 +70,8 @@ indextree-json docs doc-tree.json
 
 Any element with the `indextree-root` class marks where a tree renders. Add as
 many as needed on the same page, each with a `data-src` attribute pointing to
-its JSON file. Load `indextree.js` through the page's `header_includes`
-metadata; Markdown escapes `<script>` tags to prevent XSS.
+its JSON file. Load `indextree.js` through the page's `html.extras` metadata;
+Markdown escapes `<script>` tags to prevent XSS.
 
 ## Usage
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -22,7 +22,7 @@ existing documents.
 - [update-pubdate.md](update-pubdate.md) – update the `doc.pubdate` field for
 modified files.
 - [migrate-metadata.md](migrate-metadata.md) – move legacy fields under
-  `doc`.
+  `doc` and header includes under `html.extras`.
 - [update-url.md](update-url.md) – rename files and update URL fields.
 - [update-link-filters.md](update-link-filters.md) – convert legacy `link*`
 filters into globals.

--- a/docs/reference/migrate-metadata.md
+++ b/docs/reference/migrate-metadata.md
@@ -1,9 +1,9 @@
 # migrate-metadata
 
-Move legacy top-level `author`, `pubdate`, `link`, `title`, and `citation`
-fields under the `doc` mapping. This script scans the provided files or
-directories and rewrites
-Markdown front matter and YAML metadata in place.
+Move legacy top-level `author`, `pubdate`, `link`, `title`, `citation`, and
+`header_includes` fields under the `doc` mapping and `html.extras`.
+This script scans the provided files or directories and rewrites Markdown
+front matter and YAML metadata in place.
 
 ```bash
 migrate-metadata PATH [PATH...]

--- a/src/examples/index.yml
+++ b/src/examples/index.yml
@@ -7,8 +7,9 @@ doc:
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: Examples
-header_includes:
-- <script type="module" src="/static/js/indextree.js" defer></script>
+html:
+  extras:
+  - <script type="module" src="/static/js/indextree.js" defer></script>
 id: examples
 indextree:
   link: true

--- a/src/examples/indextree/index.yml
+++ b/src/examples/indextree/index.yml
@@ -9,6 +9,7 @@ doc:
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: IndexTree Demo
-header_includes:
-- <script type="module" src="/static/js/indextree.js" defer></script>
+html:
+  extras:
+  - <script type="module" src="/static/js/indextree.js" defer></script>
 id: indextree-demo

--- a/src/index.yml
+++ b/src/index.yml
@@ -5,8 +5,9 @@ doc:
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: Home
-header_includes:
-- <script type="module" src="/static/js/indextree.js" defer></script>
+html:
+  extras:
+  - <script type="module" src="/static/js/indextree.js" defer></script>
 id: home
 og_image: /img/home.png
 schema: v1

--- a/src/magicbar/index.yml
+++ b/src/magicbar/index.yml
@@ -6,7 +6,8 @@ doc:
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: MagicBar Demo
-header_includes:
-- <script type="module" src="/static/js/magicbar.js" defer></script>
+html:
+  extras:
+  - <script type="module" src="/static/js/magicbar.js" defer></script>
 id: magicbar
 schema: v1

--- a/src/quiz/index.yml
+++ b/src/quiz/index.yml
@@ -6,7 +6,8 @@ doc:
   author: Brian Lee
   pubdate: Sep 07, 2025
   title: Quiz
-header_includes:
-- <script type="module" src="/static/js/quiz.js" defer></script>
+html:
+  extras:
+  - <script type="module" src="/static/js/quiz.js" defer></script>
 id: quiz
 schema: v1

--- a/src/templates/blog/template.html.jinja
+++ b/src/templates/blog/template.html.jinja
@@ -143,8 +143,8 @@
         <p><small>Enjoyed this article? Share it!</small></p>
       </footer>
     </article>
-    {% for header_include in header_includes %}
-    {{ header_include | safe }}
+    {% for extra in html.extras %}
+    {{ extra | safe }}
     {% endfor %}
     <script>
       document.addEventListener('DOMContentLoaded', () => {

--- a/src/templates/template.html.jinja
+++ b/src/templates/template.html.jinja
@@ -221,8 +221,8 @@
       </p>
     </footer>
 
-    {% for header_include in header_includes %}
-    {{ header_include | safe }}
+    {% for extra in html.extras %}
+    {{ extra | safe }}
     {% endfor %}
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- migrate `header_includes` into `html.extras` during metadata migration
- adjust templates, tests, docs, and example metadata to use `html.extras`

## Testing
- `make check` *(fails: check-all: No such file or directory)*
- `pytest` *(fails: Interrupted: 48 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf473ee3883218851b37a12ead656