### PR TITLE
Add PubDate model for document metadata

### DIFF
--- a/app/shell/py/pie/pie/create/post.py
+++ b/app/shell/py/pie/pie/create/post.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from typing import Sequence
 
 from pie.cli import create_parser
-from pie.model import Breadcrumb, Doc, Metadata
+from pie.model import Breadcrumb, Doc, Metadata, PubDate
 from pie.logging import configure_logging, logger
-from pie.utils import get_pubdate, write_yaml
+from pie.utils import write_yaml
 
 
 DEFAULT_MD = (
@@ -69,7 +69,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         id=_id_from_slug(slug),
         doc=Doc(
             author="",
-            pubdate=get_pubdate(),
+            pubdate=PubDate(),
             title="",
             breadcrumbs=breadcrumbs,
         ),

--- a/app/shell/py/pie/pie/model/__init__.py
+++ b/app/shell/py/pie/pie/model/__init__.py
@@ -1,5 +1,5 @@
 """Data models for pie."""
 
-__all__ = ["Breadcrumb", "Doc", "Metadata"]
+__all__ = ["Breadcrumb", "Doc", "Metadata", "PubDate"]
 
-from .metadata import Breadcrumb, Doc, Metadata  # noqa: F401
+from .metadata import Breadcrumb, Doc, Metadata, PubDate  # noqa: F401

--- a/app/shell/py/pie/tests/test_metadata_model.py
+++ b/app/shell/py/pie/tests/test_metadata_model.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from pie.model import Breadcrumb, Doc, Metadata
+from datetime import datetime
+
+import pie.model.metadata as metadata_module
+
+from pie.model import Breadcrumb, Doc, Metadata, PubDate
 from pie.schema import DEFAULT_SCHEMA
 
 
@@ -29,3 +33,36 @@ def test_metadata_to_dict_excludes_missing_url() -> None:
         "id": "post",
         "schema": DEFAULT_SCHEMA,
     }
+
+
+def test_pubdate_from_datetime() -> None:
+    moment = datetime(2024, 1, 1)
+
+    pubdate = PubDate(moment)
+
+    assert str(pubdate) == metadata_module.get_pubdate(moment)
+
+
+def test_pubdate_uses_get_pubdate_for_none(monkeypatch) -> None:
+    special = "Jan 02, 2000"
+    monkeypatch.setattr(metadata_module, "get_pubdate", lambda date=None: special)
+
+    pubdate = metadata_module.PubDate(None)
+
+    assert str(pubdate) == special
+
+
+def test_doc_coerces_string_pubdate() -> None:
+    doc = Doc(author="", pubdate="Jan 03, 2000", title="")
+
+    assert isinstance(doc.pubdate, PubDate)
+    assert doc.to_dict()["pubdate"] == "Jan 03, 2000"
+
+
+def test_doc_accepts_pubdate_instance() -> None:
+    pubdate = PubDate("Jan 04, 2000")
+
+    doc = Doc(author="", pubdate=pubdate, title="")
+
+    assert doc.pubdate is pubdate
+    assert doc.to_dict()["pubdate"] == "Jan 04, 2000"


### PR DESCRIPTION
## Summary
- add a PubDate data class that normalizes doc.pubdate values using get_pubdate
- coerce Doc.pubdate to the new model and use it in the create-post CLI
- cover the new model behaviour with dedicated metadata model tests

## Testing
- pytest app/shell/py/pie/tests/test_metadata_model.py app/shell/py/pie/tests/test_create_post.py

------
https://chatgpt.com/codex/tasks/task_e_68c840fbed808321909967b7107797e1