### PR TITLE
chore: sync create-site templates with project

### DIFF
--- a/app/shell/py/pie/pie/create/site.py
+++ b/app/shell/py/pie/pie/create/site.py
@@ -42,6 +42,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "src/robots.txt": "robots.txt.jinja",
         "README.md": "README.md.jinja",
         "app/shell/Dockerfile": "shell.Dockerfile.jinja",
+        "makefile": "makefile.jinja",
         "redo.mk": "redo.mk.jinja",
     }
 

--- a/app/shell/py/pie/pie/create/templates/docker-compose.yml.jinja
+++ b/app/shell/py/pie/pie/create/templates/docker-compose.yml.jinja
@@ -1,23 +1,106 @@
 services:
   nginx:
-    image: nginx:latest
-    ports:
-      - "80:80"
+    build:
+      context: .
+      dockerfile: ./app/nginx/Dockerfile
+      args:
+        NGINX_CONF: app/nginx/prod.conf
+    restart: unless-stopped
+
+  # No ports are exposed so we can use a private instance to check for broken
+  # links. All scripts are executed within a container.
+  nginx-test:
+    build:
+      context: .
+      dockerfile: ./app/nginx/Dockerfile
 
   nginx-dev:
-    image: nginx:latest
+    build:
+      context: .
+      dockerfile: ./app/nginx/Dockerfile
     ports:
       - "80:80"
     volumes:
       - ./build:/usr/share/nginx/html
+    restart: unless-stopped
 
-  dragonfly:
-    image: docker.dragonflydb.io/dragonflydb/dragonfly
+  sync:
+    build: ./app/s3
+    container_name: press-sync
+    entrypoint: ["/app/bin/sync"]
+    environment:
+      S3_BUCKET_PATH: ${S3_BUCKET_PATH:-s3://press}
+      S3CFG_PATH: ${S3CFG_PATH:-/root/.s3cfg}
+    volumes:
+      - ../s3:/s3
 
-  shell:
-    build: app/shell
-    working_dir: /data
-    entrypoint: ["bash"]
+  seed:
+    build: ./app/s3
+    container_name: press-seed
+    entrypoint: ["/app/bin/seed"]
+    environment:
+      S3_BUCKET_PATH: ${S3_BUCKET_PATH:-s3://press}
+      S3CFG_PATH: ${S3CFG_PATH:-/root/.s3cfg}
+    volumes:
+      - ../s3:/s3
 
+  webp:
+    build: ./app/webp
+    container_name: press-webp
+    entrypoint: ["/app/bin/service"]
+    volumes:
+      - ./app/webp/input:/app/input
+      - ./app/webp/output:/app/output
+      - ../log:/app/log
+
+  mermaid:
+    image: minlag/mermaid-cli
+    container_name: press-mermaid
     volumes:
       - ./:/data
+
+  # Default port is 6379. Not exposed to the host to avoid port conflicts.
+  # You can run redis-cli within this container.
+  #   docker compose exec dragonfly redis-cli
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly
+    # Useful in avoiding conflicts from multiple active instances of press projects.
+    container_name: press-dragonfly
+
+  shell:
+    image: press-shell
+    build: ./app/shell
+    container_name: press-shell
+    working_dir: /data
+    entrypoint: ["bash"]
+    environment:
+      OPENAI_API_KEY: "${OPENAI_API_KEY}"
+      REDIS_HOST: dragonfly
+      REDIS_PORT: 6379
+      TEST_HOST_URL: ${TEST_HOST_URL:-http://nginx-test}
+      BASE_URL: ${BASE_URL:-http://press.io}
+    volumes:
+      - ./:/data
+      - ./app/shell/bin:/app/bin
+      - ./app/shell/py/pie/pie:/press/py/pie/pie
+      - ./app/shell/py/pie/tests:/press/py/pie/tests
+      - ./src/templates/:/press/templates/
+
+  release:
+    image: press-release
+    build:
+      context: .
+      dockerfile: ./app/release/Dockerfile
+    depends_on:
+      - shell
+
+  pdoc:
+    build:
+      context: .
+      dockerfile: ./app/pdoc/Dockerfile
+    command: pdoc -h 0.0.0.0 -p 8080
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./app/shell/py/pie:/pie
+    profiles: ["pdoc"]

--- a/app/shell/py/pie/pie/create/templates/makefile.jinja
+++ b/app/shell/py/pie/pie/create/templates/makefile.jinja
@@ -1,0 +1,173 @@
+# Makefile for building and managing Press
+# Targets run from the repository root.
+
+export PATH := /app/bin:$(PATH)
+
+# Allow the environment to override BASE_URL instead of forcing localhost.
+# This ensures tooling such as the sitemap generator picks up the value
+# provided via docker-compose or the user's shell.
+BASE_URL ?= http://press.io
+export BASE_URL
+
+# Override MAKEFLAGS (so your settings can’t be clobbered by the environment)
+# docker-make previously passed these flags inside the container; still useful.
+override MAKEFLAGS += --warn-undefined-variables  \
+              --no-builtin-rules        \
+              -j16                      \
+              --no-print-directory      \
+
+# Export it so sub-makes see the same flags
+export MAKEFLAGS
+
+# Verbosity control
+VERBOSE ?= 0
+ifeq ($(VERBOSE),1)
+Q :=
+else
+Q := @
+endif
+
+# Helper to print status messages
+status = @echo "==> $(1)"
+
+# Redis connection settings
+REDIS_HOST ?= dragonfly
+REDIS_PORT ?= 6379
+export REDIS_HOST
+export REDIS_PORT
+
+# Directories
+SRC_DIR   := src
+BUILD_DIR := build
+LOG_DIR   := log
+CFG_DIR   := cfg
+
+# Default template used by render-html
+HTML_TEMPLATE := $(SRC_DIR)/templates/template.html.jinja
+
+# Command for minifying HTML files
+MINIFY_CMD := minify
+
+CHECKLINKS_CMD := checklinks
+TEST_HOST_URL ?= http://nginx-test
+
+VPATH := $(SRC_DIR)
+
+# Find all Markdown files excluding specified directories
+MARKDOWNS := $(shell find $(SRC_DIR)/ -name '*.md')
+YAMLS := $(shell find $(SRC_DIR) -name "*.yml")
+BUILD_YAMLS := $(patsubst $(SRC_DIR)/%,$(BUILD_DIR)/%,$(YAMLS))
+
+# Define the corresponding HTML output files
+HTMLS := $(patsubst $(SRC_DIR)/%.md, $(BUILD_DIR)/%.html, $(MARKDOWNS))
+
+# Sort and define build subdirectories based on HTML files
+BUILD_SUBDIRS := $(sort $(dir $(HTMLS))) $(LOG_DIR) $(BUILD_DIR)/static $(BUILD_DIR)/css
+
+CSS_SRC := $(wildcard $(SRC_DIR)/css/*.css)
+CSS := $(patsubst $(SRC_DIR)/css/%.css,$(BUILD_DIR)/css/%.css, $(CSS_SRC))
+
+# Nginx permalink redirect configuration
+PERMALINKS_CONF := $(BUILD_DIR)/permalinks.conf
+
+START_TIME := $(shell date +%s)
+
+# Define the default target to build everything
+.PHONY: everything
+everything: | $(BUILD_DIR) $(BUILD_SUBDIRS)
+	$(call status,Updating author)
+	$(Q)update-author --sort-keys
+	$(call status,Updating pubdate)
+	$(Q)update-pubdate --sort-keys
+	$(Q)$(MAKE) -s $(BUILD_DIR)/.update-index VERBOSE=$(VERBOSE)
+	$(Q)$(MAKE) -s all VERBOSE=$(VERBOSE)
+	$(Q)END_TIME=$$(date +%s); \
+	ELAPSED=$$((END_TIME - $(START_TIME))); \
+	MIN=$$((ELAPSED / 60)); \
+	SEC=$$((ELAPSED % 60)); \
+	printf "==> Total execution time: %dm %ds\n" $$MIN $$SEC
+
+all: $(HTMLS)
+all: $(CSS)
+all: $(BUILD_DIR)/robots.txt
+all: $(BUILD_DIR)/sitemap.xml
+all: $(PERMALINKS_CONF)
+
+$(BUILD_DIR)/robots.txt: $(SRC_DIR)/robots.txt
+	cp $< $@
+
+$(BUILD_DIR)/sitemap.xml: $(HTMLS)
+	$(call status,Generate sitemap)
+	$(Q)sitemap $(BUILD_DIR)
+
+$(PERMALINKS_CONF): $(MARKDOWNS) $(YAMLS) | $(BUILD_DIR) $(LOG_DIR)
+	$(call status,Generate permalink redirects)
+	$(Q)nginx-permalinks $(SRC_DIR) -o $@ --log $(LOG_DIR)/nginx-permalinks.txt
+
+$(BUILD_DIR)/.update-index: $(YAMLS)
+	$(call status,Updating Redis Index)
+	$(Q)update-index --host $(REDIS_HOST) --port $(REDIS_PORT) src
+	$(Q)touch $@
+
+# Target to minify HTML and CSS files
+# Modifies file timestamps. The preserve option doesn't seem to work.
+# No touch at the end. Minify should always execute.
+$(BUILD_DIR)/.minify:
+	$(call status,Minify HTML and CSS)
+	$(Q)cd $(BUILD_DIR); $(MINIFY_CMD) -a -v -r -o . .
+
+.PHONY: report-static-links
+report-static-links: $(BUILD_DIR)/.minify
+	$(call status,Generate static links report)
+	$(Q)report-static-links
+
+.PHONY: test
+# Triggered by the test target; see docs/guides/redo-mk.md.
+test: $(BUILD_DIR)/.minify check | $(LOG_DIR)
+	$(call status,Run link check)
+	$(Q)$(CHECKLINKS_CMD) $(TEST_HOST_URL)
+
+.PHONY: check
+check: report-static-links
+	$(call status,Run checks)
+	$(Q)check-all
+
+# Create necessary build directories
+$(BUILD_DIR): | $(BUILD_SUBDIRS)
+
+# Create each build subdirectory if it doesn't exist
+$(BUILD_SUBDIRS):
+	$(call status,Create directory $@)
+	$(Q)mkdir -p $@
+
+# Compile SCSS files to the build directory
+$(BUILD_DIR)/css/%.css: $(SRC_DIR)/css/%.css | $(BUILD_DIR)/css
+	$(call status,Compile SCSS $<)
+	$(Q)pysassc $< $@
+
+# Include and preprocess Markdown files up to three levels deep
+# See docs/guides/preprocess.md for preprocessing details
+$(BUILD_DIR)/%.md: %.md | $(BUILD_DIR)
+	$(call status,Preprocess $<)
+	$(Q)cp $< $@
+
+# Generate HTML from processed Markdown using render-html
+$(BUILD_DIR)/%.html: $(BUILD_DIR)/%.md $(BUILD_DIR)/%.yml $(HTML_TEMPLATE) | $(BUILD_DIR)
+	$(call status,Generate HTML $@)
+	$(Q)render-html $(BUILD_DIR)/%.md $< $@
+
+# Clean the build directory by removing all build artifacts
+.PHONY: clean
+clean:
+	$(call status,Remove build artifacts)
+	$(Q)-rm -rf $(BUILD_DIR)/*
+	$(Q)-rm -f $(BUILD_DIR)/.update-index
+
+# Optionally include user dependencies
+-include src/dep.mk
+
+$(BUILD_DIR)/picasso.mk: $(YAMLS) | $(BUILD_DIR)
+	$(call status,Generate picasso rules)
+	$(Q)picasso --src $(SRC_DIR) --build $(BUILD_DIR) > $@
+
+include $(BUILD_DIR)/picasso.mk

--- a/app/shell/py/pie/pie/create/templates/redo.mk.jinja
+++ b/app/shell/py/pie/pie/create/templates/redo.mk.jinja
@@ -21,7 +21,12 @@ VPATH := $(SRC_DIR)
 COMPOSE_FILE := docker-compose.yml
 DOCKER_COMPOSE := docker compose -f $(COMPOSE_FILE)
 
-MAKE_CMD := $(DOCKER_COMPOSE) run --rm --entrypoint make -u $(shell id -u) -T shell -C /data
+UID := $(shell id -u)
+GID := $(shell id -g)
+
+COMPOSE_RUN := $(DOCKER_COMPOSE) run --build --rm -T
+PYTEST_CMD  := $(DOCKER_COMPOSE) run --rm --user $(UID):$(GID) --entrypoint pytest shell
+RUN_MAKE   := $(DOCKER_COMPOSE) run --rm --user $(UID):$(GID) --entrypoint make shell
 
 # Verbosity control
 VERBOSE ?= 0
@@ -30,6 +35,9 @@ Q :=
 else
 Q := @
 endif
+
+# Git version for cache busting
+BUILD_VER := $(shell git rev-parse --short HEAD)
 
 # Helper to print status messages
 status = @echo "==> $(1)"
@@ -42,11 +50,21 @@ status = @echo "==> $(1)"
 all: ## Build the site using the shell service
 	$(call status,Build site)
 	$(Q)$(DOCKER_COMPOSE) up -d --remove-orphans dragonfly
-	$(Q)$(MAKE_CMD) VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR)
+	$(Q)$(RUN_MAKE) VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) BUILD_VER=$(BUILD_VER)
 
 $(BUILD_DIR): ## Helper target used by other rules
 	$(call status,Prepare build directory $@)
 	$(Q)mkdir -p $@
+
+all: build/examples/mermaid/diagram.svg | build/examples/mermaid
+
+build/examples/mermaid:
+	mkdir -p $@
+
+# Generate SVG diagrams from Mermaid source files
+$(BUILD_DIR)/%.svg: $(SRC_DIR)/%.mmd | $(dir $(BUILD_DIR)/%.svg)
+	$(call status,Render Mermaid $<)
+	$(Q)$(COMPOSE_RUN) -u `id -u` mermaid -i $< -o $@
 
 # Docker-related targets
 # Initialize Docker authentication and build the Nginx image
@@ -68,7 +86,12 @@ docker: test ## Build and push the Nginx image after running test
 .PHONY: test
 test: ## Restart nginx-dev and run tests
 	$(call status,Run tests)
-	$(Q)$(MAKE_CMD) VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
+	$(Q)$(RUN_MAKE) VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
+
+.PHONY: check
+check:
+	$(call status,Run checks)
+	$(Q)$(RUN_MAKE) VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) check
 
 # Target to bring up the development Nginx container
 .PHONY: up
@@ -85,20 +108,21 @@ upd: ## Start development containers in detached mode
 down: ## Stop and remove the compose stack
 	$(call status,Stop compose stack)
 	$(Q)$(DOCKER_COMPOSE) down --remove-orphans
+	$(Q)-rm -f $(BUILD_DIR)/.update-index
 
 # Clean the build directory by removing all build artifacts
 .PHONY: clean
 clean: ## Remove everything under build/
-	$(call status,Remove build artifacts)
-	$(Q)-rm -rf $(BUILD_DIR)/*
-	$(Q)-rm -f $(BUILD_DIR)/.update-index
+	$(Q)$(RUN_MAKE) VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) clean
 
 .PHONY: distclean
 distclean: clean ## Remove .init markers and clear Dragonfly index cache
 	$(call status,Remove .init)
 	$(Q)-rm -f `find app/ -name .init`
 	$(call status,Empty Index Cache)
-	$(Q)./bin/redis-cli flushall
+	$(Q)-./bin/redis-cli flushall
+	$(call status,Clearing log/)
+	$(Q)-rm -rf log/*
 
 .PHONY: prune
 prune: ## Run docker system prune -f to clean unused resources
@@ -116,22 +140,22 @@ setup: ## Prepare app/webp directories and build all services
 .PHONY: seed
 seed: ## Run the seed container to populate initial data
 	$(call status,Seed database)
-	$(Q)$(DOCKER_COMPOSE) run --build --rm -T seed
+	$(Q)$(COMPOSE_RUN) seed
 
 .PHONY: sync
 sync: ## Upload site files to S3 using the sync container
 	$(call status,Run sync container)
-	$(Q)$(DOCKER_COMPOSE) run --build --rm -T sync
+	$(Q)$(COMPOSE_RUN) sync
 
 .PHONY: webp
 webp: ## Convert images to webp format
 	$(call status,Convert images to webp)
-	$(Q)$(DOCKER_COMPOSE) run --build --rm -T webp
+	$(Q)$(COMPOSE_RUN) webp
 
 .PHONY: shell
 shell: ## Open an interactive shell container
 	$(call status,Open shell)
-	$(Q)$(DOCKER_COMPOSE) run --rm --build shell
+	$(Q)./bin/shell
 
 .PHONY: rmi
 rmi: ## Remove Docker images matching press-*
@@ -141,6 +165,7 @@ rmi: ## Remove Docker images matching press-*
 .PHONY: help
 help: ## List available tasks
 	@grep -E '^[a-zA-Z0-9_-]+:.*##' $(MAKEFILE_LIST) | \
+	sort | \
 	awk -F ':.*##' '{printf "%-10s %s\n", $$1, $$2}'
 
 .PHONY: buildx
@@ -153,18 +178,19 @@ buildx: ## Run Docker buildx
 pytest:
 	# Add option -s to see stdout.
 	$(call status,Run pytest)
-	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell /press/py/pie/tests
+	$(Q)$(PYTEST_CMD) /press/py/pie/tests
 
 .PHONY: cov
 cov:
 	$(call status,Run coverage)
 	$(Q)mkdir -p log/cov
-	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell --cov=pie --cov-report=term-missing --cov-report=html:/data/log/cov /press/py/pie/tests
+	$(Q)$(PYTEST_CMD) --cov=pie --cov-report=term-missing --cov-report=html:/data/log/cov /press/py/pie/tests
+
 .PHONY: t
 t: ## Restart nginx-dev and run tests, ansi colors
 	$(call status,Run tests with colors)
-	$(Q)$(DOCKER_COMPOSE) run --entrypoint make --rm shell -C /data VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
-	$(Q)$(DOCKER_COMPOSE) run --entrypoint pytest --rm shell /press/py/pie/tests
+	$(Q)./bin/nginx-test VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) test
+	$(Q)$(PYTEST_CMD) /press/py/pie/tests
 
 .PHONY: redis
 redis: ## Open redis-cli on the dragonfly service
@@ -175,6 +201,5 @@ tags:
 	$(Q)ctags -R app/shell/py
 
 .PHONY: release
-release: all test
-	$(Q)$(DOCKER_COMPOSE) build shell
-	$(Q)$(DOCKER_COMPOSE) build release
+release:
+	$(Q)VERBOSE=$(VERBOSE) SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR) ./bin/release

--- a/app/shell/py/pie/pie/create/templates/style.css.jinja
+++ b/app/shell/py/pie/pie/create/templates/style.css.jinja
@@ -1,7 +1,305 @@
-/* Minimal stylesheet */
-body {
-  font-family: sans-serif;
-  margin: 1em auto;
-  max-width: 40em;
+/*! 
+ * Custom styles supplementing Bootstrap.
+ * Defines styles for quiz components and utility classes.
+ */
+
+:root {
+    --font-base: var(--bs-body-font-family);
 }
 
+/* Layout */
+html {
+  scroll-padding-top: calc(80px + env(safe-area-inset-top)); /* same as navbar height */
+}
+
+/* Layout */
+body {
+  margin: 0;
+  padding-top: calc(56px + env(safe-area-inset-top));
+}
+
+/* Quiz */
+.quiz-container {
+  max-width: 600px;
+  margin: 2rem auto;
+}
+
+.question-block {
+  margin-bottom: 2rem;
+}
+
+.question {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.choices {
+  list-style: none;
+  padding: 0;
+}
+
+.choice {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  margin-bottom: 0.3rem;
+  cursor: pointer;
+  border-radius: 4px;
+  user-select: none;
+}
+
+.choice:hover {
+  background-color: #f5f5f5;
+}
+
+.choice.selected {
+  background-color: #e0f7fa;
+}
+
+.choice.correct {
+  background-color: #c8f7c5;
+  border-color: #27ae60;
+}
+
+.choice.incorrect {
+  background-color: #f7c5c5;
+  border-color: #e74c3c;
+}
+
+.explanation {
+  background: #f9f9f9;
+  padding: 0.5rem;
+  margin-top: 0.5rem;
+  border-left: 3px solid #ccc;
+}
+
+/* Buttons */
+.opcalc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 1rem auto;
+  padding: 0.5rem 1.25rem;
+  background-color: #1976d2;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02857em;
+  box-shadow:
+    0px 2px 4px -1px rgba(0, 0, 0, 0.2),
+    0px 4px 5px 0px rgba(0, 0, 0, 0.14),
+    0px 1px 10px 0px rgba(0, 0, 0, 0.12);
+  transition: background-color 0.3s, box-shadow 0.3s;
+  max-width: fit-content;
+}
+
+.opcalc-btn:hover,
+.opcalc-btn:focus {
+  background-color: #1565c0;
+  box-shadow:
+    0px 3px 5px -1px rgba(0, 0, 0, 0.2),
+    0px 5px 8px 0px rgba(0, 0, 0, 0.14),
+    0px 1px 14px 0px rgba(0, 0, 0, 0.12);
+}
+
+@media (max-width: 600px) {
+  .opcalc-btn {
+    width: 100%;
+    padding: 0.75rem;
+  }
+}
+
+.submit-btn {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+/* Misc */
+.my-comment {
+  font-style: italic;
+}
+
+.preamble {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+/* Table of Contents */
+#TOC {
+  margin-bottom: 2rem;
+}
+
+main li + li {
+  margin-top: 0.5rem;
+}
+
+main nav li + li {
+  margin-top: 0 !important;
+}
+
+.image-container {
+  position: relative;
+  display: inline-block;
+}
+
+.magnify-icon {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  background-color: rgba(255, 255, 255, 0.8);
+  border-radius: 50%;
+  padding: 6px;
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.citation {
+  border: thin solid black;
+  border-radius: 3px;
+  padding: 2px;
+}
+
+.emoji {
+  font-size: 1.1em;
+  line-height: 1;
+}
+
+ol + details.answer {
+  margin-top: 15px;
+}
+
+/* Metadata block */
+.metablock {
+  background-color: #f8f9fa;
+  border-left: 4px solid #6c757d;
+  padding: 1rem;
+  margin-bottom: 2rem;
+  border-radius: 0.25rem;
+}
+
+/* Headings and section layout */
+main h1,
+main h2,
+main h3,
+main h4,
+main h5,
+main h6 {
+  margin-top: 3rem;
+  margin-bottom: 2rem;
+}
+
+main h2 {
+  padding-top: 1rem;
+  border-top: 2px solid #e9ecef;
+}
+
+h1 + p,
+h2 + p,
+h3 + p,
+h4 + p,
+h5 + p,
+h6 + p {
+  margin-top: 2rem;
+}
+
+main section {
+  margin-bottom: 3rem;
+  padding: 2.5rem;
+  background-color: #f8f9fa;
+  border-radius: 0.5rem;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
+}
+
+/* Paragraph spacing and indentation */
+main > p,
+main section > p {
+  margin-bottom: 2rem;
+}
+
+main > p:first-of-type,
+main section > p:first-of-type {
+}
+
+/* Figures */
+main figure {
+  max-width: 100%;
+  margin: 0 auto 2rem;
+}
+
+main figure img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+/* Definition lists */
+main dl {
+  margin-bottom: 2rem;
+}
+
+main dt {
+  font-weight: 600;
+}
+
+main dd {
+  margin-left: 1.5rem;
+}
+
+main dd + dt {
+  margin-top: 2rem;
+}
+
+/* Tables */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 2rem;
+}
+
+th,
+td {
+  border: 1px solid #dee2e6;
+  padding: 0.5rem;
+}
+
+th {
+  background-color: #f8f9fa;
+  font-weight: 600;
+  text-align: left;
+}
+
+tbody tr:nth-of-type(even) {
+  background-color: #f2f2f2;
+}
+
+/* Code blocks */
+pre,
+code {
+  font-family: var(--bs-font-monospace);
+}
+
+pre {
+  padding: 1rem;
+  background-color: var(--bs-light);
+  border: 1px solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  overflow-x: auto;
+}
+
+code {
+  padding: 0.2rem 0.4rem;
+  font-size: 1em;
+  color: var(--bs-code-color);
+  background-color: var(--bs-light);
+  border-radius: var(--bs-border-radius);
+}
+
+pre code {
+  padding: 0;
+  color: inherit;
+  background-color: transparent;
+  border: 0;
+}

--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -2,56 +2,75 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from pie.create import site
 
 
-def test_create_scaffolding(tmp_path: Path) -> None:
+@pytest.fixture()
+def scaffold(tmp_path: Path) -> Path:
     target = tmp_path / "press-project"
     site.main([str(target)])
+    return target
 
-    compose = target / "docker-compose.yml"
+
+def test_docker_compose_has_services(scaffold: Path) -> None:
+    compose = scaffold / "docker-compose.yml"
     assert compose.exists()
     text = compose.read_text(encoding="utf-8")
     for svc in ["nginx:", "nginx-dev:", "dragonfly:", "shell:"]:
         assert svc in text
-    assert "    build: app/shell" in text
+    assert "    build: ./app/shell" in text
     assert "    working_dir: /data" in text
     assert '    entrypoint: ["bash"]' in text
     assert "      - ./:/data" in text
-    assert (target / "src").is_dir()
 
-    dep_mk = target / "src/dep.mk"
+
+def test_generated_files_have_content(scaffold: Path) -> None:
+    assert (scaffold / "src").is_dir()
+
+    dep_mk = scaffold / "src/dep.mk"
     assert dep_mk.exists()
     assert dep_mk.read_text(encoding="utf-8") == ""
 
-    robots = target / "src/robots.txt"
+    robots = scaffold / "src/robots.txt"
     assert robots.exists()
     robots_text = robots.read_text(encoding="utf-8")
     assert "User-agent: *" in robots_text
 
-    assert (target / "redo.mk").exists()
+    redo_mk = scaffold / "redo.mk"
+    assert "PYTEST_CMD" in redo_mk.read_text(encoding="utf-8")
 
-    assert (target / "src/css/style.css").exists()
-    template = target / "src/templates/template.html.jinja"
+    style_css = scaffold / "src/css/style.css"
+    style_text = style_css.read_text(encoding="utf-8")
+    assert "font-family" in style_text
+
+    template = scaffold / "src/templates/template.html.jinja"
     assert template.exists()
-    assert not (target / "src/template.html").exists()
+    assert not (scaffold / "src/template.html").exists()
 
-    shell_dockerfile = target / "app/shell/Dockerfile"
+    makefile = scaffold / "makefile"
+    assert makefile.exists()
+    make_text = makefile.read_text(encoding="utf-8")
+    assert "BASE_URL ?= http://press.io" in make_text
+
+    shell_dockerfile = scaffold / "app/shell/Dockerfile"
     assert shell_dockerfile.exists()
-    assert shell_dockerfile.read_text(encoding="utf-8").startswith("FROM press-release")
+    docker_text = shell_dockerfile.read_text(encoding="utf-8")
+    assert docker_text.startswith("FROM press-release")
 
-    index_md = target / "src/index.md"
+    index_md = scaffold / "src/index.md"
     assert index_md.exists()
     md_text = index_md.read_text(encoding="utf-8")
     assert "Welcome" in md_text
     assert "view it locally" in md_text
 
-    index_yml = target / "src/index.yml"
+    index_yml = scaffold / "src/index.yml"
     assert index_yml.exists()
     yml_text = index_yml.read_text(encoding="utf-8")
     assert "title:" in yml_text
 
-    readme = target / "README.md"
+    readme = scaffold / "README.md"
     assert readme.exists(), "README should be created"
     readme_text = readme.read_text(encoding="utf-8")
     assert "docker-compose build" in readme_text


### PR DESCRIPTION
## Summary
- update redo.mk.jinja to match current redo.mk
- add makefile.jinja template
- copy site CSS into style.css.jinja
- mirror docker-compose.yml.jinja to project docker-compose.yml
- generate makefile during scaffold creation
- refactor scaffolding test and expand coverage

## Testing
- `pytest app/shell/py/pie/tests/test_create.py::test_docker_compose_has_services -q`
- `pytest -q` *(fails: TemplateNotFound: 'macros.jinja')*
- `make check` *(fails: picasso not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c82e156e6c83219c0592dc65042f29