### PR TITLE
Add indextree to scaffolding home page

### DIFF
--- a/app/shell/py/pie/pie/create/templates/dep.mk.jinja
+++ b/app/shell/py/pie/pie/create/templates/dep.mk.jinja
@@ -1,0 +1,14 @@
+# Generate the IndexTree bundle and JSON data used by the home page.
+include app/indextree/dep.mk
+
+INDEX_DIR := build/static/index
+SITE_TREE := $(INDEX_DIR)/pages.json
+
+all: $(SITE_TREE)
+
+$(INDEX_DIR):
+	mkdir -p $@
+
+$(SITE_TREE): $(shell find src -name '*.yml') | $(INDEX_DIR)
+	$(call status,Indexing src/)
+	$(Q)indextree-json src > $@

--- a/app/shell/py/pie/pie/create/templates/index.md.jinja
+++ b/app/shell/py/pie/pie/create/templates/index.md.jinja
@@ -5,3 +5,10 @@ Welcome to your new Press project.
 Run `redo build` to build the project then `docker compose up --remove-orphans`
 to view it locally.
 
+## Site index
+
+The tree below lists every page under `src/`. It updates automatically when you
+add Markdown or metadata files.
+
+<div class="indextree-root" data-src="/static/index/pages.json"></div>
+

--- a/app/shell/py/pie/pie/create/templates/index.yml.jinja
+++ b/app/shell/py/pie/pie/create/templates/index.yml.jinja
@@ -1,2 +1,5 @@
 title: Home
+html:
+  scripts:
+    - <script type="module" src="/static/js/indextree.js" defer></script>
 

--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -31,7 +31,10 @@ def test_generated_files_have_content(scaffold: Path) -> None:
 
     dep_mk = scaffold / "src/dep.mk"
     assert dep_mk.exists()
-    assert dep_mk.read_text(encoding="utf-8") == ""
+    dep_text = dep_mk.read_text(encoding="utf-8")
+    assert "include app/indextree/dep.mk" in dep_text
+    assert "pages.json" in dep_text
+    assert "indextree-json src" in dep_text
 
     robots = scaffold / "src/robots.txt"
     assert robots.exists()
@@ -80,11 +83,13 @@ def test_generated_files_have_content(scaffold: Path) -> None:
     md_text = index_md.read_text(encoding="utf-8")
     assert "Welcome" in md_text
     assert "view it locally" in md_text
+    assert "indextree-root" in md_text
 
     index_yml = scaffold / "src/index.yml"
     assert index_yml.exists()
     yml_text = index_yml.read_text(encoding="utf-8")
     assert "title:" in yml_text
+    assert "static/js/indextree.js" in yml_text
 
     readme = scaffold / "README.md"
     assert readme.exists(), "README should be created"


### PR DESCRIPTION
## Summary
- show an IndexTree of all pages on the scaffolded home page
- bundle the IndexTree script and JSON generator into the default dep.mk
- cover the new scaffolding assets in the create-site test

## Testing
- `PYTHONPATH=app/shell/py/pie pytest app/shell/py/pie/tests/test_create.py`


------
https://chatgpt.com/codex/tasks/task_e_68c856064f3c8321af4e1136cbab153d