### PR TITLE
feat: support mdi extension

### DIFF
--- a/app/shell/py/pie/pie/metadata.py
+++ b/app/shell/py/pie/pie/metadata.py
@@ -37,14 +37,14 @@ def get_url(filename: str) -> Optional[str]:
     if filename.startswith(prefix):
         relative_path = filename[len(prefix) :]
         base, ext = os.path.splitext(relative_path)
-        if ext.lower() in {".md"} | YAML_EXTS:
+        if ext.lower() in {".md", ".mdi"} | YAML_EXTS:
             html_path = base + ".html"
             return "/" + html_path
     prefix = "build" + os.sep
     if filename.startswith(prefix):
         relative_path = filename[len(prefix) :]
         base, ext = os.path.splitext(relative_path)
-        if ext.lower() in {".md"} | YAML_EXTS:
+        if ext.lower() in {".md", ".mdi"} | YAML_EXTS:
             html_path = base + ".html"
             return "/" + html_path
     logger.warning("Can't create a url.", filename=filename)
@@ -338,10 +338,10 @@ def get_metadata_by_path(filepath: str, keypath: str) -> Any | None:
 def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
     """Load metadata from ``path`` and a sibling Markdown or metadata file.
 
-    If both a ``.md`` and ``.yml``/``.yaml`` exist for the same base name, the
-    metadata from each file is combined. Values from YAML override those from
-    Markdown when keys conflict and a :class:`UserWarning` is emitted. Returns
-    ``None`` if neither file contains metadata.
+    If both a ``.md``/``.mdi`` and ``.yml``/``.yaml`` exist for the same base
+    name, the metadata from each file is combined. Values from YAML override
+    those from Markdown when keys conflict and a :class:`UserWarning` is
+    emitted. Returns ``None`` if neither file contains metadata.
 
     Example
     -------
@@ -355,12 +355,18 @@ def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
 
     base = path.with_suffix("")
     md_path = base.with_suffix(".md")
+    mdi_path = base.with_suffix(".mdi")
     yml_path = base.with_suffix(".yml")
     yaml_path = base.with_suffix(".yaml")
 
     md_data = None
+    markdown_file: Path | None = None
     if md_path.exists():
-        md_data = _read_from_markdown(str(md_path))
+        markdown_file = md_path
+    elif mdi_path.exists():
+        markdown_file = mdi_path
+    if markdown_file:
+        md_data = _read_from_markdown(str(markdown_file))
 
     meta_data = None
     meta_file: Path | None = None
@@ -390,13 +396,15 @@ def load_metadata_pair(path: Path) -> Mapping[str, Any] | None:
     files: list[Path] = []
     if meta_file:
         files.append(meta_file)
-    if md_path.exists():
-        files.append(md_path)
+    if markdown_file:
+        files.append(markdown_file)
 
     if files:
-        combined["path"] = [str(p.resolve().relative_to(Path.cwd())) for p in files]
+        combined["path"] = [
+            str(p.resolve().relative_to(Path.cwd())) for p in files
+        ]
     # Populate any missing metadata fields based on the source path.
-    source = md_path if md_path.exists() else meta_file or path
+    source = markdown_file or meta_file or path
     combined = generate_missing_metadata(combined, str(source))
 
     logger.debug("returning", combined=combined)

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -3,6 +3,7 @@ import os
 import fakeredis
 import pytest
 import ruamel.yaml as yaml
+from pathlib import Path
 
 from pie import metadata
 
@@ -98,6 +99,20 @@ def test_load_metadata_pair_conflict_shows_path(tmp_path, monkeypatch):
         assert any("dir/post.yml" in m for m in messages)
     finally:
         os.chdir("/tmp")
+
+
+def test_load_metadata_pair_accepts_mdi(tmp_path):
+    """'.mdi' files are treated like '.md'."""
+    mdi = tmp_path / "src" / "post.mdi"
+    mdi.parent.mkdir(parents=True)
+    mdi.write_text("---\ntitle: MDI\n---\n")
+    os.chdir(tmp_path)
+    try:
+        data = metadata.load_metadata_pair(Path("src/post.mdi"))
+    finally:
+        os.chdir("/tmp")
+    assert data["title"] == "MDI"
+    assert data["path"] == ["src/post.mdi"]
 
 
 def test_read_from_yaml_error_logs_path(tmp_path):


### PR DESCRIPTION
## Summary
- treat `.mdi` files like Markdown in metadata loader
- support `.mdi` URLs alongside `.md`
- test loading metadata from `.mdi` files

## Testing
- `pytest -q` *(fails: include_filter and template_mathjax tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c3083fdd7c83218f2e70d8f418a295