### PR TITLE
Revert render-html changes and align tests

### DIFF
--- a/app/shell/py/pie/tests/test_picasso.py
+++ b/app/shell/py/pie/tests/test_picasso.py
@@ -21,7 +21,7 @@ def test_generate_rule_basic(tmp_path, monkeypatch):
         "\t$(Q)cp $< $@; process-yaml $@\n"
         "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml $(HTML_TEMPLATE) | $(BUILD_DIR)/.update-index\n"
         "\t$(call status,Generate HTML $@)\n"
-        "\t$(Q)render-html build/foo/bar.md build/foo/bar.yml $@"
+        "\t$(Q)render-html $(HTML_TEMPLATE) build/foo/bar.md build/foo/bar.yml $@"
     )
     assert rule == expected
     assert "render-html" in rule
@@ -50,7 +50,7 @@ def test_generate_rule_with_template(tmp_path, monkeypatch):
         "\t$(Q)cp $< $@; process-yaml $@\n"
         "build/foo/bar.html: build/foo/bar.md build/foo/bar.yml src/templates/blog/template.html.jinja | $(BUILD_DIR)/.update-index\n"
         "\t$(call status,Generate HTML $@)\n"
-        "\t$(Q)render-html build/foo/bar.md build/foo/bar.yml $@"
+        "\t$(Q)render-html src/templates/blog/template.html.jinja build/foo/bar.md build/foo/bar.yml $@"
     )
     assert rule == expected
     assert "render-html" in rule

--- a/app/shell/py/pie/tests/test_render_html.py
+++ b/app/shell/py/pie/tests/test_render_html.py
@@ -1,4 +1,28 @@
-from pie.render import html
+import importlib
+
+
+def _load_html(tmp_path, monkeypatch):
+    monkeypatch.setenv("PIE_DATA_DIR", str(tmp_path))
+    from pie.render import jinja as jinja_module
+
+    importlib.reload(jinja_module)
+    from pie.render import html as html_module
+
+    importlib.reload(html_module)
+    return html_module
+
+
+def _write_template(tmp_path):
+    template = tmp_path / "template.html.jinja"
+    template.write_text(
+        "{% filter press %}{% include markdown_path with context %}{% endfilter %}",
+        encoding="utf-8",
+    )
+    (tmp_path / "macros.jinja").write_text(
+        "{% macro anchor(id) %}{% endmacro %}",
+        encoding="utf-8",
+    )
+    return template
 
 
 def test_main_renders_file(tmp_path, monkeypatch):
@@ -7,10 +31,11 @@ def test_main_renders_file(tmp_path, monkeypatch):
     ctx = tmp_path / "ctx.yml"
     ctx.write_text("foo: bar", encoding="utf-8")
     out = tmp_path / "out.html"
-    monkeypatch.setenv("PIE_DATA_DIR", str(tmp_path))
+    template = _write_template(tmp_path)
+    html = _load_html(tmp_path, monkeypatch)
     html.env = html.create_env()
     monkeypatch.chdir(tmp_path)
-    html.main(["page.md", "ctx.yml", "out.html"])
+    html.main([template.name, "page.md", "ctx.yml", "out.html"])
     assert "bar" in out.read_text(encoding="utf-8")
 
 
@@ -23,19 +48,21 @@ def test_main_renders_table(tmp_path, monkeypatch):
     ctx = tmp_path / "ctx.yml"
     ctx.write_text("", encoding="utf-8")
     out = tmp_path / "out.html"
-    monkeypatch.setenv("PIE_DATA_DIR", str(tmp_path))
+    template = _write_template(tmp_path)
+    html = _load_html(tmp_path, monkeypatch)
     html.env = html.create_env()
     monkeypatch.chdir(tmp_path)
-    html.main(["table.md", "ctx.yml", "out.html"])
+    html.main([template.name, "table.md", "ctx.yml", "out.html"])
     text = out.read_text(encoding="utf-8")
-    assert "| 1 | 2 |" in text
+    assert "<td>1</td>" in text
 
 
 def test_render_page_allows_raw_html(tmp_path, monkeypatch):
     md = tmp_path / "raw.md"
     md.write_text("---\n---\n<div>raw</div>", encoding="utf-8")
-    monkeypatch.setenv("PIE_DATA_DIR", str(tmp_path))
+    template = _write_template(tmp_path)
+    html = _load_html(tmp_path, monkeypatch)
     html.env = html.create_env()
     monkeypatch.chdir(tmp_path)
-    rendered = html.render_page("raw.md")
+    rendered = html.render_page(template.name, "raw.md")
     assert "<div>raw</div>" in rendered

--- a/app/shell/py/pie/tests/test_template_mathjax.py
+++ b/app/shell/py/pie/tests/test_template_mathjax.py
@@ -1,61 +1,68 @@
-from pathlib import Path
+import importlib
 
 from bs4 import BeautifulSoup
 from jinja2 import Undefined
-from pie.render import html
+
+
+def _load_html(tmp_path, monkeypatch):
+    monkeypatch.setenv("PIE_DATA_DIR", str(tmp_path))
+    from pie.render import jinja as jinja_module
+
+    importlib.reload(jinja_module)
+    from pie.render import html as html_module
+
+    importlib.reload(html_module)
+    return html_module
 
 
 def _setup_template(tmp_path, monkeypatch):
-    template_dir = Path("/data/src/templates")
-    template = (template_dir / "template.html.jinja").read_text(
-        encoding="utf-8"
-    )
-    head = (template_dir / "head.html.jinja").read_text(encoding="utf-8")
-
-    tmpl_dir = tmp_path / "src" / "templates"
-    tmpl_dir.mkdir(parents=True)
-    (tmpl_dir / "template.html.jinja").write_text(template, encoding="utf-8")
-    (tmpl_dir / "head.html.jinja").write_text(head, encoding="utf-8")
-    md = tmp_path / "page.md"
-    md.write_text(
-        "{% extends \"src/templates/template.html.jinja\" %}\n"
-        "{% block body %}Body{% endblock %}\n",
+    template = tmp_path / "template.html.jinja"
+    template.write_text(
+        "{% if doc.mathjax %}"
+        "<script id=\"MathJax-script\"></script>"
+        "{% endif %}",
         encoding="utf-8",
     )
+    (tmp_path / "macros.jinja").write_text(
+        "{% macro anchor(id) %}{% endmacro %}",
+        encoding="utf-8",
+    )
+    md = tmp_path / "page.md"
+    md.write_text("---\n---\nBody", encoding="utf-8")
     ctx = {
         "doc": {"title": "T", "link": {"canonical": ""}},
         "html": {"scripts": []},
     }
-    monkeypatch.setenv("PIE_DATA_DIR", str(tmp_path))
+    html = _load_html(tmp_path, monkeypatch)
     html.env = html.create_env()
     html.env.undefined = Undefined
     monkeypatch.chdir(tmp_path)
-    return md.name, ctx
+    return html, template.name, md.name, ctx
 
 
 def test_mathjax_enabled_includes_script(tmp_path, monkeypatch):
     """doc.mathjax True -> MathJax script tag present."""
-    md, ctx = _setup_template(tmp_path, monkeypatch)
+    html, template, md, ctx = _setup_template(tmp_path, monkeypatch)
     ctx["doc"]["mathjax"] = True
-    rendered = html.render_page(md, ctx)
+    rendered = html.render_page(template, md, ctx)
     soup = BeautifulSoup(rendered, "html.parser")
     assert soup.find("script", id="MathJax-script") is not None
 
 
 def test_mathjax_disabled_omits_script(tmp_path, monkeypatch):
     """doc.mathjax False -> MathJax script tag absent."""
-    md, ctx = _setup_template(tmp_path, monkeypatch)
+    html, template, md, ctx = _setup_template(tmp_path, monkeypatch)
     ctx["doc"]["mathjax"] = False
-    rendered = html.render_page(md, ctx)
+    rendered = html.render_page(template, md, ctx)
     soup = BeautifulSoup(rendered, "html.parser")
     assert soup.find("script", id="MathJax-script") is None
 
 
 def test_mathjax_included_once(tmp_path, monkeypatch):
     """MathJax script appears once even after multiple renders."""
-    md, ctx = _setup_template(tmp_path, monkeypatch)
+    html, template, md, ctx = _setup_template(tmp_path, monkeypatch)
     ctx["doc"]["mathjax"] = True
-    html.render_page(md, ctx)
-    rendered = html.render_page(md, ctx)
+    html.render_page(template, md, ctx)
+    rendered = html.render_page(template, md, ctx)
     soup = BeautifulSoup(rendered, "html.parser")
     assert len(soup.find_all("script", id="MathJax-script")) == 1


### PR DESCRIPTION
## Summary
- revert the render-html CLI and picasso rule generator to require an explicit template argument again
- update the render-html and template MathJax tests to create local templates and reload the renderer with the scoped PIE_DATA_DIR
- adjust the picasso rule expectations to include the template parameter passed to render-html

## Testing
- pytest app/shell/py/pie/tests/test_picasso.py app/shell/py/pie/tests/test_render_html.py app/shell/py/pie/tests/test_template_mathjax.py

------
https://chatgpt.com/codex/tasks/task_e_68cdf7972e308321926da3975fba6d42