### PR TITLE
Add flashoffer CTA tests and guidance

### DIFF
--- a/app/shell/py/pie/pie/__init__.py
+++ b/app/shell/py/pie/pie/__init__.py
@@ -23,6 +23,8 @@ Use ``help(pie.<module>)`` to view documentation for any of the individual
 modules.
 """
 
+from . import flashoffer
+
 __all__ = [
     "filter",
     "metadata",
@@ -35,4 +37,5 @@ __all__ = [
     "build",
     "check",
     "update",
+    "flashoffer",
 ]

--- a/app/shell/py/pie/pie/flashoffer.py
+++ b/app/shell/py/pie/pie/flashoffer.py
@@ -1,0 +1,119 @@
+"""Render landing page call-to-action buttons.
+
+This module provides helpers equivalent to the ``primary_cta`` and
+``outline_cta`` Jinja macros that live alongside landing page templates.
+The functions return ``Markup`` strings so they can be used directly from
+Jinja without additional escaping. Attribute handling mirrors the macros:
+optional ``rel``/``target`` parameters are appended only when supplied and
+any extra keyword arguments are rendered verbatim as HTML attributes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from markupsafe import Markup, escape
+
+__all__ = ["primary_cta", "outline_cta"]
+
+
+def _merge_attrs(
+    base_classes: str,
+    href: str,
+    extra_classes: str,
+    rel: str | None,
+    target: str | None,
+    attrs: dict[str, Any],
+) -> Iterable[tuple[str, Markup]]:
+    """Yield escaped attribute/value pairs for rendering."""
+
+    class_list = base_classes
+    if extra_classes:
+        class_list = f"{class_list} {extra_classes}"
+
+    pairs: list[tuple[str, Any]] = [
+        ("class", class_list),
+        ("href", href),
+    ]
+    if rel is not None:
+        pairs.append(("rel", rel))
+    if target is not None:
+        pairs.append(("target", target))
+    pairs.extend(attrs.items())
+
+    for name, value in pairs:
+        if value is None:
+            continue
+        yield (escape(str(name)), escape(str(value)))
+
+
+def _render_cta(
+    base_classes: str,
+    text: str | Markup,
+    href: str,
+    *,
+    extra_classes: str = "",
+    rel: str | None = None,
+    target: str | None = None,
+    **attrs: Any,
+) -> Markup:
+    """Return a button-style anchor tag matching the landing CTA macros."""
+
+    attr_html = " ".join(
+        f"{name}=\"{value}\"" for name, value in _merge_attrs(
+            base_classes,
+            href,
+            extra_classes,
+            rel,
+            target,
+            attrs,
+        )
+    )
+    if isinstance(text, Markup):
+        label = text
+    else:
+        label = escape(text)
+    return Markup(f"<a {attr_html}>{label}</a>")
+
+
+def primary_cta(
+    text: str | Markup,
+    href: str,
+    extra_classes: str = "",
+    rel: str | None = None,
+    target: str | None = None,
+    **attrs: Any,
+) -> Markup:
+    """Render the primary call-to-action button."""
+
+    return _render_cta(
+        "btn btn-primary btn-lg px-4",
+        text,
+        href,
+        extra_classes=extra_classes,
+        rel=rel,
+        target=target,
+        **attrs,
+    )
+
+
+def outline_cta(
+    text: str | Markup,
+    href: str,
+    extra_classes: str = "",
+    rel: str | None = None,
+    target: str | None = None,
+    **attrs: Any,
+) -> Markup:
+    """Render the outline-style call-to-action button."""
+
+    return _render_cta(
+        "btn btn-outline-light btn-lg px-4",
+        text,
+        href,
+        extra_classes=extra_classes,
+        rel=rel,
+        target=target,
+        **attrs,
+    )

--- a/app/shell/py/pie/pie/render/jinja/__init__.py
+++ b/app/shell/py/pie/pie/render/jinja/__init__.py
@@ -415,7 +415,11 @@ def create_env():
     env.globals["metadata"] = metadata_module
     env.globals["read_json"] = read_json
     env.globals["read_yaml"] = read_yaml
-    env.globals["pie"] = {"yaml": pie.yaml, "utils": pie.utils}
+    env.globals["pie"] = {
+        "yaml": pie.yaml,
+        "utils": pie.utils,
+        "flashoffer": pie.flashoffer,
+    }
     env.globals["render_jinja"] = render_jinja
     env.globals["to_alpha_index"] = to_alpha_index
     env.filters["press"] = render_press

--- a/app/shell/py/pie/requirements.txt
+++ b/app/shell/py/pie/requirements.txt
@@ -5,6 +5,7 @@ fakeredis
 flatten-dict
 beautifulsoup4
 jinja2
+markupsafe
 cmarkgfm
 pytest
 pytest-cov

--- a/app/shell/py/pie/tests/test_flashoffer.py
+++ b/app/shell/py/pie/tests/test_flashoffer.py
@@ -1,0 +1,95 @@
+import pytest
+from markupsafe import Markup
+
+from pie import flashoffer
+
+
+@pytest.mark.parametrize(
+    "helper,expected_class",
+    [
+        (flashoffer.primary_cta, "btn btn-primary btn-lg px-4"),
+        (flashoffer.outline_cta, "btn btn-outline-light btn-lg px-4"),
+    ],
+)
+def test_cta_renders_anchor_with_expected_classes(helper, expected_class):
+    html = helper("Join", "/apply")
+    assert isinstance(html, Markup)
+    assert html == Markup(
+        f'<a class="{expected_class}" href="/apply">Join</a>'
+    )
+
+
+def test_cta_includes_optional_attributes_and_extra_kwargs():
+    html = flashoffer.primary_cta(
+        "Learn More",
+        "/learn",
+        extra_classes="cta",
+        rel="noopener",
+        target="_blank",
+        data_testid="hero-cta",
+    )
+    assert html == Markup(
+        "<a "
+        'class="btn btn-primary btn-lg px-4 cta" '
+        'href="/learn" '
+        'rel="noopener" '
+        'target="_blank" '
+        'data_testid="hero-cta"'
+        ">Learn More</a>"
+    )
+
+
+def test_cta_escapes_text_and_attribute_values():
+    html = flashoffer.primary_cta('Use "quote"', '/promo?ref="id"')
+    assert html == Markup(
+        "<a "
+        'class="btn btn-primary btn-lg px-4" '
+        'href="/promo?ref=&#34;id&#34;"'
+        ">Use &#34;quote&#34;</a>"
+    )
+
+
+def test_cta_preserves_markup_text():
+    html = flashoffer.primary_cta(Markup("<strong>Ready</strong>"), "/go")
+    assert html == Markup(
+        "<a "
+        'class="btn btn-primary btn-lg px-4" '
+        'href="/go"'
+        "><strong>Ready</strong></a>"
+    )
+
+
+def test_flashoffer_module_is_registered_with_jinja_globals(monkeypatch, tmp_path):
+    import sys
+    import types
+
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "macros.jinja").write_text(
+        "{% macro anchor(id) %}<a id=\"{{ id }}\"></a>{% endmacro %}",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PIE_DATA_DIR", str(templates_dir))
+
+    redis_stub = types.ModuleType("redis")
+
+    class _FakeRedis:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    redis_stub.Redis = _FakeRedis
+    monkeypatch.setitem(sys.modules, "redis", redis_stub)
+
+    flatten_stub = types.ModuleType("flatten_dict")
+
+    def _unflatten(*args, **kwargs):  # pragma: no cover - simple stub
+        return {}
+
+    flatten_stub.unflatten = _unflatten
+    monkeypatch.setitem(sys.modules, "flatten_dict", flatten_stub)
+
+    from pie.render import jinja
+
+    flashoffer_global = jinja.env.globals["pie"]["flashoffer"]
+    assert flashoffer_global.primary_cta is flashoffer.primary_cta
+    assert flashoffer_global.outline_cta is flashoffer.outline_cta

--- a/docs/guides/flashoffer-codex-instructions.md
+++ b/docs/guides/flashoffer-codex-instructions.md
@@ -1,0 +1,17 @@
+# Codex Instructions for Flashoffer CTAs
+
+The following block can be copied into an `AGENTS.md` file so Codex-powered
+agents know how to render landing page buttons using `pie.flashoffer`.
+
+```
+# Flashoffer CTA Helpers
+- Use `pie.flashoffer.primary_cta(text, href, extra_classes="", rel=None,
+  target=None, **attrs)` for the solid call-to-action button.
+- Use `pie.flashoffer.outline_cta(text, href, extra_classes="", rel=None,
+  target=None, **attrs)` for the outline button variant.
+- Pass any additional keyword arguments to append raw HTML attributes (for
+  example, `data_tracking_id="hero"`).
+- Provide `rel` and `target` explicitly when linking to external destinations.
+- The helpers escape text and attribute values automatically; wrap trusted
+  markup in `markupsafe.Markup` if you need to opt out of escaping.
+```

--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -28,6 +28,10 @@ for details on the structure of this metadata.
   `figure-img img-fluid rounded`, and `figure-caption tex-center`).
 - `definition(desc)` – expand the `definition` metadata field as Markdown.
   See [definition.md](definition.md) for details.
+- `pie.flashoffer.primary_cta(...)` and `pie.flashoffer.outline_cta(...)` –
+  render the landing page call-to-action buttons. Both helpers mirror the
+  original Jinja macros, support optional `rel`/`target` parameters, and accept
+  arbitrary HTML attributes via keyword arguments.
 
 Example:
 


### PR DESCRIPTION
## Summary
- add pytest coverage for the flashoffer CTA helpers and their Jinja registration
- document reusable Codex instructions for invoking the CTA helpers in AGENTS.md files
- declare the MarkupSafe dependency explicitly in the pie requirements list

## Testing
- pytest app/shell/py/pie/tests/test_flashoffer.py

------
https://chatgpt.com/codex/tasks/task_e_68d82723eff8832183ce7da936b0e3dd