### PR TITLE
Add render-press CLI

### DIFF
--- a/app/shell/py/pie/pie/render/__init__.py
+++ b/app/shell/py/pie/pie/render/__init__.py
@@ -1,5 +1,5 @@
 """Rendering utilities for the pie package."""
 
-from . import html, jinja
+from . import html, jinja, press
 
-__all__ = ["html", "jinja"]
+__all__ = ["html", "jinja", "press"]

--- a/app/shell/py/pie/pie/render/press.py
+++ b/app/shell/py/pie/pie/render/press.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+"""Render Markdown text using the press Markdown renderer.
+
+This module exposes the command line entry point for the
+``render-press`` console script. Markdown input is rendered with
+:func:`pie.render.jinja.render_press` and the resulting HTML is written to
+the requested output file.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from pie.cli import create_parser
+from pie.logging import configure_logging
+from pie.render.jinja import render_press
+from pie.utils import read_utf8, write_utf8
+
+
+__all__ = ["parse_args", "render_markdown", "main"]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Return parsed arguments for the ``render-press`` CLI."""
+
+    parser = create_parser("Render Markdown using the press renderer")
+    parser.add_argument("markdown", help="Markdown source file")
+    parser.add_argument("output", help="File to write rendered HTML to")
+    return parser.parse_args(argv)
+
+
+def render_markdown(markdown_path: str | Path) -> str:
+    """Return HTML by rendering *markdown_path* with ``render_press``."""
+
+    text = read_utf8(str(markdown_path))
+    return str(render_press(text))
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the ``render-press`` console script."""
+
+    args = parse_args(argv)
+    configure_logging(args.verbose, args.log)
+    html = render_markdown(args.markdown)
+    write_utf8(html, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -35,6 +35,7 @@ setup(
             'nginx-permalinks=pie.nginx_permalinks:main',
             'picasso=pie.build.picasso:main',
             'render-html=pie.render.html:main',
+            'render-press=pie.render.press:main',
             'render-jinja-template=pie.render.jinja:main',
             'render-study-json=pie.render_study_json:main',
             'report-static-links=pie.report.static_links:main',

--- a/app/shell/py/pie/tests/test_render_package.py
+++ b/app/shell/py/pie/tests/test_render_package.py
@@ -1,3 +1,11 @@
+import os
+from pathlib import Path
+
+os.environ.setdefault(
+    "PIE_DATA_DIR",
+    str(Path(__file__).resolve().parents[5] / "src" / "templates"),
+)
+
 import pie.render as render_pkg
 
 
@@ -9,3 +17,8 @@ def test_render_package_exports_jinja():
 def test_render_package_exports_html():
     assert "html" in render_pkg.__all__
     assert hasattr(render_pkg, "html")
+
+
+def test_render_package_exports_press():
+    assert "press" in render_pkg.__all__
+    assert hasattr(render_pkg, "press")

--- a/app/shell/py/pie/tests/test_render_press_cli.py
+++ b/app/shell/py/pie/tests/test_render_press_cli.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+
+os.environ.setdefault(
+    "PIE_DATA_DIR",
+    str(Path(__file__).resolve().parents[5] / "src" / "templates"),
+)
+
+from pie.render import press
+
+
+def test_main_renders_markdown_file(tmp_path):
+    markdown = tmp_path / "doc.md"
+    markdown.write_text("Hello :smile:\n", encoding="utf-8")
+    output = tmp_path / "doc.html"
+    press.main([str(markdown), str(output)])
+    html = output.read_text(encoding="utf-8")
+    assert "Hello 😄" in html
+
+
+def test_main_renders_footnotes(tmp_path):
+    markdown = tmp_path / "doc.md"
+    markdown.write_text("Note.[^1]\n\n[^1]: Footnote", encoding="utf-8")
+    output = tmp_path / "doc.html"
+    press.main([str(markdown), str(output)])
+    html = output.read_text(encoding="utf-8")
+    assert '<section class="footnotes"' in html


### PR DESCRIPTION
## Summary
- add a ``render-press`` console script that renders Markdown with ``render_press`` and writes HTML output
- expose the new renderer from ``pie.render`` and register the script in the package entry points
- cover the CLI and package exports with tests

## Testing
- pytest app/shell/py/pie/tests/test_render_press_cli.py app/shell/py/pie/tests/test_render_package.py

------
https://chatgpt.com/codex/tasks/task_e_68c985891f7c8321b53509d5d2fc41a8