### PR TITLE
Add configurable flashoffer footer helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@
   helpers change, also refresh
   `docs/guides/flashoffer-codex-instructions.md` to keep Codex guidance in
   sync.
+- When modifying Flashoffer methods, ensure any text rendered to end users is
+  configurable via function parameters.
 
 ## Checker Scripts
 

--- a/app/shell/py/pie/pie/flashoffer.py
+++ b/app/shell/py/pie/pie/flashoffer.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from markupsafe import Markup, escape
 
-__all__ = ["primary_cta", "outline_cta", "preview_card"]
+__all__ = ["primary_cta", "outline_cta", "preview_card", "footer"]
 
 
 def _merge_attrs(
@@ -173,5 +173,55 @@ def preview_card(card: Mapping[str, Any]) -> Markup:
             '    </div>\n'
             '  </div>\n'
             '</div>'
+        )
+    )
+
+
+def _coerce_optional_html(value: str | Markup | None) -> Markup:
+    if value is None:
+        return Markup("")
+    return _coerce_html(value)
+
+
+def footer(
+    *,
+    container_id: str = "contact",
+    left_prefix: str | Markup | None = Markup("©&nbsp;"),
+    site_name: str | Markup = "Seattle Figure Studio",
+    site_href: str = "https://seattlefigurestudio.com",
+    rights_statement: str | Markup = "All rights reserved.",
+    email_label: str | Markup = "brian@seattlefigurestudio.com",
+    email_href: str = "mailto:brian@seattlefigurestudio.com",
+) -> Markup:
+    """Render the Flashoffer footer snippet."""
+
+    id_attr = _escape_attr_value(container_id)
+    site_href_attr = _escape_attr_value(site_href)
+    email_href_attr = _escape_attr_value(email_href)
+
+    prefix_html = _coerce_optional_html(left_prefix)
+    site_html = _coerce_html(site_name)
+    rights_html = _coerce_html(rights_statement)
+    email_html = _coerce_html(email_label)
+
+    return Markup(
+        (
+            f'<footer id="{id_attr}" class="container py-4 small">\n'
+            '  <div class="row gy-3 align-items-center">\n'
+            '    <div class="col-12 col-md">\n'
+            f'      {prefix_html}<a\n'
+            '        class="link-dark text-decoration-none"\n'
+            f'        href="{site_href_attr}"\n'
+            '      >\n'
+            f'        {site_html}\n'
+            f'      </a>. {rights_html}\n'
+            '    </div>\n'
+            '    <div class="col-12 col-md-auto">\n'
+            f'      <a class="fw-semibold" href="{email_href_attr}">\n'
+            f'        {email_html}\n'
+            '      </a>\n'
+            '    </div>\n'
+            '  </div>\n'
+            '</footer>'
         )
     )

--- a/app/shell/py/pie/tests/test_flashoffer.py
+++ b/app/shell/py/pie/tests/test_flashoffer.py
@@ -174,6 +174,60 @@ def test_preview_card_requires_expected_card_keys(missing_key):
         flashoffer.preview_card(card)
 
 
+def test_footer_renders_expected_markup():
+    html = flashoffer.footer()
+    assert html == Markup(
+        '<footer id="contact" class="container py-4 small">\n'
+        '  <div class="row gy-3 align-items-center">\n'
+        '    <div class="col-12 col-md">\n'
+        '      ©&nbsp;<a\n'
+        '        class="link-dark text-decoration-none"\n'
+        '        href="https://seattlefigurestudio.com"\n'
+        '      >\n'
+        '        Seattle Figure Studio\n'
+        '      </a>. All rights reserved.\n'
+        '    </div>\n'
+        '    <div class="col-12 col-md-auto">\n'
+        '      <a class="fw-semibold" href="mailto:brian@seattlefigurestudio.com">\n'
+        '        brian@seattlefigurestudio.com\n'
+        '      </a>\n'
+        '    </div>\n'
+        '  </div>\n'
+        '</footer>'
+    )
+
+
+def test_footer_allows_custom_text_and_markup():
+    html = flashoffer.footer(
+        container_id="footer",  # attribute, not displayed
+        left_prefix=Markup("<strong>&copy;</strong>&nbsp;"),
+        site_name=Markup("<em>Pie Corp</em>"),
+        site_href="/about",
+        rights_statement="All <rights>",
+        email_label=Markup("<span>Contact&nbsp;Us</span>"),
+        email_href="mailto:support@example.com",
+    )
+    assert "<em>Pie Corp</em>" in html
+    assert "<span>Contact&nbsp;Us</span>" in html
+    assert "All &lt;rights&gt;" in html
+    assert "href=\"/about\"" in html
+    assert "href=\"mailto:support@example.com\"" in html
+
+
+def test_footer_escapes_plain_text_segments():
+    html = flashoffer.footer(
+        left_prefix='"copy" ',
+        site_name='Pie & Co',
+        rights_statement='Rights "reserved"',
+        email_label='team@example.com?subject="Hi"',
+        email_href='mailto:team@example.com?subject="Hi"',
+    )
+    assert '&#34;copy&#34;' in html
+    assert 'Pie &amp; Co' in html
+    assert 'Rights &#34;reserved&#34;' in html
+    assert 'team@example.com?subject=&#34;Hi&#34;' in html
+
+
 def test_flashoffer_module_is_registered_with_jinja_globals(monkeypatch, tmp_path):
     import sys
     import types
@@ -203,9 +257,80 @@ def test_flashoffer_module_is_registered_with_jinja_globals(monkeypatch, tmp_pat
     flatten_stub.unflatten = _unflatten
     monkeypatch.setitem(sys.modules, "flatten_dict", flatten_stub)
 
+    cmarkgfm_stub = types.ModuleType("cmarkgfm")
+
+    def _markdown_to_html(*args, **kwargs):  # pragma: no cover - stub
+        return ""
+
+    cmarkgfm_stub.github_flavored_markdown_to_html = _markdown_to_html
+    monkeypatch.setitem(sys.modules, "cmarkgfm", cmarkgfm_stub)
+
+    class _FakeLogger:
+        def remove(self, *args, **kwargs):  # pragma: no cover - stub
+            return None
+
+        def add(self, *args, **kwargs):  # pragma: no cover - stub
+            return 0
+
+    loguru_stub = types.ModuleType("loguru")
+    loguru_stub.logger = _FakeLogger()
+    monkeypatch.setitem(sys.modules, "loguru", loguru_stub)
+
+    ruamel_stub = types.ModuleType("ruamel")
+    ruamel_yaml_stub = types.ModuleType("ruamel.yaml")
+
+    class _FakeYAML:  # pragma: no cover - stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+    ruamel_yaml_stub.YAML = _FakeYAML
+    ruamel_yaml_stub.YAMLError = Exception
+    monkeypatch.setitem(sys.modules, "ruamel", ruamel_stub)
+    monkeypatch.setitem(sys.modules, "ruamel.yaml", ruamel_yaml_stub)
+
+    emoji_stub = types.ModuleType("emoji")
+
+    def _emojize(value, *args, **kwargs):  # pragma: no cover - stub
+        return value
+
+    emoji_stub.emojize = _emojize
+    monkeypatch.setitem(sys.modules, "emoji", emoji_stub)
+
+    class _FakeTemplate:
+        def render(self, *args, **kwargs):  # pragma: no cover - stub
+            return ""
+
+        @property
+        def module(self):  # pragma: no cover - stub
+            return types.SimpleNamespace(anchor=lambda _id: "")
+
+    class _FakeEnvironment:
+        def __init__(self, *args, **kwargs):  # pragma: no cover - stub
+            self.globals = {}
+            self.filters = {}
+
+        def from_string(self, *args, **kwargs):  # pragma: no cover - stub
+            return _FakeTemplate()
+
+        def get_template(self, *args, **kwargs):  # pragma: no cover - stub
+            return _FakeTemplate()
+
+    class _FakeLoader:  # pragma: no cover - stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+    jinja2_stub = types.ModuleType("jinja2")
+    jinja2_stub.Environment = _FakeEnvironment
+    jinja2_stub.FileSystemLoader = _FakeLoader
+    jinja2_stub.StrictUndefined = object
+    jinja2_stub.TemplateNotFound = Exception
+    jinja2_stub.TemplateSyntaxError = Exception
+    monkeypatch.setitem(sys.modules, "jinja2", jinja2_stub)
+
     from pie.render import jinja
 
     flashoffer_global = jinja.env.globals["pie"]["flashoffer"]
     assert flashoffer_global.primary_cta is flashoffer.primary_cta
     assert flashoffer_global.outline_cta is flashoffer.outline_cta
     assert flashoffer_global.preview_card is flashoffer.preview_card
+    assert flashoffer_global.footer is flashoffer.footer

--- a/docs/guides/flashoffer-codex-instructions.md
+++ b/docs/guides/flashoffer-codex-instructions.md
@@ -12,6 +12,8 @@ agents know how to render landing page buttons using `pie.flashoffer`.
 - Use `pie.flashoffer.preview_card(card)` to render the preview card markup.
   The `card` mapping must include `image_url`, `alt_text`, `link_href`, and
   `caption` keys.
+- Use `pie.flashoffer.footer(...)` to render the Flashoffer footer snippet.
+  All visible text segments are configurable through the helper arguments.
 - Pass any additional keyword arguments to append raw HTML attributes (for
   example, `data_tracking_id="hero"`).
 - Provide `rel` and `target` explicitly when linking to external destinations.

--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -35,6 +35,9 @@ for details on the structure of this metadata.
 - `pie.flashoffer.preview_card(card)` – render the Flashoffer preview card.
   Provide a mapping with `image_url`, `alt_text`, `link_href`, and `caption`
   entries to populate the image, overlay link, and caption text.
+- `pie.flashoffer.footer(...)` – render the Flashoffer footer layout. All text
+  displayed to users can be customized through keyword arguments while the
+  helper continues to escape plain strings safely.
 
 Example:
 

--- a/src/examples/flashoffer.md
+++ b/src/examples/flashoffer.md
@@ -9,6 +9,9 @@ Available helpers:
   target=None, **attrs)` renders the outline secondary button.
 - `pie.flashoffer.preview_card(card)` renders the Flashoffer preview card from
   a mapping that includes `image_url`, `alt_text`, `link_href`, and `caption`.
+- `pie.flashoffer.footer(**kwargs)` renders the Flashoffer footer. Customize the
+  visible text by overriding keyword arguments such as `left_prefix`,
+  `site_name`, `rights_statement`, and `email_label`.
 
 ## Step-by-step instructions
 
@@ -92,3 +95,21 @@ full image behind a tap target.
     "caption": "a cool place",
 } %}
 {{ pie.flashoffer.preview_card(preview) }}
+
+## Footer
+
+Use the footer helper to render the contact information block.
+
+```jinja
+{{ pie.flashoffer.footer(
+    left_prefix="©&nbsp;",
+    site_name="Seattle Figure Studio",
+    site_href="https://seattlefigurestudio.com",
+    rights_statement="All rights reserved.",
+    email_label="brian@seattlefigurestudio.com",
+) }}
+```
+
+renders as:
+
+{{ pie.flashoffer.footer() }}


### PR DESCRIPTION
## Summary
- add a configurable `pie.flashoffer.footer` helper that renders the Flashoffer footer markup
- expand Flashoffer unit tests with footer coverage and lightweight stubs for external dependencies
- document the new helper across agent instructions, reference material, and examples

## Testing
- pytest tests/test_flashoffer.py

------
https://chatgpt.com/codex/tasks/task_e_68d83a2547e08321aac184c68086632d