### PR TITLE
Add IndexTree creation script and auto-index build rules

### DIFF
--- a/app/shell/py/pie/pie/create/__init__.py
+++ b/app/shell/py/pie/pie/create/__init__.py
@@ -1,6 +1,6 @@
 """Helpers for creating Press projects and posts."""
 
-__all__ = ["site", "post"]
+__all__ = ["site", "post", "indextree"]
 
 # Export submodules for convenience
-from . import site, post  # noqa: F401
+from . import indextree, post, site  # noqa: F401

--- a/app/shell/py/pie/pie/create/indextree.py
+++ b/app/shell/py/pie/pie/create/indextree.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+"""Create Markdown and metadata scaffolding for an IndexTree section."""
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+from pie.cli import create_parser
+from pie.logging import configure_logging, logger
+from pie.model import Breadcrumb, Doc, Metadata, PubDate
+from pie.utils import write_yaml
+
+SCRIPT_TAG = '<script type="module" src="/static/js/indextree.js" defer></script>'
+DEFAULT_MD_TEMPLATE = (
+    "Explore this section through the tree below.\n\n"
+    '<div class="indextree-root" data-src="{data_src}"></div>\n'
+)
+
+__all__ = ["main"]
+
+
+def _title_from_slug(slug: str) -> str:
+    """Return a title-cased string derived from *slug*."""
+
+    return slug.replace("-", " ").replace("_", " ").title()
+
+
+def _relative_parts(directory: Path) -> list[str]:
+    """Return path components relative to ``src/`` when available."""
+
+    src_root = Path("src").resolve()
+    try:
+        rel = directory.resolve().relative_to(src_root)
+        parts = [part for part in rel.parts if part not in {"", "."}]
+        if parts:
+            return parts
+    except ValueError:
+        pass
+    return [directory.resolve().name]
+
+
+def _build_breadcrumbs(parts: list[str], final_title: str) -> list[Breadcrumb]:
+    """Return breadcrumbs for *parts* including the implicit Home link."""
+
+    breadcrumbs: list[Breadcrumb] = [Breadcrumb("Home", "/")]
+    url_parts: list[str] = []
+    for index, part in enumerate(parts):
+        title = final_title if index == len(parts) - 1 else _title_from_slug(part)
+        url_parts.append(part)
+        if index == len(parts) - 1:
+            breadcrumbs.append(Breadcrumb(title))
+        else:
+            url = "/" + "/".join(url_parts) + "/"
+            breadcrumbs.append(Breadcrumb(title, url))
+    return breadcrumbs
+
+
+def _build_doc_id(parts: list[str]) -> str:
+    """Return a document identifier based on *parts*."""
+
+    return "-".join(part.replace("_", "-").lower() for part in parts)
+
+
+def _build_data_src(parts: list[str]) -> str:
+    """Return the ``data-src`` attribute for the generated Markdown."""
+
+    rel_path = "/".join(parts)
+    return f"/static/index/{rel_path}.json"
+
+
+def _build_metadata(
+    doc_id: str,
+    title: str,
+    breadcrumbs: list[Breadcrumb],
+    url: str,
+    description: str | None = None,
+) -> dict[str, object]:
+    """Return metadata dictionary for the IndexTree page."""
+
+    metadata = Metadata(
+        id=doc_id,
+        doc=Doc(
+            author="",
+            pubdate=PubDate(),
+            title=title,
+            breadcrumbs=breadcrumbs,
+        ),
+        description=description,
+    ).to_dict()
+    metadata["html"] = {"scripts": [SCRIPT_TAG]}
+    metadata["indextree"] = {"link": True}
+    metadata["url"] = url
+    return metadata
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+
+    parser = create_parser("Create metadata for an IndexTree directory")
+    parser.add_argument(
+        "path",
+        help="Directory that should contain index.md and index.yml",
+    )
+    parser.add_argument(
+        "--title",
+        help="Override the generated title for the index page",
+    )
+    parser.add_argument(
+        "--description",
+        help="Optional description stored in index.yml",
+    )
+    parser.add_argument(
+        "--data-src",
+        help="Custom data-src value for the generated Markdown",
+    )
+    parser.add_argument(
+        "--url",
+        help="Explicit URL to store in index.yml (defaults to derived path)",
+    )
+    parser.add_argument(
+        "--id",
+        help="Explicit document identifier (defaults to derived value)",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the ``indextree-create`` console script."""
+
+    args = parse_args(argv)
+    configure_logging(args.verbose, args.log)
+
+    directory = Path(args.path)
+    directory.mkdir(parents=True, exist_ok=True)
+
+    parts = _relative_parts(directory)
+    title = args.title or _title_from_slug(parts[-1])
+    doc_id = args.id or _build_doc_id(parts)
+    data_src = args.data_src or _build_data_src(parts)
+    url = args.url or "/" + "/".join(parts) + "/"
+
+    md_path = directory / "index.md"
+    md_path.write_text(DEFAULT_MD_TEMPLATE.format(data_src=data_src), encoding="utf-8")
+
+    metadata = _build_metadata(
+        doc_id=doc_id,
+        title=title,
+        breadcrumbs=_build_breadcrumbs(parts, title),
+        url=url,
+        description=args.description,
+    )
+    yml_path = directory / "index.yml"
+    write_yaml(metadata, yml_path)
+
+    logger.info(
+        "Created IndexTree files",
+        directory=str(directory),
+        md=str(md_path),
+        yml=str(yml_path),
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())

--- a/app/shell/py/pie/setup.py
+++ b/app/shell/py/pie/setup.py
@@ -30,6 +30,7 @@ setup(
             'create-site=pie.create.site:main',
             'emojify=pie.filter.emojify:main',
             'gen-markdown-index=pie.gen_markdown_index:main',
+            'indextree-create=pie.create.indextree:main',
             'include-filter=pie.filter.include:main',
             'indextree-json=pie.indextree_json:main',
             'nginx-permalinks=pie.nginx_permalinks:main',

--- a/app/shell/py/pie/tests/test_create_indextree.py
+++ b/app/shell/py/pie/tests/test_create_indextree.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+from pie.create import indextree
+from pie.schema import DEFAULT_SCHEMA
+from pie.utils import get_pubdate
+
+
+yaml = YAML(typ="safe")
+
+
+def test_indextree_create_generates_files(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    target = Path("src") / "guides"
+
+    exit_code = indextree.main([str(target)])
+
+    assert exit_code == 0
+
+    md_path = target / "index.md"
+    yml_path = target / "index.yml"
+
+    assert md_path.exists()
+    assert yml_path.exists()
+
+    expected_md = (
+        "Explore this section through the tree below.\n\n"
+        '<div class="indextree-root" data-src="/static/index/guides.json"></div>\n'
+    )
+    assert md_path.read_text(encoding="utf-8") == expected_md
+
+    data = yaml.load(yml_path.read_text(encoding="utf-8"))
+
+    assert data["id"] == "guides"
+    assert data["schema"] == DEFAULT_SCHEMA
+    assert data["url"] == "/guides/"
+    assert data["html"] == {
+        "scripts": [indextree.SCRIPT_TAG],
+    }
+    assert data["indextree"] == {"link": True}
+
+    doc = data["doc"]
+    assert doc["title"] == "Guides"
+    assert doc["author"] == ""
+    assert doc["pubdate"] == get_pubdate()
+    assert doc["breadcrumbs"] == [
+        {"title": "Home", "url": "/"},
+        {"title": "Guides"},
+    ]
+
+    assert "description" not in data
+
+
+def test_indextree_create_handles_nested_paths(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    target = Path("src") / "docs" / "api"
+
+    indextree.main([str(target)])
+
+    md_path = target / "index.md"
+    yml_path = target / "index.yml"
+
+    expected_md = (
+        "Explore this section through the tree below.\n\n"
+        '<div class="indextree-root" data-src="/static/index/docs/api.json"></div>\n'
+    )
+    assert md_path.read_text(encoding="utf-8") == expected_md
+
+    data = yaml.load(yml_path.read_text(encoding="utf-8"))
+
+    assert data["id"] == "docs-api"
+    assert data["url"] == "/docs/api/"
+    assert data["doc"]["breadcrumbs"] == [
+        {"title": "Home", "url": "/"},
+        {"title": "Docs", "url": "/docs/"},
+        {"title": "Api"},
+    ]
+
+
+def test_indextree_create_respects_overrides(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    target = Path("src") / "reference"
+
+    indextree.main(
+        [
+            str(target),
+            "--title",
+            "Reference",
+            "--description",
+            "API reference section",
+            "--data-src",
+            "/static/index/custom.json",
+            "--url",
+            "/docs/reference/",
+            "--id",
+            "custom-id",
+        ]
+    )
+
+    md_path = target / "index.md"
+    yml_path = target / "index.yml"
+
+    assert md_path.read_text(encoding="utf-8") == (
+        "Explore this section through the tree below.\n\n"
+        '<div class="indextree-root" data-src="/static/index/custom.json"></div>\n'
+    )
+
+    data = yaml.load(yml_path.read_text(encoding="utf-8"))
+
+    assert data["id"] == "custom-id"
+    assert data["description"] == "API reference section"
+    assert data["url"] == "/docs/reference/"
+    assert data["doc"]["title"] == "Reference"
+    assert data["doc"]["breadcrumbs"][-1] == {"title": "Reference"}

--- a/src/dep.mk
+++ b/src/dep.mk
@@ -13,8 +13,47 @@ include app/quiz/dep.mk
 include app/indextree/dep.mk
 include app/magicbar/dep.mk
 
-all: build/static/index/examples.json
+INDEXTREE_MAP := $(strip $(shell python - <<'PY'
+from pathlib import Path
 
-build/static/index/examples.json: $(shell find src/examples -name '*.yml') | build/static/index
-	$(call status,Indexing src/examples)
-	$(Q)indextree-json src/examples > $@
+root = Path('src')
+entries = []
+for index in sorted(root.rglob('index.yml')):
+    try:
+        rel_dir = index.parent.relative_to(root)
+    except ValueError:
+        continue
+    if 'indextree:' not in index.read_text(encoding='utf-8'):
+        continue
+    target = (Path('build/static/index') / rel_dir).with_suffix('.json')
+    entries.append(f"{target.as_posix()}|{index.parent.as_posix()}")
+for item in entries:
+    print(item)
+PY))
+
+define indextree_target
+$(word 1,$(subst |, ,$(1)))
+endef
+
+define indextree_source
+$(word 2,$(subst |, ,$(1)))
+endef
+
+define indextree_deps
+$(shell find $(1) -type f \( -name '*.md' -o -name '*.mdi' -o -name '*.yml' -o -name '*.yaml' \))
+endef
+
+INDEXTREE_TARGETS := $(foreach entry,$(INDEXTREE_MAP),$(call indextree_target,$(entry)))
+
+all: $(INDEXTREE_TARGETS)
+
+define indextree_rule
+$(call indextree_target,$(1)): $(call indextree_deps,$(call indextree_source,$(1))) | build/static/index
+        $(call status,Indexing $(call indextree_source,$(1)))
+        $(Q)mkdir -p $$(dir $$@)
+        $(Q)indextree-json $(call indextree_source,$(1)) > $$@
+endef
+
+ifneq ($(strip $(INDEXTREE_MAP)),)
+$(foreach entry,$(INDEXTREE_MAP),$(eval $(call indextree_rule,$(entry))))
+endif


### PR DESCRIPTION
## Summary
- add an `indextree-create` CLI that scaffolds index.md/index.yml files for a directory with sensible defaults and overrides
- expose the new CLI entry point and cover it with tests
- automatically discover IndexTree directories in `src/dep.mk` so the corresponding JSON is generated during builds

## Testing
- pytest tests/test_create_indextree.py

------
https://chatgpt.com/codex/tasks/task_e_68d2cf20ba3883218d58331b5ffd438c