### PR TITLE
Ensure create-site scaffolds check page title config

### DIFF
--- a/app/shell/py/pie/pie/create/site.py
+++ b/app/shell/py/pie/pie/create/site.py
@@ -46,6 +46,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "app/nginx/default.conf": "nginx.default.conf.jinja",
         "app/nginx/prod.conf": "nginx.prod.conf.jinja",
         "cfg/update-author.yml": "update-author.yml.jinja",
+        "cfg/check-page-title-exclude.yml": None,
         "makefile": "makefile.jinja",
         "redo.mk": "redo.mk.jinja",
         "bin/shell": "bin_shell.jinja",
@@ -58,14 +59,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     for rel_path, template_name in files.items():
         target = root / rel_path
         target.parent.mkdir(parents=True, exist_ok=True)
-        template_text = (template_dir / template_name).read_text(
-            encoding="utf-8"
-        )
-        if rel_path.endswith(".jinja"):
-            # Preserve Jinja templates without rendering
-            content = template_text
+        if template_name is None:
+            content = ""
         else:
-            content = env.from_string(template_text).render()
+            template_text = (template_dir / template_name).read_text(
+                encoding="utf-8"
+            )
+            if rel_path.endswith(".jinja"):
+                # Preserve Jinja templates without rendering
+                content = template_text
+            else:
+                content = env.from_string(template_text).render()
         target.write_text(content, encoding="utf-8")
         if rel_path in executable_files:
             target.chmod(target.stat().st_mode | 0o111)

--- a/app/shell/py/pie/tests/test_create.py
+++ b/app/shell/py/pie/tests/test_create.py
@@ -101,6 +101,10 @@ def test_generated_files_have_content(scaffold: Path) -> None:
     update_author_text = update_author.read_text(encoding="utf-8")
     assert update_author_text == "doc:\n  author: unknown\n"
 
+    page_title_exclude = scaffold / "cfg/check-page-title-exclude.yml"
+    assert page_title_exclude.exists()
+    assert page_title_exclude.read_text(encoding="utf-8") == ""
+
     shell_script = scaffold / "bin/shell"
     assert shell_script.exists()
     shell_text = shell_script.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- have the create-site scaffold create an empty cfg/check-page-title-exclude.yml file
- adjust the scaffolding test to verify the new config file is created without content

## Testing
- pytest app/shell/py/pie/tests/test_create.py

------
https://chatgpt.com/codex/tasks/task_e_68c99317f024832197a05e4b1c283e48