### PR TITLE
Remove include_deflist_entry helper

### DIFF
--- a/app/shell/py/pie/pie/filter/include.py
+++ b/app/shell/py/pie/pie/filter/include.py
@@ -19,7 +19,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import IO, Callable, Iterable
+from typing import IO, Iterable
 
 from pie.cli import create_parser
 from pie.logging import configure_logging, logger
@@ -85,45 +85,6 @@ def include(filename: str) -> None:
                 line = "#" * heading_level + line
             print(line, end="", file=outfile)
 
-
-def include_deflist_entry(
-    *paths: str,
-    glob: str = "*",
-    sort_fn: Callable[[Iterable[Path]], Iterable[Path]] | None = None,
-) -> None:
-    """Insert contents of Markdown files as definition list entries.
-
-    Each argument in ``paths`` may be a file or directory.  Directories are
-    scanned recursively for files matching ``glob``.  All discovered
-    files are processed in alphabetical order by default, but a custom
-    ``sort_fn`` can be supplied to override the ordering.
-    """
-
-    files: list[Path] = []
-    for p in paths:
-        path = Path(p)
-        if path.is_dir():
-            files.extend(f for f in path.rglob(glob) if f.is_file())
-        else:
-            files.append(path)
-
-    if sort_fn is None:
-        files = sorted(files, key=lambda p: p.name)
-    else:
-        files = list(sort_fn(files))
-
-    for filename in files:
-        logger.debug("include_deflist_entry", filename=str(filename))
-        with open(filename, "r", encoding="utf-8") as f:
-            rel = os.path.relpath(Path(filename).resolve(), Path.cwd())
-            doc_id = get_metadata_by_path(rel, "id")
-            title = get_metadata_by_path(rel, "doc.title")
-            yield f'<dt id="{doc_id}">{title} <a href="#{doc_id}"><small>#</small></a></dt>'
-            yield "<dd>"
-            _skip_front_matter(f)
-            for line in f:
-                yield line
-            yield "</dd>"
 
 
 def yield_lines(infile: IO[str]) -> Iterable[str]:

--- a/app/shell/py/pie/pie/render/jinja.py
+++ b/app/shell/py/pie/pie/render/jinja.py
@@ -32,7 +32,6 @@ from pie.utils import read_json, read_utf8, write_utf8
 from pie.yaml import read_yaml as load_yaml_file
 from pie.yaml import yaml
 from ruamel.yaml import YAMLError
-from pie.filter.include import include_deflist_entry
 
 DEFAULT_CONFIG = Path("cfg/render-jinja-template.yml")
 
@@ -503,9 +502,6 @@ def render_press(text):
         )
     )
 
-def _include_deflist_entry_wrapper(*args, **kwargs):
-    return "".join(include_deflist_entry(*args, **kwargs))
-
 def create_env():
     """Create and configure the Jinja2 environment."""
 
@@ -520,7 +516,6 @@ def create_env():
     env.globals["definition"] = definition
     env.globals["figure"] = figure
     env.globals["get_desc"] = get_desc
-    env.globals["include_deflist_entry"] = _include_deflist_entry_wrapper
     env.globals["linkcap"] = linkcap
     env.globals["linkicon"] = linkicon
     env.globals["link_icon_title"] = link_icon_title

--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -294,40 +294,6 @@ def test_resolve_include_paths_directory(tmp_path):
     ]
 
 
-def test_resolve_include_paths_glob(tmp_path):
-    """_resolve_include_paths applies glob patterns."""
-    src = tmp_path / "src"
-    build = tmp_path / "build"
-    src.mkdir()
-
-    defs = src / "defs"
-    defs.mkdir()
-    (defs / "a.md").write_text("a")
-    (defs / "b.txt").write_text("b")
-
-    index = src / "index.md"
-    index.write_text("body")
-
-    def build_path(p: Path) -> str:
-        rel = p.relative_to(src)
-        out = build / rel
-        if build.is_absolute():
-            out = Path(build.name) / rel
-        return out.as_posix()
-
-    src_build = Path(build_path(index)).with_suffix(index.suffix)
-    rules = picasso._resolve_include_paths(
-        "include_deflist_entry",
-        "'defs', glob='*.md'",
-        src_build=src_build,
-        src_root=src,
-        build_root=build,
-        build_path=build_path,
-    )
-
-    assert rules == ["build/index.md: build/defs/a.md"]
-
-
 def test_resolve_include_paths_absolute(tmp_path):
     """Absolute paths are returned unchanged."""
     src = tmp_path / "src"
@@ -360,28 +326,6 @@ def test_resolve_include_paths_absolute(tmp_path):
 
     expected = f"build/index.md: {(ext / 'x.md').as_posix()}"
     assert rules == [expected]
-
-
-def test_include_deflist_entry_with_glob_and_directory(tmp_path):
-    """include_deflist_entry('defs', glob='*.md') -> deps for each file."""
-    src = tmp_path / "src"
-    build = tmp_path / "build"
-    src.mkdir()
-
-    defs = src / "defs"
-    defs.mkdir()
-    (defs / "a.md").write_text("a")
-    (defs / "b.md").write_text("b")
-
-    index = src / "index.md"
-    index.write_text("```python\ninclude_deflist_entry('defs', glob='*.md')\n```\n")
-
-    deps = picasso.generate_dependencies(src, build)
-
-    assert sorted(deps) == [
-        "build/index.md: build/defs/a.md",
-        "build/index.md: build/defs/b.md",
-    ]
 
 
 def test_include_with_absolute_directory(tmp_path):

--- a/docs/guides/include-filter.md
+++ b/docs/guides/include-filter.md
@@ -22,8 +22,6 @@ include-filter <output-dir> <input> <output>
 
 Repository examples:
 
-- `src/examples/include-filter/index.md` demonstrates `include_deflist_entry`
-  gathering entries from multiple directories.
 - `src/examples/diagram.mmd` contains a Mermaid block rendered by the filter.
 - `src/examples/include-filter/a.md` is a simple file you can pull in with
   `include()`.
@@ -31,8 +29,6 @@ Repository examples:
 ## Functions
 
 - `include(path)` – insert another Markdown file
-- `include_deflist_entry(*paths, glob='*', sort_fn=None)` – build definition
-  list entries
 - `mermaid(file, alt, id)` – convert a Mermaid code block into an image link
 
 ## include
@@ -46,35 +42,6 @@ document.
 ```python
 include("src/examples/include-filter/a.md")
 ```
-```
-
-## include_deflist_entry
-
-Insert Markdown files as definition list entries using their `title` metadata.
-Metadata is retrieved from Redis via `get_metadata_by_path()` and the resulting
-title is followed by a `#` that links to the entry's `url` when available.
-
-Each argument may be a file or directory.
-Multiple paths can be provided to gather entries from different locations.
-Directories are searched recursively for files matching `glob` and processed in
-alphabetical order by default.
-A custom `sort_fn` can be provided to override the ordering.
-
-See `src/examples/include-filter/index.md` for a complete example.
-
-### Example
-
-```markdown
-<dl>
-```python
-# combine entries from two directories using include_deflist_filter
-include_deflist_entry(
-    "src/examples/include-filter",
-    "docs/reference",
-    glob="*.md",
-)
-```
-</dl>
 ```
 
 ## mermaid

--- a/docs/guides/reading-notes.md
+++ b/docs/guides/reading-notes.md
@@ -23,12 +23,7 @@ definitions.
 1. Create `index.md` with two sections:
    - **Bibliography** – cite the book. The hull example embeds a link to the
      Amazon listing stored in `hull-2016-amzn.yml`.
-   - **Reading Notes** – add a `<dl>` block containing an
-     `include_deflist_entry` call that pulls in note pages:
-
-   ```python
-   include_deflist_entry("src/books/<slug>", glob="p*.md")
-   ```
+   - **Reading Notes** – add a `<dl>` block linking to each note page.
 
 2. Add a sidecar file like `hull-2016-amzn.yml` if you want to link to an
    external resource.


### PR DESCRIPTION
## Summary
- drop deprecated include_deflist_entry generator
- remove template integration and tests tied to include_deflist_entry
- update docs to no longer reference include_deflist_entry

## Testing
- `PYTHONPATH=app/shell/py pytest app/shell/py/pie/tests` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/data/src/templates/template.html.jinja')*


------
https://chatgpt.com/codex/tasks/task_e_68c5a08de4c88321a66cdd06480d8729