### PR TITLE
Refine check-author exclude handling

### DIFF
--- a/app/shell/py/pie/pie/check/author.py
+++ b/app/shell/py/pie/pie/check/author.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Iterable
+from typing import Iterator
 from itertools import chain
 
 from pie.cli import create_parser
 from pie.logging import logger, configure_logging
 from pie.metadata import load_metadata_pair
+from pie.utils import load_exclude_file
 
 DEFAULT_LOG = "log/check-author.txt"
+DEFAULT_EXCLUDE = Path("cfg/check-author-exclude.yml")
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -27,11 +29,22 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="src",
         help="Root directory to scan for metadata files",
     )
+    parser.add_argument(
+        "-x",
+        "--exclude",
+        help=(
+            "YAML file listing metadata files to skip "
+            f"(default: {DEFAULT_EXCLUDE})"
+        ),
+    )
     return parser.parse_args(argv)
 
 
-def _iter_metadata(root: Path) -> Iterable[tuple[list[Path], dict | None]]:
-    """Yield ``(paths, metadata)`` pairs for files under *root*.
+def _iter_metadata(
+    root: Path,
+    base_dir: Path,
+) -> Iterator[tuple[Path, list[Path], dict | None]]:
+    """Yield ``(metadata_path, paths, metadata)`` for files under *root*.
 
     Each metadata pair is loaded with :func:`load_metadata_pair` to ensure that
     companion Markdown/YAML files are merged.
@@ -39,19 +52,34 @@ def _iter_metadata(root: Path) -> Iterable[tuple[list[Path], dict | None]]:
 
     processed: set[Path] = set()
 
-    for path in chain(root.rglob("*.md"), root.rglob("*.yml"), root.rglob("*.yaml")):
+    for path in chain(
+        root.rglob("*.md"),
+        root.rglob("*.yml"),
+        root.rglob("*.yaml"),
+    ):
         if not path.is_file():
             continue
         base = path.with_suffix("")
         if base in processed:
             continue
         processed.add(base)
-        meta = load_metadata_pair(path)
+        try:
+            source = path.relative_to(base_dir)
+        except ValueError:
+            source = path
+        meta = load_metadata_pair(source)
         if meta and "path" in meta:
-            paths = [Path(p) for p in meta["path"]]
+            paths = []
+            for raw in meta["path"]:
+                candidate = Path(raw)
+                if candidate.is_absolute():
+                    resolved_candidate = candidate.resolve()
+                else:
+                    resolved_candidate = (base_dir / candidate).resolve()
+                paths.append(resolved_candidate)
         else:
             paths = [path]
-        yield paths, meta
+        yield path, paths, meta
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -61,15 +89,38 @@ def main(argv: list[str] | None = None) -> int:
     configure_logging(args.verbose, args.log)
 
     root = Path(args.directory)
+    scan_root = root if root.is_absolute() else (Path.cwd() / root).resolve()
+    if args.exclude:
+        exclude_file = Path(args.exclude)
+    elif DEFAULT_EXCLUDE.is_file():
+        exclude_file = DEFAULT_EXCLUDE
+    else:
+        exclude_file = None
+    exclude = load_exclude_file(exclude_file, scan_root)
+
     ok = True
-    for paths, meta in _iter_metadata(root):
-        author = meta.get("doc", {}).get("author") if meta else None
+    base_dir = scan_root.parent
+    for metadata_path, paths, meta in _iter_metadata(scan_root, base_dir):
+        if metadata_path in exclude:
+            continue
+        doc = meta.get("doc") if meta else None
+        author = doc.get("author") if isinstance(doc, dict) else None
         for path in paths:
+            if path in exclude:
+                continue
+            try:
+                display_path = path.relative_to(scan_root)
+            except ValueError:
+                display_path = path
             if author:
-                logger.debug("Found doc.author", path=str(path), author=author)
+                logger.debug(
+                    "Found doc.author", path=str(display_path), author=author
+                )
             else:
-                logger.error("Missing doc.author", path=str(path))
+                logger.error("Missing doc.author", path=str(display_path))
                 ok = False
+    if ok:
+        logger.info("All metadata files define doc.author.")
     return 0 if ok else 1
 
 

--- a/cfg/check-author-exclude.yml
+++ b/cfg/check-author-exclude.yml
@@ -1,0 +1,2 @@
+# List metadata files for check-author to skip.
+# Paths may be absolute or relative to the directory being scanned.

--- a/docs/pie/check/README.md
+++ b/docs/pie/check/README.md
@@ -10,4 +10,5 @@ Documentation for Pie's validation scripts.
   rendering.
 - [check-breadcrumbs](check-breadcrumbs.md) – ensure metadata defines
   `doc.breadcrumbs`.
+- [check-author](check-author.md) – confirm metadata provides `doc.author`.
 

--- a/docs/pie/check/check-author.md
+++ b/docs/pie/check/check-author.md
@@ -1,0 +1,34 @@
+# check-author
+
+`check-author` ensures that every metadata file found under the target tree
+defines a `doc.author` field. The checker inspects Markdown/YAML pairs using
+`pie.metadata.load_metadata_pair` so front matter and sidecar YAML are merged
+before validation. Results are logged to `stderr` and appended to
+`log/check-author.txt` by default.
+
+## Usage
+
+```bash
+check-author [directory]
+```
+
+When no directory is supplied the command scans `src/`. The checker walks the
+filesystem looking for `*.md`, `*.yml`, and `*.yaml` files and groups matching
+Markdown/YAML pairs to avoid duplicate warnings. For each metadata document, the
+checker verifies that `doc.author` is defined and non-empty. Missing authors are
+reported as errors; the process exits with status `1` when any are found.
+
+Use `-l`/`--log` to change the log destination and `-v`/`--verbose` to emit
+per-file debug messages describing the detected author values. Pass
+`--exclude` (or `-x`) to provide a YAML file listing metadata entries to skip.
+When no flag is supplied the checker loads `cfg/check-author-exclude.yml` if
+the file exists. Paths may be absolute or relative to the scanned directory
+and can include shell-style wildcards or regular expressions prefixed with
+`regex:`.
+
+### Example exclude file
+
+```yaml
+- news/archive/doc.yml
+- regex:.*drafts/.*
+```


### PR DESCRIPTION
## Summary
- Refactored `check-author` to load YAML-based exclude lists, resolve metadata relative to the scan root, and log relative paths while honoring skip patterns.
- Updated the CLI tests to reflect the new exclude flag semantics and coverage of wildcard-driven YAML excludes.
- Documented the YAML exclude workflow and added a default configuration stub.

## Testing
- pytest app/shell/py/pie/tests/test_check_author.py

------
https://chatgpt.com/codex/tasks/task_e_68cf008f58848321870dc624b2083e86