### PR TITLE
feat: add static link reporting tool

### DIFF
--- a/app/shell/py/pie/pie/report/static_links.py
+++ b/app/shell/py/pie/pie/report/static_links.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from bs4 import BeautifulSoup
+
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
+
+__all__ = ["main"]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Return parsed command line arguments."""
+    parser = create_parser("Generate report of static links")
+    parser.add_argument(
+        "build_dir",
+        nargs="?",
+        default="build",
+        help="Directory containing HTML files (default: build)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="report/static-links.html",
+        help="Path to output report (default: report/static-links.html)",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def iter_html_files(path: Path) -> Iterable[Path]:
+    """Yield HTML files under *path* recursively."""
+    yield from path.rglob("*.html")
+
+
+def extract_links(path: Path) -> list[str]:
+    """Return sorted list of links from *path*."""
+    soup = BeautifulSoup(path.read_text(encoding="utf-8"), "html.parser")
+    urls = {a["href"] for a in soup.find_all("a", href=True)}
+    return sorted(urls)
+
+
+def generate_report(links: dict[Path, list[str]], dest: Path) -> None:
+    """Write *links* report to *dest* as HTML."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("w", encoding="utf-8") as fh:
+        fh.write("<html><body>\n")
+        for path, urls in links.items():
+            fh.write(f"<h2>{path}</h2>\n<ul>\n")
+            for url in urls:
+                fh.write(f"  <li>{url}</li>\n")
+            fh.write("</ul>\n")
+        fh.write("</body></html>\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for ``report-static-links``."""
+    args = parse_args(argv)
+    configure_logging(args.verbose, args.log)
+
+    build_dir = Path(args.build_dir)
+    report_path = Path(args.output)
+
+    links: dict[Path, list[str]] = {}
+    for html_file in iter_html_files(build_dir):
+        rel = html_file.relative_to(build_dir)
+        links[rel] = extract_links(html_file)
+    links = dict(sorted(links.items()))
+
+    generate_report(links, report_path)
+    logger.info("wrote report", path=str(report_path))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -37,6 +37,7 @@ setup(
             'render-html=pie.render.html:main',
             'render-jinja-template=pie.render.jinja:main',
             'render-study-json=pie.render_study_json:main',
+            'report-static-links=pie.report.static_links:main',
             'store-files=pie.store_files:main',
             'update-author=pie.update.author:main',
             'update-index=pie.update.index:main',

--- a/makefile
+++ b/makefile
@@ -113,8 +113,13 @@ $(BUILD_DIR)/.update-index: $(YAMLS)
 # Modifies file timestamps. The preserve option doesn't seem to work.
 # No touch at the end. Minify should always execute.
 $(BUILD_DIR)/.minify:
-	$(call status,Minify HTML and CSS)
-	$(Q)cd $(BUILD_DIR); $(MINIFY_CMD) -a -v -r -o . .
+        $(call status,Minify HTML and CSS)
+        $(Q)cd $(BUILD_DIR); $(MINIFY_CMD) -a -v -r -o . .
+
+.PHONY: report-static-links
+report-static-links: $(BUILD_DIR)/.minify
+	$(call status,Generate static links report)
+	$(Q)report-static-links
 
 .PHONY: test
 # Triggered by the test target; see docs/guides/redo-mk.md.
@@ -123,7 +128,7 @@ test: $(BUILD_DIR)/.minify check | $(LOG_DIR)
 	$(Q)$(CHECKLINKS_CMD) $(TEST_HOST_URL)
 
 .PHONY: check
-check:
+check: report-static-links
 	$(call status,Run checks)
 	$(Q)check-all
 


### PR DESCRIPTION
## Summary
- add `report-static-links` console script to enumerate anchors in build HTML
- generate report at `report/static-links.html`
- run static link report before `check` target in Makefile

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a1a7f0748321b15d1e2886c7bde0