### PR TITLE
Enable footnote support in Markdown rendering

### DIFF
--- a/app/shell/py/pie/pie/render/jinja.py
+++ b/app/shell/py/pie/pie/render/jinja.py
@@ -495,7 +495,10 @@ def render_press(text):
     return Markup(
         cmarkgfm.github_flavored_markdown_to_html(
             text,
-            options=cmarkgfm.Options.CMARK_OPT_UNSAFE,
+            options=(
+                cmarkgfm.Options.CMARK_OPT_UNSAFE
+                | cmarkgfm.Options.CMARK_OPT_FOOTNOTES
+            ),
         )
     )
 

--- a/app/shell/py/pie/tests/test_render_jinja.py
+++ b/app/shell/py/pie/tests/test_render_jinja.py
@@ -97,3 +97,9 @@ def test_render_press_ignores_unknown_alias():
     html = jinja.render_press("Hi :does_not_exist:")
     assert str(html) == "<p>Hi :does_not_exist:</p>\n"
 
+
+def test_render_press_renders_footnotes():
+    text = "Note.[^1]\n\n[^1]: Footnote"
+    html = jinja.render_press(text)
+    assert '<section class="footnotes"' in str(html)
+


### PR DESCRIPTION
## Summary
- enable CMARK_OPT_FOOTNOTES for Markdown rendering
- add regression test covering footnote output

## Testing
- `PYTHONPATH=app/shell/py pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf185d11548321a1027f95784092fb