### PR TITLE
Document flashoffer helper maintenance guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,10 @@
   Leading spaces will break Makefile syntax. Never replace tabs with spaces.
 - Documentation: write as an **expert engineer**.
   Provide enough detail for new team members.
+- Flashoffer updates: whenever `app/shell/py/pie/pie/flashoffer.py` or related
+  helpers change, also refresh
+  `docs/guides/flashoffer-codex-instructions.md` to keep Codex guidance in
+  sync.
 
 ## Checker Scripts
 

--- a/app/shell/py/pie/pie/flashoffer.py
+++ b/app/shell/py/pie/pie/flashoffer.py
@@ -10,12 +10,12 @@ any extra keyword arguments are rendered verbatim as HTML attributes.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 from markupsafe import Markup, escape
 
-__all__ = ["primary_cta", "outline_cta"]
+__all__ = ["primary_cta", "outline_cta", "preview_card"]
 
 
 def _merge_attrs(
@@ -116,4 +116,62 @@ def outline_cta(
         rel=rel,
         target=target,
         **attrs,
+    )
+
+
+def _require_card_value(card: Mapping[str, Any], key: str) -> Any:
+    try:
+        return card[key]
+    except KeyError as exc:  # pragma: no cover - defensive branch
+        raise KeyError(
+            "preview_card() card mapping is missing required key " f"'{key}'"
+        ) from exc
+
+
+def _escape_attr_value(value: Any) -> Markup:
+    return escape(str(value))
+
+
+def _coerce_html(value: Any) -> Markup:
+    if isinstance(value, Markup):
+        return value
+    return escape(value)
+
+
+def preview_card(card: Mapping[str, Any]) -> Markup:
+    """Render the Flashoffer preview card partial."""
+
+    image_url = _escape_attr_value(_require_card_value(card, "image_url"))
+    alt_text = _escape_attr_value(_require_card_value(card, "alt_text"))
+    link_href = _escape_attr_value(_require_card_value(card, "link_href"))
+    caption = _coerce_html(_require_card_value(card, "caption"))
+
+    return Markup(
+        (
+            '<div class="col">\n'
+            '  <div class="card h-100 bg-dark border border-light-subtle shadow-sm">\n'
+            '    <div\n'
+            '      class="card-img-top bg-black d-flex align-items-center justify-content-center rounded-top overflow-hidden position-relative preview-card"\n'
+            '    >\n'
+            '      <img\n'
+            f'        src="{image_url}"\n'
+            '        class="img-fluid w-100 h-auto preview-image"\n'
+            f'        alt="{alt_text}"\n'
+            '        loading="lazy"\n'
+            '      />\n'
+            '      <div class="preview-overlay">\n'
+            '        <div class="text-center px-3">\n'
+            '          <p class="mb-2 fw-semibold">Tap to reveal this artistic nude pose.</p>\n'
+            f'          <a class="btn btn-outline-light btn-sm preview-toggle" href="{link_href}" role="button">\n'
+            '            View image\n'
+            '          </a>\n'
+            '        </div>\n'
+            '      </div>\n'
+            '    </div>\n'
+            '    <div class="card-body">\n'
+            f'      <p class="card-text mb-0 text-white-50">{caption}</p>\n'
+            '    </div>\n'
+            '  </div>\n'
+            '</div>'
+        )
     )

--- a/app/shell/py/pie/tests/test_flashoffer.py
+++ b/app/shell/py/pie/tests/test_flashoffer.py
@@ -9,14 +9,28 @@ from pie import flashoffer
     [
         (flashoffer.primary_cta, "btn btn-primary btn-lg px-4"),
         (flashoffer.outline_cta, "btn btn-outline-light btn-lg px-4"),
+        (flashoffer.preview_card, None),
     ],
 )
 def test_cta_renders_anchor_with_expected_classes(helper, expected_class):
-    html = helper("Join", "/apply")
+    if helper is flashoffer.preview_card:
+        html = helper(
+            {
+                "image_url": "https://cdn.example.com/preview.jpg",
+                "alt_text": "Preview image",
+                "link_href": "https://example.com/full",
+                "caption": "A short caption",
+            }
+        )
+    else:
+        html = helper("Join", "/apply")
     assert isinstance(html, Markup)
-    assert html == Markup(
-        f'<a class="{expected_class}" href="/apply">Join</a>'
-    )
+    if helper is flashoffer.preview_card:
+        assert html.startswith("<div class=\"col\">")
+    else:
+        assert html == Markup(
+            f'<a class="{expected_class}" href="/apply">Join</a>'
+        )
 
 
 def test_cta_includes_optional_attributes_and_extra_kwargs():
@@ -59,6 +73,107 @@ def test_cta_preserves_markup_text():
     )
 
 
+def test_preview_card_renders_expected_markup():
+    html = flashoffer.preview_card(
+        {
+            "image_url": "https://cdn.example.com/image.jpg",
+            "alt_text": "Hero image",
+            "link_href": "https://example.com/gallery",
+            "caption": "The caption",
+        }
+    )
+    assert html == Markup(
+        '<div class="col">\n'
+        '  <div class="card h-100 bg-dark border border-light-subtle shadow-sm">\n'
+        '    <div\n'
+        '      class="card-img-top bg-black d-flex align-items-center justify-content-center rounded-top overflow-hidden position-relative preview-card"\n'
+        '    >\n'
+        '      <img\n'
+        '        src="https://cdn.example.com/image.jpg"\n'
+        '        class="img-fluid w-100 h-auto preview-image"\n'
+        '        alt="Hero image"\n'
+        '        loading="lazy"\n'
+        '      />\n'
+        '      <div class="preview-overlay">\n'
+        '        <div class="text-center px-3">\n'
+        '          <p class="mb-2 fw-semibold">Tap to reveal this artistic nude pose.</p>\n'
+        '          <a class="btn btn-outline-light btn-sm preview-toggle" href="https://example.com/gallery" role="button">\n'
+        '            View image\n'
+        '          </a>\n'
+        '        </div>\n'
+        '      </div>\n'
+        '    </div>\n'
+        '    <div class="card-body">\n'
+        '      <p class="card-text mb-0 text-white-50">The caption</p>\n'
+        '    </div>\n'
+        '  </div>\n'
+        '</div>'
+    )
+
+
+def test_preview_card_escapes_attribute_values_and_caption_text():
+    html = flashoffer.preview_card(
+        {
+            "image_url": '/img?tag="x"',
+            "alt_text": 'Alt "quote"',
+            "link_href": '/preview?ref="full"',
+            "caption": 'Use <em>markup</em>',
+        }
+    )
+    assert html == Markup(
+        '<div class="col">\n'
+        '  <div class="card h-100 bg-dark border border-light-subtle shadow-sm">\n'
+        '    <div\n'
+        '      class="card-img-top bg-black d-flex align-items-center justify-content-center rounded-top overflow-hidden position-relative preview-card"\n'
+        '    >\n'
+        '      <img\n'
+        '        src="/img?tag=&#34;x&#34;"\n'
+        '        class="img-fluid w-100 h-auto preview-image"\n'
+        '        alt="Alt &#34;quote&#34;"\n'
+        '        loading="lazy"\n'
+        '      />\n'
+        '      <div class="preview-overlay">\n'
+        '        <div class="text-center px-3">\n'
+        '          <p class="mb-2 fw-semibold">Tap to reveal this artistic nude pose.</p>\n'
+        '          <a class="btn btn-outline-light btn-sm preview-toggle" href="/preview?ref=&#34;full&#34;" role="button">\n'
+        '            View image\n'
+        '          </a>\n'
+        '        </div>\n'
+        '      </div>\n'
+        '    </div>\n'
+        '    <div class="card-body">\n'
+        '      <p class="card-text mb-0 text-white-50">Use &lt;em&gt;markup&lt;/em&gt;</p>\n'
+        '    </div>\n'
+        '  </div>\n'
+        '</div>'
+    )
+
+
+def test_preview_card_preserves_markup_caption():
+    html = flashoffer.preview_card(
+        {
+            "image_url": "image.jpg",
+            "alt_text": "Alt",
+            "link_href": "link",
+            "caption": Markup("Line with <strong>markup</strong>"),
+        }
+    )
+    assert "<strong>markup</strong>" in html
+
+
+@pytest.mark.parametrize("missing_key", ["image_url", "alt_text", "link_href", "caption"])
+def test_preview_card_requires_expected_card_keys(missing_key):
+    card = {
+        "image_url": "image.jpg",
+        "alt_text": "Alt",
+        "link_href": "link",
+        "caption": "Caption",
+    }
+    card.pop(missing_key)
+    with pytest.raises(KeyError):
+        flashoffer.preview_card(card)
+
+
 def test_flashoffer_module_is_registered_with_jinja_globals(monkeypatch, tmp_path):
     import sys
     import types
@@ -93,3 +208,4 @@ def test_flashoffer_module_is_registered_with_jinja_globals(monkeypatch, tmp_pat
     flashoffer_global = jinja.env.globals["pie"]["flashoffer"]
     assert flashoffer_global.primary_cta is flashoffer.primary_cta
     assert flashoffer_global.outline_cta is flashoffer.outline_cta
+    assert flashoffer_global.preview_card is flashoffer.preview_card

--- a/docs/guides/flashoffer-codex-instructions.md
+++ b/docs/guides/flashoffer-codex-instructions.md
@@ -4,14 +4,18 @@ The following block can be copied into an `AGENTS.md` file so Codex-powered
 agents know how to render landing page buttons using `pie.flashoffer`.
 
 ```
-# Flashoffer CTA Helpers
+# Flashoffer Helpers
 - Use `pie.flashoffer.primary_cta(text, href, extra_classes="", rel=None,
   target=None, **attrs)` for the solid call-to-action button.
 - Use `pie.flashoffer.outline_cta(text, href, extra_classes="", rel=None,
   target=None, **attrs)` for the outline button variant.
+- Use `pie.flashoffer.preview_card(card)` to render the preview card markup.
+  The `card` mapping must include `image_url`, `alt_text`, `link_href`, and
+  `caption` keys.
 - Pass any additional keyword arguments to append raw HTML attributes (for
   example, `data_tracking_id="hero"`).
 - Provide `rel` and `target` explicitly when linking to external destinations.
 - The helpers escape text and attribute values automatically; wrap trusted
-  markup in `markupsafe.Markup` if you need to opt out of escaping.
+  markup in `markupsafe.Markup` if you need to opt out of escaping. The preview
+  card preserves `Markup` captions while escaping plain text strings.
 ```

--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -32,6 +32,9 @@ for details on the structure of this metadata.
   render the landing page call-to-action buttons. Both helpers mirror the
   original Jinja macros, support optional `rel`/`target` parameters, and accept
   arbitrary HTML attributes via keyword arguments.
+- `pie.flashoffer.preview_card(card)` – render the Flashoffer preview card.
+  Provide a mapping with `image_url`, `alt_text`, `link_href`, and `caption`
+  entries to populate the image, overlay link, and caption text.
 
 Example:
 

--- a/src/examples/flashoffer.md
+++ b/src/examples/flashoffer.md
@@ -7,6 +7,8 @@ Available helpers:
   target=None, **attrs)` renders the filled primary button.
 - `pie.flashoffer.outline_cta(text, href, extra_classes="", rel=None,
   target=None, **attrs)` renders the outline secondary button.
+- `pie.flashoffer.preview_card(card)` renders the Flashoffer preview card from
+  a mapping that includes `image_url`, `alt_text`, `link_href`, and `caption`.
 
 ## Step-by-step instructions
 
@@ -72,3 +74,18 @@ renders as:
     data_tracking_id="hero-secondary",
 ) }}
 </div>
+
+## Preview card
+
+Combine the preview card with CTA helpers when a template needs to hide the
+full image behind a tap target.
+
+```jinja
+{% set preview = {
+    "image_url": "https://cdn.example.com/image.jpg",
+    "alt_text": "Gallery preview",
+    "link_href": "https://example.com/gallery",
+    "caption": "Captured in natural light.",
+} %}
+{{ pie.flashoffer.preview_card(preview) }}
+```


### PR DESCRIPTION
## Summary
- add a `pie.flashoffer.preview_card` helper that renders the Flashoffer preview card markup with escaping
- extend the Flashoffer unit tests to cover the new helper and confirm it is exposed via the Jinja globals
- document the preview card usage in the Jinja reference and Flashoffer example guide
- update the root agent instructions and Codex Flashoffer guide to keep preview card documentation in sync

## Testing
- pytest app/shell/py/pie/tests/test_flashoffer.py

------
https://chatgpt.com/codex/tasks/task_e_68d8329877ec832190f5d93398ee6153