### PR TITLE
Add redis-cli helper to create-site scaffolding

### DIFF
--- a/app/shell/py/pie/pie/create/site.py
+++ b/app/shell/py/pie/pie/create/site.py
@@ -49,10 +49,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         "makefile": "makefile.jinja",
         "redo.mk": "redo.mk.jinja",
         "bin/shell": "bin_shell.jinja",
+        "bin/redis-cli": "bin_redis_cli.jinja",
         "bin/upgrade": "bin_upgrade.jinja",
     }
 
-    executable_files = {"bin/shell", "bin/upgrade"}
+    executable_files = {"bin/shell", "bin/redis-cli", "bin/upgrade"}
 
     for rel_path, template_name in files.items():
         target = root / rel_path

--- a/app/shell/py/pie/pie/create/templates/bin_redis_cli.jinja
+++ b/app/shell/py/pie/pie/create/templates/bin_redis_cli.jinja
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Run redis-cli inside the dragonfly service.
+# Any arguments provided are forwarded to redis-cli.
+
+docker compose exec dragonfly redis-cli "$@"

--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -102,6 +102,12 @@ def test_generated_files_have_content(scaffold: Path) -> None:
     assert "docker compose" in shell_text
     assert shell_script.stat().st_mode & 0o111
 
+    redis_cli = scaffold / "bin/redis-cli"
+    assert redis_cli.exists()
+    redis_text = redis_cli.read_text(encoding="utf-8")
+    assert "docker compose exec dragonfly redis-cli" in redis_text
+    assert redis_cli.stat().st_mode & 0o111
+
     upgrade_script = scaffold / "bin/upgrade"
     assert upgrade_script.exists()
     upgrade_text = upgrade_script.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a redis-cli helper template to the create-site scaffolding
- ensure the generated script is marked executable during scaffolding
- extend the create-site test to cover the redis-cli helper

## Testing
- pytest app/shell/py/pie/tests/test_create.py

------
https://chatgpt.com/codex/tasks/task_e_68c842cee0f083219a9a3a6a0d959f26