### PR TITLE
Test include_deflist_entry generator and document usage

### DIFF
--- a/docs/guides/include-filter.md
+++ b/docs/guides/include-filter.md
@@ -50,9 +50,10 @@ include("src/examples/include-filter/a.md")
 
 ## include_deflist_entry
 
-Insert Markdown files as definition list entries using their `title` metadata.
-Metadata is retrieved from Redis via `get_metadata_by_path()` and the resulting
-title is followed by a `#` that links to the entry's `url` when available.
+Insert Markdown files as definition list entries using their `doc.title`
+metadata. Each term receives the document's `id` and a small `#` anchor that
+links to that identifier. The function yields `<dt>`/`<dd>` pairs that callers
+can join and embed in the output.
 
 Each argument may be a file or directory.
 Multiple paths can be provided to gather entries from different locations.


### PR DESCRIPTION
## Summary
- Exercise generator-based `include_deflist_entry` using `doc.title` and `id` metadata
- Verify generated definition list entries and custom sorting
- Clarify documentation for `include_deflist_entry`

## Testing
- `pytest app/shell/py/pie/tests/test_include_filter.py -q`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/data/src/templates/template.html.jinja')*


------
https://chatgpt.com/codex/tasks/task_e_68c3b6dd3c7c8321a359beb89cb26a1d