### PR TITLE
feat: scaffold shell, upgrade, and author config

### DIFF
--- a/app/shell/py/pie/pie/create/site.py
+++ b/app/shell/py/pie/pie/create/site.py
@@ -42,9 +42,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         "src/robots.txt": "robots.txt.jinja",
         "README.md": "README.md.jinja",
         "app/shell/Dockerfile": "shell.Dockerfile.jinja",
+        "cfg/update-author.yml": "update-author.yml.jinja",
         "makefile": "makefile.jinja",
         "redo.mk": "redo.mk.jinja",
+        "bin/shell": "bin_shell.jinja",
+        "bin/upgrade": "bin_upgrade.jinja",
     }
+
+    executable_files = {"bin/shell", "bin/upgrade"}
 
     for rel_path, template_name in files.items():
         target = root / rel_path
@@ -58,6 +63,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             content = env.from_string(template_text).render()
         target.write_text(content, encoding="utf-8")
+        if rel_path in executable_files:
+            target.chmod(target.stat().st_mode | 0o111)
 
     logger.info("Created project scaffolding", path=str(root))
     return 0

--- a/app/shell/py/pie/pie/create/templates/bin_shell.jinja
+++ b/app/shell/py/pie/pie/create/templates/bin_shell.jinja
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Description:
+#   Run the project's shell service via docker compose.
+#   Supports an optional `-u` flag to set the UID inside the container.
+#
+# Usage:
+#   bin/shell [-u [UID]] [-- COMMAND...]
+#
+# Options:
+#   -u [UID]  Run as the specified user ID. When UID is omitted,
+#             the current user's UID is used.
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [-u [UID]] [-- COMMAND...]" >&2
+  exit 1
+}
+
+uid_flag=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -u)
+      if [[ $# -gt 1 && "$2" != -* ]]; then
+        uid_flag=(-u "$2")
+        shift 2
+      else
+        uid_flag=(-u "$(id -u)")
+        shift 1
+      fi
+      ;;
+    -u*)
+      arg="${1#-u}"
+      if [[ -n "$arg" ]]; then
+        uid_flag=(-u "$arg")
+      else
+        uid_flag=(-u "$(id -u)")
+      fi
+      shift 1
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -* )
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+
+done
+
+COMPOSE_FILE="docker-compose.yml"
+
+exec docker compose -f "$COMPOSE_FILE" run --rm --build "${uid_flag[@]}" shell "$@"

--- a/app/shell/py/pie/pie/create/templates/bin_upgrade.jinja
+++ b/app/shell/py/pie/pie/create/templates/bin_upgrade.jinja
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Run after git pull to rebuild everything required for development.
+# Use -p to run bin/pull after distclean.
+set -euo pipefail
+
+RUN_PULL=0
+while getopts "p" opt; do
+  case "$opt" in
+    p) RUN_PULL=1 ;;
+    *) echo "Usage: $0 [-p]" >&2; exit 1 ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+VERBOSE="${VERBOSE:-0}"
+SRC_DIR="${SRC_DIR:-src}"
+BUILD_DIR="${BUILD_DIR:-build}"
+
+COMPOSE_FILE="docker-compose.yml"
+
+DOCKER_COMPOSE=(docker compose -f "$COMPOSE_FILE")
+
+MAKE_ARGS=(-f redo.mk VERBOSE="$VERBOSE" SRC_DIR="$SRC_DIR" BUILD_DIR="$BUILD_DIR")
+
+run_make() {
+  make "${MAKE_ARGS[@]}" "$@"
+}
+
+cleanup() {
+  "${DOCKER_COMPOSE[@]}" down --remove-orphans
+  docker system prune -f
+  rm -f build/.update-index
+}
+trap cleanup EXIT
+
+echo "Starting upgrade build..."
+
+echo "Stopping existing containers..."
+"${DOCKER_COMPOSE[@]}" down --remove-orphans >/dev/null 2>&1 || true
+echo "Building shell image..."
+"${DOCKER_COMPOSE[@]}" build shell
+echo "Starting dragonfly..."
+"${DOCKER_COMPOSE[@]}" up -d --remove-orphans dragonfly
+echo "Running distclean..."
+run_make distclean
+if [ "$RUN_PULL" -eq 1 ]; then
+  echo "Running pull..."
+  bin/pull
+  # Dockerfile for shell may have been updated.
+  echo "Building shell image..."
+  "${DOCKER_COMPOSE[@]}" build shell
+fi
+echo "Running make..."
+run_make
+echo "Starting nginx-test..."
+"${DOCKER_COMPOSE[@]}" up -d --build --remove-orphans nginx-test
+echo "Running make test..."
+run_make test
+echo "Running pytest..."
+run_make pytest
+
+echo "Upgrade Build Successful"

--- a/app/shell/py/pie/pie/create/templates/update-author.yml.jinja
+++ b/app/shell/py/pie/pie/create/templates/update-author.yml.jinja
@@ -1,0 +1,2 @@
+doc:
+  author: unknown

--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -74,3 +74,20 @@ def test_generated_files_have_content(scaffold: Path) -> None:
     assert readme.exists(), "README should be created"
     readme_text = readme.read_text(encoding="utf-8")
     assert "docker-compose build" in readme_text
+
+    update_author = scaffold / "cfg/update-author.yml"
+    assert update_author.exists()
+    update_author_text = update_author.read_text(encoding="utf-8")
+    assert update_author_text == "doc:\n  author: unknown\n"
+
+    shell_script = scaffold / "bin/shell"
+    assert shell_script.exists()
+    shell_text = shell_script.read_text(encoding="utf-8")
+    assert "docker compose" in shell_text
+    assert shell_script.stat().st_mode & 0o111
+
+    upgrade_script = scaffold / "bin/upgrade"
+    assert upgrade_script.exists()
+    upgrade_text = upgrade_script.read_text(encoding="utf-8")
+    assert "Upgrade Build Successful" in upgrade_text
+    assert upgrade_script.stat().st_mode & 0o111


### PR DESCRIPTION
## Summary
- scaffold `bin/shell`, `bin/upgrade`, and `cfg/update-author.yml` when running `create-site`
- mark generated shell and upgrade scripts executable so they can run immediately
- extend the create-site test to cover the new scripts and author config file

## Testing
- pytest app/shell/py/pie/tests/test_create.py

------
https://chatgpt.com/codex/tasks/task_e_68c83bb25240832189a9d39b158cda95