### PR TITLE
Add author check coverage scenarios

### DIFF
--- a/app/shell/py/pie/tests/test_check_author.py
+++ b/app/shell/py/pie/tests/test_check_author.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
-
 from pathlib import Path
+import runpy
+import sys
+
+import pytest
 
 from pie.check import author as check_author
 
@@ -84,3 +87,109 @@ def test_main_skips_excluded_paths(tmp_path: Path, monkeypatch) -> None:
 
     rc = check_author.main(["--exclude", str(exclude)])
     assert rc == 0
+
+
+def test_iter_metadata_handles_non_files(tmp_path: Path, monkeypatch) -> None:
+    """``_iter_metadata`` skips directories and falls back to absolute paths."""
+
+    root = tmp_path / "scan"
+    root.mkdir()
+    (root / "fake.md").mkdir()
+    doc = root / "doc.md"
+    doc.write_text("---\n---\n", encoding="utf-8")
+
+    seen: list[Path] = []
+
+    def fake_load(source: Path) -> None:
+        seen.append(source)
+        return None
+
+    monkeypatch.setattr(check_author, "load_metadata_pair", fake_load)
+
+    results = list(check_author._iter_metadata(root, tmp_path / "other"))
+
+    assert seen == [doc]
+    assert results == [(doc, [doc], None)]
+
+
+def test_iter_metadata_resolves_absolute_paths(tmp_path: Path, monkeypatch) -> None:
+    """Absolute ``meta['path']`` entries are resolved without modification."""
+
+    root = tmp_path / "scan"
+    root.mkdir()
+    doc = root / "doc.md"
+    doc.write_text("---\n---\n", encoding="utf-8")
+    outside = tmp_path / "outside.yml"
+    outside.write_text("title: Outside\n", encoding="utf-8")
+
+    def fake_load(_: Path) -> dict:
+        return {"path": [str(outside)], "doc": {"author": "Alice"}}
+
+    monkeypatch.setattr(check_author, "load_metadata_pair", fake_load)
+
+    [(metadata_path, paths, meta)] = list(
+        check_author._iter_metadata(root, tmp_path)
+    )
+
+    assert metadata_path == doc
+    assert paths == [outside.resolve()]
+    assert meta["doc"]["author"] == "Alice"
+
+
+def test_main_uses_default_exclude_file(tmp_path: Path, monkeypatch) -> None:
+    """The default exclude file is honoured when present."""
+
+    monkeypatch.chdir(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    doc = src / "doc.md"
+    doc.write_text("---\ntitle: Sample\n---\n", encoding="utf-8")
+
+    cfg = tmp_path / "cfg"
+    cfg.mkdir()
+    default_exclude = cfg / "check-author-exclude.yml"
+    default_exclude.write_text("- doc.md\n", encoding="utf-8")
+
+    def fake_iter(root: Path, base_dir: Path):
+        yield doc, [doc], {"doc": {}}
+
+    monkeypatch.setattr(check_author, "_iter_metadata", fake_iter)
+
+    rc = check_author.main([])
+    assert rc == 0
+
+
+def test_main_skips_absolute_paths(tmp_path: Path, monkeypatch) -> None:
+    """Paths outside the scan root are skipped when excluded explicitly."""
+
+    src = tmp_path / "src"
+    src.mkdir()
+    doc = src / "doc.md"
+    doc.write_text("---\ntitle: Sample\n---\n", encoding="utf-8")
+    outside = tmp_path / "outside.md"
+    outside.write_text("---\ntitle: Outside\n---\n", encoding="utf-8")
+
+    def fake_iter(root: Path, base_dir: Path):
+        yield doc, [outside], {"doc": {"author": "Jane"}}
+
+    monkeypatch.setattr(check_author, "_iter_metadata", fake_iter)
+
+    exclude = tmp_path / "exclude.yml"
+    exclude.write_text(f"- {outside}\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    rc = check_author.main(["--exclude", str(exclude)])
+    assert rc == 0
+
+
+def test_entry_point_invokes_main(tmp_path: Path, monkeypatch) -> None:
+    """Running the module as a script exits with ``SystemExit``."""
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "src").mkdir()
+    monkeypatch.setattr(sys, "argv", ["author.py"], raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_path(str(Path(check_author.__file__)), run_name="__main__")
+
+    assert exc.value.code == 0


### PR DESCRIPTION
## Summary
- add unit tests covering _iter_metadata directory handling and absolute path resolution
- exercise default exclude behaviour and absolute path exclusions in the CLI entry point
- verify the module-level entry point raises SystemExit when executed as a script

## Testing
- pytest app/shell/py/pie/tests/test_check_author.py

------
https://chatgpt.com/codex/tasks/task_e_68d2d020115483218e44ce737e37be16