### PR TITLE
Extend Press metadata with optional fields

### DIFF
--- a/app/shell/py/pie/pie/model/metadata.py
+++ b/app/shell/py/pie/pie/model/metadata.py
@@ -105,18 +105,35 @@ class Press:
 
     id: str
     schema: str = V2_SCHEMA
+    author: Optional[str] = None
+    title: Optional[str] = None
+    pubdate: PubDate | str | datetime | None = None
+    mathjax: bool = False
 
     def __post_init__(self) -> None:
-        """Ensure the schema version matches ``v2``."""
+        """Ensure the schema version matches ``v2`` and normalise fields."""
 
         if self.schema != V2_SCHEMA:
             msg = "press.schema must be 'v2'"
             raise ValueError(msg)
+        if self.pubdate is not None and not isinstance(self.pubdate, PubDate):
+            self.pubdate = PubDate(self.pubdate)
 
-    def to_dict(self) -> dict[str, str]:
+    def to_dict(self) -> dict[str, Any]:
         """Return dictionary representation for serialization."""
 
-        return {"id": self.id, "schema": self.schema}
+        data: dict[str, Any] = {
+            "id": self.id,
+            "schema": self.schema,
+            "mathjax": self.mathjax,
+        }
+        if self.author is not None:
+            data["author"] = self.author
+        if self.title is not None:
+            data["title"] = self.title
+        if self.pubdate is not None:
+            data["pubdate"] = str(self.pubdate)
+        return data
 
 
 @dataclass

--- a/app/shell/py/pie/tests/test_metadata.py
+++ b/app/shell/py/pie/tests/test_metadata.py
@@ -98,10 +98,28 @@ def test_press_invalid_schema_raises():
 def test_metadata_v2_to_dict():
     """MetadataV2 serializes only ``press`` information."""
     from pie.model import MetadataV2, Press
+    from datetime import datetime
 
-    metadata_v2 = MetadataV2(press=Press(id="doc"))
+    metadata_v2 = MetadataV2(
+        press=Press(
+            id="doc",
+            author="Ada Lovelace",
+            title="Analytical Engine",
+            pubdate=datetime(2023, 1, 5),
+            mathjax=True,
+        )
+    )
 
-    assert metadata_v2.to_dict() == {"press": {"id": "doc", "schema": "v2"}}
+    assert metadata_v2.to_dict() == {
+        "press": {
+            "id": "doc",
+            "schema": "v2",
+            "author": "Ada Lovelace",
+            "title": "Analytical Engine",
+            "pubdate": "Jan 05, 2023",
+            "mathjax": True,
+        }
+    }
 
 
 def test_metadata_v2_rejects_unknown_fields():

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -60,4 +60,11 @@ are no longer mirrored at the top level and must be provided explicitly:
 - `press.id` – Canonical identifier for the document.
 - `press.schema` – Schema version string. This must be set to `"v2"` and is
   not generated automatically.
+- `press.author` – Optional author override surfaced in Press-generated
+  metadata.
+- `press.title` – Optional title override for downstream integrations.
+- `press.pubdate` – Publication date formatted like `Jan 05, 2023`. When the
+  value is omitted no date is emitted.
+- `press.mathjax` – Boolean flag enabling MathJax; defaults to `false` when
+  unspecified.
 


### PR DESCRIPTION
## Summary
- add optional author, title, pubdate, and mathjax fields to the Press dataclass
- normalise press.pubdate to PubDate instances and expose new keys in MetadataV2 serialisation
- document the new press.* metadata keys and their defaults

## Testing
- pytest app/shell/py/pie/tests/test_metadata.py *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68d72445ae24832188325e0e5dfebfa2