### PR TITLE
Add Flashoffer preview grid documentation example

### DIFF
--- a/src/examples/flashoffer.md
+++ b/src/examples/flashoffer.md
@@ -96,6 +96,111 @@ full image behind a tap target.
 } %}
 {{ pie.flashoffer.preview_card(preview) }}
 
+## Preview grid
+
+Use the preview grid when a landing page needs to showcase more than one
+study bundle without immediately exposing the underlying figure photography.
+The layout keeps the cards aligned across breakpoints while the helper ensures
+each card carries consistent Flashoffer styling.
+
+The overlay button created by `pie.flashoffer.preview_card` is wired up by the
+base template's JavaScript in `src/templates/template.html.jinja`, so visitors
+must click **View image** before any NSFW content is revealed. No additional
+script is required inside your page.
+
+The reusable partial at
+`src/templates/examples/flashoffer-card-grid.html.jinja` iterates through
+`card_list` and calls the helper for every entry. This keeps the markup
+centralised and makes it easy to swap in new cards or update the button text
+in one place.
+
+```jinja
+<div
+  class="alert alert-warning d-flex align-items-center gap-2"
+  role="alert"
+>
+  <span class="fw-semibold text-uppercase small">Heads up</span>
+  <span>Preview links should comply with your terms of service.</span>
+</div>
+
+{% set card_list = [
+    {
+        "image_url": "https://picsum.photos/seed/flashoffer-1/640/480",
+        "alt_text": "Dynamic seated pose",
+        "link_href": "https://example.com/bundles/dynamic",
+        "caption": "45-minute seated gestures with charcoal studies.",
+    },
+    {
+        "image_url": "https://picsum.photos/seed/flashoffer-2/640/480",
+        "alt_text": "Contrapposto profile pose",
+        "link_href": "https://example.com/bundles/profile",
+        "caption": "Standing contrapposto sequence captured at 5 angles.",
+    },
+    {
+        "image_url": "https://picsum.photos/seed/flashoffer-3/640/480",
+        "alt_text": "Foreshortened reclining pose",
+        "link_href": "https://example.com/bundles/reclining",
+        "caption": "Foreshortened reclining study with lighting notes.",
+    },
+] %}
+
+{% include "examples/flashoffer-card-grid.html.jinja" %}
+
+<div class="mt-4 d-grid gap-3 d-sm-flex justify-content-center">
+  {{ pie.flashoffer.primary_cta(
+      "Download the full bundle",
+      "https://example.com/bundles/download"
+  ) }}
+  {{ pie.flashoffer.outline_cta(
+      "See studio policies",
+      "https://example.com/policies"
+  ) }}
+</div>
+```
+
+renders as:
+
+<div
+  class="alert alert-warning d-flex align-items-center gap-2"
+  role="alert"
+>
+  <span class="fw-semibold text-uppercase small">Heads up</span>
+  <span>Preview links should comply with your terms of service.</span>
+</div>
+
+{% set card_list = [
+    {
+        "image_url": "https://picsum.photos/seed/flashoffer-1/640/480",
+        "alt_text": "Dynamic seated pose",
+        "link_href": "https://example.com/bundles/dynamic",
+        "caption": "45-minute seated gestures with charcoal studies.",
+    },
+    {
+        "image_url": "https://picsum.photos/seed/flashoffer-2/640/480",
+        "alt_text": "Contrapposto profile pose",
+        "link_href": "https://example.com/bundles/profile",
+        "caption": "Standing contrapposto sequence captured at 5 angles.",
+    },
+    {
+        "image_url": "https://picsum.photos/seed/flashoffer-3/640/480",
+        "alt_text": "Foreshortened reclining pose",
+        "link_href": "https://example.com/bundles/reclining",
+        "caption": "Foreshortened reclining study with lighting notes.",
+    },
+] %}
+{% include "examples/flashoffer-card-grid.html.jinja" %}
+
+<div class="mt-4 d-grid gap-3 d-sm-flex justify-content-center">
+  {{ pie.flashoffer.primary_cta(
+      "Download the full bundle",
+      "https://example.com/bundles/download"
+  ) }}
+  {{ pie.flashoffer.outline_cta(
+      "See studio policies",
+      "https://example.com/policies"
+  ) }}
+</div>
+
 ## Footer
 
 Use the footer helper to render the contact information block.

--- a/src/templates/examples/flashoffer-card-grid.html.jinja
+++ b/src/templates/examples/flashoffer-card-grid.html.jinja
@@ -1,0 +1,5 @@
+<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-4">
+  {% for card in card_list %}
+  {{ pie.flashoffer.preview_card(card) }}
+  {% endfor %}
+</div>


### PR DESCRIPTION
## Summary
- document when to use the Flashoffer preview grid and how the NSFW toggle works
- embed the full grid snippet with warning, card list setup, and CTA rendering
- add a reusable card grid partial that loops through Flashoffer preview cards

## Testing
- make build/examples/flashoffer.html *(fails: `picasso` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d840ab11f4832188142b79cbc84755