### PR TITLE
Fix picasso rule tests for new index dependency

### DIFF
--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -19,7 +19,7 @@ def test_generate_rule_basic(tmp_path, monkeypatch):
         "\t$(call status,Preprocess $<)\n"
         "\t$(Q)mkdir -p $(dir build/foo/bar.yml)\n"
         "\t$(Q)cp $< $@; process-yaml $@\n"
-        "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml $(HTML_TEMPLATE)\n"
+        "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml $(HTML_TEMPLATE) | $(BUILD_DIR)/.update-index\n"
         "\t$(call status,Generate HTML $@)\n"
         "\t$(Q)render-html build/foo/bar.md build/foo/bar.yml $@"
     )
@@ -48,8 +48,7 @@ def test_generate_rule_with_template(tmp_path, monkeypatch):
         "\t$(call status,Preprocess $<)\n"
         "\t$(Q)mkdir -p $(dir build/foo/bar.yml)\n"
         "\t$(Q)cp $< $@; process-yaml $@\n"
-        "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml "
-        "src/templates/blog/template.html.jinja\n"
+        "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml src/templates/blog/template.html.jinja | $(BUILD_DIR)/.update-index\n"
         "\t$(call status,Generate HTML $@)\n"
         "\t$(Q)render-html build/foo/bar.md build/foo/bar.yml $@"
     )


### PR DESCRIPTION
## Summary
- update expectations to include `.update-index` order-only dependency

## Testing
- `pytest app/shell/py/pie/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf052ac83c832196453078c20bcd99