### PR TITLE
docs: stress tab indent in makefiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@
   - `id`: use `_` instead of `-` when modifying
 - Math: always use `$ ... $` or `$$ ... $$`  
   (never `\(`, `\)`, `\[`, `\]`)
-- Makefiles: **indent with tabs**, not spaces
+- Makefiles: **indent with real tab characters** for recipe lines.
+  Leading spaces will break Makefile syntax. Never replace tabs with spaces.
 - Documentation: write as an **expert engineer**.  
   Provide enough detail for new team members.
 


### PR DESCRIPTION
## Summary
- clarify Makefile guidelines to use real tabs for command recipes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_68c1a3a44418832188055e58b1558b02