### PR TITLE
docs: document deflist macro

### DIFF
--- a/src/templates/macros.jinja
+++ b/src/templates/macros.jinja
@@ -1,9 +1,17 @@
+{#--
+  Macro: deflist
+  Render a definition list from a sequence of identifiers.
+  Each identifier resolves via `get_desc` to a description template.
+
+  Args:
+    ids: Sequence of identifiers to render.
+--#}
 {% macro deflist(ids) %}
-<dl>
-{% for id in ids %}
-{% set desc = get_desc(id) %}
-<dt id="{{desc.deflist.anchor}}">{{ desc.doc.title }} <a href="#{{desc.deflist.anchor}}"><small>#</small></a></dt>
-<dd>{% include desc.deflist.src %}</dd>
-{% endfor %}
-</dl>
+  <dl>
+    {% for id in ids %}
+      {% set desc = get_desc(id) %}
+      <dt id="{{ desc.deflist.anchor }}">{{ desc.doc.title }} <a href="#{{ desc.deflist.anchor }}"><small>#</small></a></dt>
+      <dd>{% include desc.deflist.src %}</dd>
+    {% endfor %}
+  </dl>
 {% endmacro %}


### PR DESCRIPTION
## Summary
- document deflist macro in `macros.jinja`
- tidy indentation for definition list rendering

## Testing
- `pytest` *(fails: include_filter outputs empty string; template.html.jinja missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a01ea9708321b7291faee1bef86f