### PR TITLE
Add default Markdown template to create-post

### DIFF
--- a/app/shell/py/pie/pie/create/post.py
+++ b/app/shell/py/pie/pie/create/post.py
@@ -10,6 +10,12 @@ from pie.logging import configure_logging, logger
 from pie.utils import get_pubdate, write_yaml
 
 
+DEFAULT_MD = (
+    "{% extends 'src/templates/template.html.jinja' %}\n"
+    "{% block content %}\n\n"
+    "{% endblock %}\n"
+)
+
 __all__ = ["main"]
 
 
@@ -42,7 +48,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     md_path = base.with_suffix(".md")
     yml_path = base.with_suffix(".yml")
 
-    md_path.touch()
+    md_path.write_text(DEFAULT_MD, encoding="utf-8")
     try:
         rel_parts = base.resolve().relative_to(Path("src").resolve()).parts
     except ValueError:

--- a/app/shell/py/pie/tests/test_create_post.py
+++ b/app/shell/py/pie/tests/test_create_post.py
@@ -21,6 +21,7 @@ def test_create_post_creates_files(tmp_path: Path, monkeypatch) -> None:
 
     assert md_file.exists(), "Markdown file should be created"
     assert yml_file.exists(), "YAML file should be created"
+    assert md_file.read_text(encoding="utf-8") == post.DEFAULT_MD
 
     data = yaml.load(yml_file.read_text(encoding="utf-8"))
     assert set(data) == {"breadcrumbs", "doc", "id", "schema"}


### PR DESCRIPTION
## Summary
- write default Jinja template to newly created Markdown files
- verify template presence in create-post test

## Testing
- `pytest app/shell/py/pie/tests/test_create_post.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1a7dda3848321b772f6a62a90a2b8