### PR TITLE
feat: add metadata model

### DIFF
--- a/app/shell/py/pie/pie/model/__init__.py
+++ b/app/shell/py/pie/pie/model/__init__.py
@@ -1,0 +1,5 @@
+"""Data models for pie."""
+
+__all__ = ["Breadcrumb", "Doc", "Metadata"]
+
+from .metadata import Breadcrumb, Doc, Metadata  # noqa: F401

--- a/app/shell/py/pie/pie/model/metadata.py
+++ b/app/shell/py/pie/pie/model/metadata.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from pie.schema import DEFAULT_SCHEMA
+
+__all__ = ["Breadcrumb", "Doc", "Metadata"]
+
+
+@dataclass
+class Breadcrumb:
+    """Single navigation step for document hierarchy."""
+
+    title: str
+    url: Optional[str] = None
+
+    def to_dict(self) -> dict[str, str]:
+        """Return dictionary representation omitting ``url`` when absent."""
+
+        data = {"title": self.title}
+        if self.url is not None:
+            data["url"] = self.url
+        return data
+
+
+@dataclass
+class Doc:
+    """Document specific metadata."""
+
+    author: str
+    pubdate: str
+    title: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return dictionary representation for serialization."""
+
+        return {
+            "author": self.author,
+            "pubdate": self.pubdate,
+            "title": self.title,
+        }
+
+
+@dataclass
+class Metadata:
+    """Top-level metadata for a document."""
+
+    id: str
+    doc: Doc
+    breadcrumbs: List[Breadcrumb] = field(default_factory=list)
+    schema: str = DEFAULT_SCHEMA
+    description: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return dictionary representation for serialization."""
+
+        data = {
+            "breadcrumbs": [b.to_dict() for b in self.breadcrumbs],
+            "doc": self.doc.to_dict(),
+            "id": self.id,
+            "schema": self.schema,
+        }
+        if self.description:
+            data["description"] = self.description
+        return data

--- a/app/shell/py/pie/tests/test_create_post.py
+++ b/app/shell/py/pie/tests/test_create_post.py
@@ -7,6 +7,7 @@ from ruamel.yaml import YAML
 yaml = YAML(typ="safe")
 
 from pie.create import post
+from pie.schema import DEFAULT_SCHEMA
 from pie.utils import get_pubdate
 
 
@@ -22,8 +23,14 @@ def test_create_post_creates_files(tmp_path: Path, monkeypatch) -> None:
     assert yml_file.exists(), "YAML file should be created"
 
     data = yaml.load(yml_file.read_text(encoding="utf-8"))
-    assert set(data) == {"author", "pubdate", "title", "breadcrumbs"}
-    assert data["pubdate"] == get_pubdate()
+    assert set(data) == {"breadcrumbs", "doc", "id", "schema"}
+    assert data["doc"] == {
+        "author": "",
+        "pubdate": get_pubdate(),
+        "title": "",
+    }
+    assert data["id"] == "my_post"
+    assert data["schema"] == DEFAULT_SCHEMA
     assert data["breadcrumbs"] == [
         {"title": "Home", "url": "/"},
         {"title": "Blog", "url": "/blog/"},

--- a/app/shell/py/pie/tests/test_metadata_model.py
+++ b/app/shell/py/pie/tests/test_metadata_model.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pie.model import Breadcrumb, Doc, Metadata
+from pie.schema import DEFAULT_SCHEMA
+
+
+def test_metadata_to_dict_excludes_missing_url() -> None:
+    breadcrumbs = [Breadcrumb("Home", "/"), Breadcrumb("Post")]
+    meta = Metadata(
+        id="post",
+        doc=Doc(author="", pubdate="2024-01-01", title=""),
+        breadcrumbs=breadcrumbs,
+    )
+
+    assert meta.to_dict() == {
+        "breadcrumbs": [
+            {"title": "Home", "url": "/"},
+            {"title": "Post"},
+        ],
+        "doc": {"author": "", "pubdate": "2024-01-01", "title": ""},
+        "id": "post",
+        "schema": DEFAULT_SCHEMA,
+    }


### PR DESCRIPTION
## Summary
- define `Doc` and enhanced `Metadata` models matching repo schema
- generate ids and doc info in `create-post` using new models
- update tests for revised metadata structure

## Testing
- `PYTHONPATH=app/shell/py/pie pytest app/shell/py/pie/tests/test_metadata_model.py app/shell/py/pie/tests/test_create_post.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1a34a521883219af757bac2db6631