### PR TITLE
Add analytics page metadata

### DIFF
--- a/src/analytics/backend.yml
+++ b/src/analytics/backend.yml
@@ -1,0 +1,13 @@
+description: Configure the Flask ingestion API and TimescaleDB services.
+doc:
+  author: Brian Lee
+  breadcrumbs:
+  - title: Home
+    url: /
+  - title: Analytics
+    url: /analytics/
+  - title: Analytics backend service
+  pubdate: Jan 20, 2026
+  title: Analytics backend service
+id: analytics_backend_service
+schema: v1

--- a/src/analytics/demo.yml
+++ b/src/analytics/demo.yml
@@ -1,0 +1,13 @@
+description: Run the analytics playground and inspect live event streams.
+doc:
+  author: Brian Lee
+  breadcrumbs:
+  - title: Home
+    url: /
+  - title: Analytics
+    url: /analytics/
+  - title: Engagement analytics demo
+  pubdate: Jan 20, 2026
+  title: Engagement analytics demo
+id: engagement_analytics_demo
+schema: v1

--- a/src/analytics/user-engagement-tracking.yml
+++ b/src/analytics/user-engagement-tracking.yml
@@ -1,0 +1,13 @@
+description: Deploy private-network engagement instrumentation for Press sites.
+doc:
+  author: Brian Lee
+  breadcrumbs:
+  - title: Home
+    url: /
+  - title: Analytics
+    url: /analytics/
+  - title: User engagement tracking
+  pubdate: Jan 20, 2026
+  title: User engagement tracking
+id: user_engagement_tracking
+schema: v1


### PR DESCRIPTION
## Summary
- add metadata entries for the analytics backend, demo, and tracking guides

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5bb0b7394832182f19fab3d7bdfa0