### PR TITLE
Add hero banner helper for Flashoffer

### DIFF
--- a/app/shell/py/pie/pie/flashoffer.py
+++ b/app/shell/py/pie/pie/flashoffer.py
@@ -15,7 +15,13 @@ from typing import Any
 
 from markupsafe import Markup, escape
 
-__all__ = ["primary_cta", "outline_cta", "preview_card", "footer"]
+__all__ = [
+    "primary_cta",
+    "outline_cta",
+    "hero_banner",
+    "preview_card",
+    "footer",
+]
 
 
 def _merge_attrs(
@@ -116,6 +122,83 @@ def outline_cta(
         rel=rel,
         target=target,
         **attrs,
+    )
+
+
+def _coerce_mapping(mapping: Mapping[str, Any] | None) -> dict[str, Any]:
+    if mapping is None:
+        return {}
+    return dict(mapping)
+
+
+def hero_banner(
+    *,
+    eyebrow: str | Markup = "Seattle-born figure reference",
+    title: str | Markup = "Stone Canvas",
+    description: str | Markup = (
+        "Build stronger drawings with Stone Canvas reference bundles created by "
+        "Seattle models and artists. Each pack keeps studies aligned with atelier "
+        "methods, community collaborations, and clear licensing."
+    ),
+    primary_cta_text: str | Markup = "Explore Stone Canvas",
+    primary_cta_href: str = "https://seattlefigurestudio.com/shop/stone-canvas-medusa",
+    primary_cta_kwargs: Mapping[str, Any] | None = None,
+    first_outline_text: str | Markup = "Email to collaborate",
+    first_outline_href: str = "mailto:brian@seattlefigurestudio.com",
+    first_outline_kwargs: Mapping[str, Any] | None = None,
+    second_outline_text: str | Markup = "Meet Seattle Figure Studio",
+    second_outline_href: str = "https://seattlefigurestudio.com/about-us",
+    second_outline_kwargs: Mapping[str, Any] | None = None,
+) -> Markup:
+    """Render the Flashoffer hero banner with configurable CTAs."""
+
+    eyebrow_html = _coerce_html(eyebrow)
+    title_html = _coerce_html(title)
+    description_html = _coerce_html(description)
+
+    primary_kwargs = _coerce_mapping(primary_cta_kwargs)
+    first_outline = _coerce_mapping(first_outline_kwargs)
+    second_outline = _coerce_mapping(second_outline_kwargs)
+
+    primary_button = primary_cta(primary_cta_text, primary_cta_href, **primary_kwargs)
+    first_outline_button = outline_cta(
+        first_outline_text,
+        first_outline_href,
+        **first_outline,
+    )
+    second_outline_button = outline_cta(
+        second_outline_text,
+        second_outline_href,
+        **second_outline,
+    )
+
+    return Markup(
+        (
+            '<section class="section">\n'
+            '  <div class="container">\n'
+            '    <div class="row justify-content-center">\n'
+            '      <div class="col-lg-10">\n'
+            '        <div class="surface p-4 p-md-5 text-center">\n'
+            '          <span class="eyebrow mb-3 d-inline-block">\n'
+            f'            {eyebrow_html}\n'
+            '          </span>\n'
+            '          <h1 class="display-5 fw-semibold mb-3">\n'
+            f'            {title_html}\n'
+            '          </h1>\n'
+            '          <p class="lead mx-auto mb-4" style="max-width: 38rem;">\n'
+            f'            {description_html}\n'
+            '          </p>\n'
+            '          <div class="hero-cta d-grid gap-3 d-sm-flex justify-content-center">\n'
+            f'            {primary_button}\n'
+            f'            {first_outline_button}\n'
+            f'            {second_outline_button}\n'
+            '          </div>\n'
+            '        </div>\n'
+            '      </div>\n'
+            '    </div>\n'
+            '  </div>\n'
+            '</section>'
+        )
     )
 
 

--- a/docs/guides/flashoffer-codex-instructions.md
+++ b/docs/guides/flashoffer-codex-instructions.md
@@ -9,6 +9,10 @@ agents know how to render landing page buttons using `pie.flashoffer`.
   target=None, **attrs)` for the solid call-to-action button.
 - Use `pie.flashoffer.outline_cta(text, href, extra_classes="", rel=None,
   target=None, **attrs)` for the outline button variant.
+- Use `pie.flashoffer.hero_banner(...)` to render the Flashoffer hero banner.
+  Configure the eyebrow, heading, description, and each call-to-action via the
+  helper parameters or pass keyword argument dictionaries through to the CTA
+  helpers.
 - Use `pie.flashoffer.preview_card(card)` to render the preview card markup.
   The `card` mapping must include `image_url`, `alt_text`, `link_href`, and
   `caption` keys.


### PR DESCRIPTION
## Summary
- add a `hero_banner` helper that renders the Flashoffer hero layout with configurable text and call-to-action buttons
- reuse existing CTA helpers so callers can supply additional HTML attributes through mapping arguments
- document the new helper in the Flashoffer Codex instructions guide

## Testing
- pytest *(fails: missing optional dependencies such as analytics_backend, markupsafe, fakeredis, and ruamel.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68d83cc0c4148321a6e72b1ed9f6ce1a