### PR TITLE
Handle missing check-post-build config file

### DIFF
--- a/app/shell/py/pie/pie/check/post_build.py
+++ b/app/shell/py/pie/pie/check/post_build.py
@@ -42,7 +42,14 @@ def main(argv: list[str] | None = None) -> int:
     Path(args.log).parent.mkdir(parents=True, exist_ok=True)
     configure_logging(args.verbose, args.log)
 
-    required = read_yaml(args.config) or []
+    try:
+        required = read_yaml(args.config) or []
+    except FileNotFoundError:
+        logger.info(
+            "Missing configuration; assuming no required artifacts",
+            path=str(args.config),
+        )
+        required = []
 
     base = Path(args.directory)
     missing = False

--- a/app/shell/py/pie/tests/test_check_post_build.py
+++ b/app/shell/py/pie/tests/test_check_post_build.py
@@ -27,6 +27,20 @@ def test_main_passes_and_logs(tmp_path):
     assert log.exists()
 
 
+def test_main_allows_missing_config(tmp_path):
+    """Missing configuration file -> exit 0."""
+    rc = check_post_build.main(
+        [
+            str(tmp_path / "build"),
+            "-c",
+            str(tmp_path / "missing.yml"),
+            "-l",
+            str(tmp_path / "log.txt"),
+        ]
+    )
+    assert rc == 0
+
+
 def test_parse_args_defaults():
     """parse_args returns default paths."""
     args = check_post_build.parse_args([])


### PR DESCRIPTION
## Summary
- default check-post-build to an empty requirement list when the configuration file is missing
- log that the configuration was skipped and add coverage for the missing-file behavior

## Testing
- pytest app/shell/py/pie/tests/test_check_post_build.py

------
https://chatgpt.com/codex/tasks/task_e_68caed2275e88321af9e0c3fd46a6774