### PR TITLE
Limit metadata v2 to press namespace

### DIFF
--- a/app/shell/py/pie/pie/model/__init__.py
+++ b/app/shell/py/pie/pie/model/__init__.py
@@ -1,5 +1,19 @@
 """Data models for pie."""
 
-__all__ = ["Breadcrumb", "Doc", "Metadata", "PubDate"]
+__all__ = [
+    "Breadcrumb",
+    "Doc",
+    "Metadata",
+    "MetadataV2",
+    "Press",
+    "PubDate",
+]
 
-from .metadata import Breadcrumb, Doc, Metadata, PubDate  # noqa: F401
+from .metadata import (  # noqa: F401
+    Breadcrumb,
+    Doc,
+    Metadata,
+    MetadataV2,
+    Press,
+    PubDate,
+)

--- a/app/shell/py/pie/pie/model/metadata.py
+++ b/app/shell/py/pie/pie/model/metadata.py
@@ -4,10 +4,17 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, List, Optional
 
-from pie.schema import DEFAULT_SCHEMA
+from pie.schema import DEFAULT_SCHEMA, V2_SCHEMA
 from pie.utils import get_pubdate
 
-__all__ = ["Breadcrumb", "Doc", "Metadata", "PubDate"]
+__all__ = [
+    "Breadcrumb",
+    "Doc",
+    "Metadata",
+    "MetadataV2",
+    "Press",
+    "PubDate",
+]
 
 
 @dataclass
@@ -90,3 +97,35 @@ class Metadata:
         if self.description:
             data["description"] = self.description
         return data
+
+
+@dataclass
+class Press:
+    """Press specific metadata for schema ``v2``."""
+
+    id: str
+    schema: str = V2_SCHEMA
+
+    def __post_init__(self) -> None:
+        """Ensure the schema version matches ``v2``."""
+
+        if self.schema != V2_SCHEMA:
+            msg = "press.schema must be 'v2'"
+            raise ValueError(msg)
+
+    def to_dict(self) -> dict[str, str]:
+        """Return dictionary representation for serialization."""
+
+        return {"id": self.id, "schema": self.schema}
+
+
+@dataclass
+class MetadataV2:
+    """Metadata schema ``v2`` exposing only the ``press`` namespace."""
+
+    press: Press
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return dictionary representation containing only ``press``."""
+
+        return {"press": self.press.to_dict()}

--- a/app/shell/py/pie/pie/schema.py
+++ b/app/shell/py/pie/pie/schema.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 DEFAULT_SCHEMA = "v1"
+V2_SCHEMA = "v2"
 
-__all__ = ["Schema", "DEFAULT_SCHEMA"]
+__all__ = ["Schema", "DEFAULT_SCHEMA", "V2_SCHEMA"]
 
 
 @dataclass

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -79,6 +79,39 @@ def test_schema_default():
     assert Schema().schema == "v1"
 
 
+def test_press_defaults_to_v2():
+    """Press metadata enforces the ``v2`` schema version."""
+    from pie.model import Press
+
+    info = Press(id="doc")
+    assert info.schema == "v2"
+
+
+def test_press_invalid_schema_raises():
+    """Attempting to override ``press.schema`` raises an error."""
+    from pie.model import Press
+
+    with pytest.raises(ValueError):
+        Press(id="doc", schema="v1")
+
+
+def test_metadata_v2_to_dict():
+    """MetadataV2 serializes only ``press`` information."""
+    from pie.model import MetadataV2, Press
+
+    metadata_v2 = MetadataV2(press=Press(id="doc"))
+
+    assert metadata_v2.to_dict() == {"press": {"id": "doc", "schema": "v2"}}
+
+
+def test_metadata_v2_rejects_unknown_fields():
+    """Passing unexpected fields raises a ``TypeError``."""
+    from pie.model import MetadataV2, Press
+
+    with pytest.raises(TypeError):
+        MetadataV2(id="doc", press=Press(id="doc"))
+
+
 def test_load_metadata_pair_conflict_shows_path(tmp_path, monkeypatch):
     """Conflicting values include path in warning."""
     md = tmp_path / "dir" / "post.md"

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -52,3 +52,12 @@ text in parentheses.
 `doc.link.class` defaults to `internal-link`.
 `doc.mathjax` defaults to `false`, so MathJax is not loaded by default.
 
+## Schema ``v2``
+
+Metadata schema ``v2`` consists solely of the ``press`` namespace. The values
+are no longer mirrored at the top level and must be provided explicitly:
+
+- `press.id` – Canonical identifier for the document.
+- `press.schema` – Schema version string. This must be set to `"v2"` and is
+  not generated automatically.
+


### PR DESCRIPTION
## Summary
- restrict the `MetadataV2` dataclass to expose only the `press` namespace
- adjust metadata tests to validate the reduced schema surface
- clarify the schema v2 documentation to note the `press`-only payload

## Testing
- pytest app/shell/py/pie/tests/test_metadata.py


------
https://chatgpt.com/codex/tasks/task_e_68d71b6f0d9483218e7dbe3bd3149ff9