### PR TITLE
Support nested metadata defaults and set doc mathjax

### DIFF
--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -127,30 +127,31 @@ def _add_canonical_link_if_missing(metadata: dict[str, Any], filepath: str) -> N
     metadata.setdefault("doc", {}).setdefault("link", {})["canonical"] = canonical
 
 
-def _add_empty_if_missing(metadata: dict[str, Any], field: str, filepath: str) -> None:
-    """Generate an ``id`` based on ``filepath`` if absent."""
+def _add_if_missing(
+    metadata: dict[str, Any], field: str, value: Any, filepath: str
+) -> None:
+    """Assign ``value`` to ``field`` when it is missing.
 
-    if field not in metadata:
-        metadata[field] = None
+    ``field`` may be a dotted path such as ``foo.bar``.
+    """
+
+    parts = field.split(".")
+    obj: dict[str, Any] = metadata
+    for part in parts[:-1]:
+        sub = obj.get(part)
+        if not isinstance(sub, dict):
+            sub = {}
+            obj[part] = sub
+        obj = sub
+    last = parts[-1]
+    if last not in obj:
+        obj[last] = value
         logger.debug(
             "Generated",
-            id=metadata["id"],
+            id=metadata.get("id"),
             field=field,
             filename=str(Path(filepath).resolve().relative_to(Path.cwd())),
         )
-
-def _add_if_missing(metadata: dict[str, Any], field: str, value, filepath: str) -> None:
-    """Generate an ``id`` based on ``filepath`` if absent."""
-
-    if field not in metadata:
-        metadata[field] = value
-        logger.debug(
-            "Generated",
-            id=metadata["id"],
-            field=field,
-            filename=str(Path(filepath).resolve().relative_to(Path.cwd())),
-        )
-
 
 def generate_missing_metadata(
     metadata: dict[str, Any], filepath: str
@@ -161,27 +162,27 @@ def generate_missing_metadata(
     _add_canonical_link_if_missing(metadata, filepath)
     _add_citation_if_missing(metadata, filepath)
     _add_id_if_missing(metadata, filepath)
-    _add_empty_if_missing(metadata, 'breadcrumbs', filepath)
-    _add_empty_if_missing(metadata, 'description', filepath)
-    _add_empty_if_missing(metadata, 'mathjax', filepath)
-    _add_empty_if_missing(metadata, 'next', filepath)
-    _add_empty_if_missing(metadata, 'og_description', filepath)
-    _add_empty_if_missing(metadata, 'og_image', filepath)
-    _add_empty_if_missing(metadata, 'og_title', filepath)
-    _add_empty_if_missing(metadata, 'og_url', filepath)
-    _add_empty_if_missing(metadata, 'page_heading', filepath)
-    _add_empty_if_missing(metadata, 'partof', filepath)
-    _add_empty_if_missing(metadata, 'preamble', filepath)
-    _add_empty_if_missing(metadata, 'prev', filepath)
-    _add_empty_if_missing(metadata, 'status', filepath)
-    _add_empty_if_missing(metadata, 'toc', filepath)
-    _add_empty_if_missing(metadata, 'twitter_card', filepath)
-    _add_empty_if_missing(metadata, 'twitter_image', filepath)
-    _add_empty_if_missing(metadata, 'pubdate', filepath)
-    _add_if_missing(metadata, 'schema', DEFAULT_SCHEMA, filepath)
+    _add_if_missing(metadata, 'breadcrumbs', None, filepath)
     _add_if_missing(metadata, 'css', ['/css/style.css'], filepath)
+    _add_if_missing(metadata, 'description', None, filepath)
+    _add_if_missing(metadata, 'doc.mathjax', False, filepath)
     _add_if_missing(metadata, 'header', {'header': None}, filepath)
-    _add_if_missing(metadata, 'html', {'scripts':[]}, filepath)
+    _add_if_missing(metadata, 'html', {'scripts': []}, filepath)
+    _add_if_missing(metadata, 'next', None, filepath)
+    _add_if_missing(metadata, 'og_description', None, filepath)
+    _add_if_missing(metadata, 'og_image', None, filepath)
+    _add_if_missing(metadata, 'og_title', None, filepath)
+    _add_if_missing(metadata, 'og_url', None, filepath)
+    _add_if_missing(metadata, 'page_heading', None, filepath)
+    _add_if_missing(metadata, 'partof', None, filepath)
+    _add_if_missing(metadata, 'preamble', None, filepath)
+    _add_if_missing(metadata, 'prev', None, filepath)
+    _add_if_missing(metadata, 'pubdate', None, filepath)
+    _add_if_missing(metadata, 'schema', DEFAULT_SCHEMA, filepath)
+    _add_if_missing(metadata, 'status', None, filepath)
+    _add_if_missing(metadata, 'toc', None, filepath)
+    _add_if_missing(metadata, 'twitter_card', None, filepath)
+    _add_if_missing(metadata, 'twitter_image', None, filepath)
     logger.debug("returning", metadata=metadata)
     return metadata
 

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -46,6 +46,7 @@ def test__read_from_markdown_generates_fields(tmp_path):
     assert data["title"] == "T"
     assert data["url"] == "/doc.html"
     assert data["doc"]["citation"] == "t"
+    assert data["doc"]["mathjax"] is False
     assert data["id"] == "doc"
     assert data["schema"] == "v1"
 
@@ -65,6 +66,7 @@ def test_read_from_yaml_generates_fields(tmp_path):
     assert data["title"] == "Foo"
     assert data["url"] == "/item.html"
     assert data["doc"]["citation"] == "foo"
+    assert data["doc"]["mathjax"] is False
     assert data["id"] == "item"
     assert data["schema"] == "v1"
 
@@ -150,6 +152,13 @@ def test__add_canonical_link_if_missing_sets_value(monkeypatch):
     info = {"url": "/foo"}
     metadata._add_canonical_link_if_missing(info, "doc.md")
     assert info["doc"]["link"]["canonical"] == "http://press.io/foo"
+
+
+def test__add_if_missing_nested_key():
+    """Nested dotted keys are created when missing."""
+    info: dict[str, str] = {}
+    metadata._add_if_missing(info, "foo.bar", "baz", "doc.md")
+    assert info["foo"]["bar"] == "baz"
 
 
 def test__get_redis_value_missing_returns_none():

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -11,6 +11,7 @@ missing values are automatically generated.
 
 - `doc.author` – Author string used in metadata.
 - `doc.pubdate` – Publication date used for document listings.
+- `doc.mathjax` – Enable MathJax support when set to `true`.
 - `definition` – Markdown snippet rendered through the `definition` global
   and used for meta tags.
 - `og_image` – OpenGraph image path.
@@ -33,6 +34,7 @@ several fields when they are missing:
 | `doc.citation` | Lowercase form of the `title` value            |
 | `url`      | Derived from the source path (e.g. `src/foo.md` → `/foo.html`) |
 | `doc.link.canonical` | Absolute form of the `url` value          |
+| `doc.mathjax` | `false` — MathJax is disabled by default        |
 
 The `doc.citation` value is used as the anchor text when other pages link to
 this document using Jinja globals such as `linktitle`. The helper that assigns
@@ -48,4 +50,5 @@ text in parentheses.
 
 `doc.link.tracking` defaults to `true`, meaning links open in the same tab.
 `doc.link.class` defaults to `internal-link`.
+`doc.mathjax` defaults to `false`, so MathJax is not loaded by default.
 


### PR DESCRIPTION
## Summary
- allow `_add_if_missing` to handle dotted paths
- default `doc.mathjax` to false when missing
- document `doc.mathjax` and sort generated metadata list
- test nested metadata updates
- remove redundant `_add_empty_if_missing` helper

## Testing
- `pytest app/shell/py/pie/tests/test_metadata.py`
- `pytest` *(fails: No module named 'bs4', 'emoji', 'cmarkgfm', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0cfc97408321b9ba229a91f5933b