### PR TITLE
Use Flashoffer hero banner across templates

### DIFF
--- a/app/shell/py/pie/pie/flashoffer.py
+++ b/app/shell/py/pie/pie/flashoffer.py
@@ -10,7 +10,7 @@ any extra keyword arguments are rendered verbatim as HTML attributes.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 
 from markupsafe import Markup, escape
@@ -131,73 +131,112 @@ def _coerce_mapping(mapping: Mapping[str, Any] | None) -> dict[str, Any]:
     return dict(mapping)
 
 
+def _render_optional_hero_cta(
+    renderer: Callable[..., Markup],
+    text: str | Markup | None,
+    href: str | None,
+    kwargs: Mapping[str, Any],
+) -> Markup | None:
+    if text is None or href is None:
+        return None
+    return renderer(text, href, **kwargs)
+
+
 def hero_banner(
     *,
-    eyebrow: str | Markup = "Seattle-born figure reference",
+    eyebrow: str | Markup | None = "Seattle-born figure reference",
     title: str | Markup = "Stone Canvas",
-    description: str | Markup = (
+    description: str | Markup | None = (
         "Build stronger drawings with Stone Canvas reference bundles created by "
         "Seattle models and artists. Each pack keeps studies aligned with atelier "
         "methods, community collaborations, and clear licensing."
     ),
-    primary_cta_text: str | Markup = "Explore Stone Canvas",
-    primary_cta_href: str = "https://seattlefigurestudio.com/shop/stone-canvas-medusa",
+    primary_cta_text: str | Markup | None = "Explore Stone Canvas",
+    primary_cta_href: str | None = "https://seattlefigurestudio.com/shop/stone-canvas-medusa",
     primary_cta_kwargs: Mapping[str, Any] | None = None,
-    first_outline_text: str | Markup = "Email to collaborate",
-    first_outline_href: str = "mailto:brian@seattlefigurestudio.com",
+    first_outline_text: str | Markup | None = "Email to collaborate",
+    first_outline_href: str | None = "mailto:brian@seattlefigurestudio.com",
     first_outline_kwargs: Mapping[str, Any] | None = None,
-    second_outline_text: str | Markup = "Meet Seattle Figure Studio",
-    second_outline_href: str = "https://seattlefigurestudio.com/about-us",
+    second_outline_text: str | Markup | None = "Meet Seattle Figure Studio",
+    second_outline_href: str | None = "https://seattlefigurestudio.com/about-us",
     second_outline_kwargs: Mapping[str, Any] | None = None,
 ) -> Markup:
     """Render the Flashoffer hero banner with configurable CTAs."""
 
-    eyebrow_html = _coerce_html(eyebrow)
+    eyebrow_html = _coerce_optional_html(eyebrow)
     title_html = _coerce_html(title)
-    description_html = _coerce_html(description)
+    description_html = _coerce_optional_html(description)
 
     primary_kwargs = _coerce_mapping(primary_cta_kwargs)
     first_outline = _coerce_mapping(first_outline_kwargs)
     second_outline = _coerce_mapping(second_outline_kwargs)
 
-    primary_button = primary_cta(primary_cta_text, primary_cta_href, **primary_kwargs)
-    first_outline_button = outline_cta(
-        first_outline_text,
-        first_outline_href,
-        **first_outline,
+    buttons = [
+        _render_optional_hero_cta(
+            primary_cta,
+            primary_cta_text,
+            primary_cta_href,
+            primary_kwargs,
+        ),
+        _render_optional_hero_cta(
+            outline_cta,
+            first_outline_text,
+            first_outline_href,
+            first_outline,
+        ),
+        _render_optional_hero_cta(
+            outline_cta,
+            second_outline_text,
+            second_outline_href,
+            second_outline,
+        ),
+    ]
+
+    eyebrow_block = ""
+    if eyebrow_html:
+        eyebrow_block = (
+            '          <span class="eyebrow mb-3 d-inline-block">\n'
+            f'            {eyebrow_html}\n'
+            "          </span>\n"
+        )
+
+    description_block = ""
+    if description_html:
+        description_block = (
+            '          <p class="lead mx-auto mb-4" style="max-width: 38rem;">\n'
+            f'            {description_html}\n'
+            "          </p>\n"
+        )
+
+    button_markup = "".join(
+        f"            {button}\n" for button in buttons if button is not None
     )
-    second_outline_button = outline_cta(
-        second_outline_text,
-        second_outline_href,
-        **second_outline,
-    )
+    buttons_block = ""
+    if button_markup:
+        buttons_block = (
+            '          <div class="hero-cta d-grid gap-3 d-sm-flex justify-content-center">\n'
+            f"{button_markup}"
+            "          </div>\n"
+        )
 
     return Markup(
         (
-            '<section class="section">\n'
+            '<section class="section flashoffer-hero">\n'
             '  <div class="container">\n'
             '    <div class="row justify-content-center">\n'
             '      <div class="col-lg-10">\n'
             '        <div class="surface p-4 p-md-5 text-center">\n'
-            '          <span class="eyebrow mb-3 d-inline-block">\n'
-            f'            {eyebrow_html}\n'
-            '          </span>\n'
+            f"{eyebrow_block}"
             '          <h1 class="display-5 fw-semibold mb-3">\n'
             f'            {title_html}\n'
-            '          </h1>\n'
-            '          <p class="lead mx-auto mb-4" style="max-width: 38rem;">\n'
-            f'            {description_html}\n'
-            '          </p>\n'
-            '          <div class="hero-cta d-grid gap-3 d-sm-flex justify-content-center">\n'
-            f'            {primary_button}\n'
-            f'            {first_outline_button}\n'
-            f'            {second_outline_button}\n'
-            '          </div>\n'
-            '        </div>\n'
-            '      </div>\n'
-            '    </div>\n'
-            '  </div>\n'
-            '</section>'
+            "          </h1>\n"
+            f"{description_block}"
+            f"{buttons_block}"
+            "        </div>\n"
+            "      </div>\n"
+            "    </div>\n"
+            "  </div>\n"
+            "</section>"
         )
     )
 

--- a/app/shell/py/pie/tests/test_flashoffer.py
+++ b/app/shell/py/pie/tests/test_flashoffer.py
@@ -73,6 +73,47 @@ def test_cta_preserves_markup_text():
     )
 
 
+def test_hero_banner_renders_optional_sections():
+    html = flashoffer.hero_banner(
+        eyebrow="Limited release",
+        title="Discover Stone Canvas",
+        description="Explore new poses crafted in Seattle.",
+        primary_cta_text="Start now",
+        primary_cta_href="/start",
+        first_outline_text="See docs",
+        first_outline_href="/docs",
+        second_outline_text="Contact",
+        second_outline_href="/contact",
+    )
+
+    assert isinstance(html, Markup)
+    html_text = str(html)
+    assert "Limited release" in html_text
+    assert "Discover Stone Canvas" in html_text
+    assert "hero-cta" in html_text
+    assert ">Start now<" in html_text
+
+
+def test_hero_banner_omits_optional_content_when_none():
+    html = flashoffer.hero_banner(
+        eyebrow=None,
+        title="Documentation",
+        description=None,
+        primary_cta_text=None,
+        primary_cta_href=None,
+        first_outline_text=None,
+        first_outline_href=None,
+        second_outline_text=None,
+        second_outline_href=None,
+    )
+
+    html_text = str(html)
+    assert "Documentation" in html_text
+    assert "hero-cta" not in html_text
+    assert "eyebrow" not in html_text
+    assert "lead mx-auto" not in html_text
+
+
 def test_preview_card_renders_expected_markup():
     html = flashoffer.preview_card(
         {
@@ -332,5 +373,6 @@ def test_flashoffer_module_is_registered_with_jinja_globals(monkeypatch, tmp_pat
     flashoffer_global = jinja.env.globals["pie"]["flashoffer"]
     assert flashoffer_global.primary_cta is flashoffer.primary_cta
     assert flashoffer_global.outline_cta is flashoffer.outline_cta
+    assert flashoffer_global.hero_banner is flashoffer.hero_banner
     assert flashoffer_global.preview_card is flashoffer.preview_card
     assert flashoffer_global.footer is flashoffer.footer

--- a/docs/guides/flashoffer-codex-instructions.md
+++ b/docs/guides/flashoffer-codex-instructions.md
@@ -13,6 +13,8 @@ agents know how to render landing page buttons using `pie.flashoffer`.
   Configure the eyebrow, heading, description, and each call-to-action via the
   helper parameters or pass keyword argument dictionaries through to the CTA
   helpers.
+- Pass `None` for any hero banner CTA text or link to omit that button. Set
+  `eyebrow` or `description` to `None` when those sections should be hidden.
 - Use `pie.flashoffer.preview_card(card)` to render the preview card markup.
   The `card` mapping must include `image_url`, `alt_text`, `link_href`, and
   `caption` keys.

--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -32,6 +32,10 @@ for details on the structure of this metadata.
   render the landing page call-to-action buttons. Both helpers mirror the
   original Jinja macros, support optional `rel`/`target` parameters, and accept
   arbitrary HTML attributes via keyword arguments.
+- `pie.flashoffer.hero_banner(...)` – render the Flashoffer hero banner.
+  Provide eyebrow, heading, description, and CTA values through keyword
+  arguments. Pass `None` for any CTA text or link to omit that button
+  entirely.
 - `pie.flashoffer.preview_card(card)` – render the Flashoffer preview card.
   Provide a mapping with `image_url`, `alt_text`, `link_href`, and `caption`
   entries to populate the image, overlay link, and caption text.

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -76,32 +76,43 @@ main {
   border-color: rgba(248, 249, 250, 0.9);
 }
 
-.hero-header {
-  min-height: 30vh;
+.section {
+  padding: clamp(4rem, 10vw, 6.5rem) 0;
 }
 
-.bg-image {
-  transition: opacity 0.6s ease;
-  object-position: var(--hero-image-position, center);
+.surface {
+  background: rgba(15, 18, 26, 0.85);
+  border: 1px solid rgba(248, 249, 250, 0.12);
+  border-radius: 1.5rem;
+  box-shadow: 0 2.5rem 3.5rem -2.5rem rgba(9, 11, 16, 0.9);
+  color: var(--sfs-foreground);
+}
+
+.surface .lead {
+  color: var(--sfs-muted);
+}
+
+.eyebrow {
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--sfs-accent);
+}
+
+.hero-cta .btn {
+  min-width: 10.5rem;
 }
 
 @media (max-width: 576px) {
-  .bg-image {
-    object-position: var(
-      --hero-image-position-mobile,
-      var(--hero-image-position, center)
-    );
+  .section {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
   }
-}
 
-.bg-overlay {
-  background: linear-gradient(
-    180deg,
-    rgba(0, 0, 0, 0.45) 0%,
-    rgba(0, 0, 0, 0.65) 60%,
-    rgba(0, 0, 0, 0.75) 100%
-  );
-  pointer-events: none;
+  .hero-cta .btn {
+    width: 100%;
+  }
 }
 
 .preview-card {

--- a/src/templates/template.html.jinja
+++ b/src/templates/template.html.jinja
@@ -43,41 +43,47 @@
     </nav>
     {% endif %}
 
-    <header
-      class="hero-header mb-5 text-white border-bottom position-relative bg-black d-flex align-items-center"
-    >
-      {% if header and header.get("src") %}
-      {% set hero_image_styles = [] %}
-      {% if header.get("object_position") %}
-      {% set hero_image_styles = hero_image_styles +
-        ["--hero-image-position: " ~ header.get("object_position")] %}
-      {% endif %}
-      {% if header.object_position_mobile %}
-      {% set hero_image_styles = hero_image_styles +
-        ["--hero-image-position-mobile: " ~ header.object_position_mobile] %}
-      {% endif %}
-      <img
-        src="{{ header.src }}"
-        {% if header.srcset %}srcset="{{ header.get('srcset') }}"
-        {% endif %}
-        sizes="100vw"
-        class="bg-image position-absolute top-0 start-0 w-100 h-100 object-fit-cover opacity-0"
-        onload="this.classList.add('opacity-100')"
-        {% if hero_image_styles %}style="{{ hero_image_styles | join('; ') }};"
-        {% endif %}
-        {% if header.get("alt") %}alt="{{ header.get('alt') }}"
-        {% else %}alt="Background"
-        {% endif %}
-      />
-      <div class="bg-overlay position-absolute top-0 start-0 w-100 h-100"></div>
-      {% endif %}
+    {% set show_hero_banner = true %}
+    {% set hero_config = {} %}
+    {% if hero_banner is defined %}
+    {% if hero_banner is sameas false %}
+    {% set show_hero_banner = false %}
+    {% elif hero_banner is mapping %}
+    {% set hero_config = hero_banner %}
+    {% endif %}
+    {% endif %}
+    {% if html is defined and html.hero_banner is defined %}
+    {% if html.hero_banner is sameas false %}
+    {% set show_hero_banner = false %}
+    {% elif html.hero_banner is mapping %}
+    {% set hero_config = html.hero_banner %}
+    {% endif %}
+    {% endif %}
 
-      <div class="container-fluid position-relative text-center">
-        <h1 class="display-3 fw-bold">
-          {% if page_heading %} {{ page_heading }} {% else %} {{ doc.title }} {% endif %}
-        </h1>
-      </div>
-    </header>
+    {% if show_hero_banner %}
+    {% set hero_title = hero_config.get('title') if hero_config.get('title') is not none else None %}
+    {% if hero_title is none %}
+    {% if page_heading is defined and page_heading %}
+    {% set hero_title = page_heading %}
+    {% else %}
+    {% set hero_title = doc.title %}
+    {% endif %}
+    {% endif %}
+    {{ pie.flashoffer.hero_banner(
+      eyebrow=hero_config.get('eyebrow'),
+      title=hero_title,
+      description=hero_config.get('description'),
+      primary_cta_text=hero_config.get('primary_cta_text'),
+      primary_cta_href=hero_config.get('primary_cta_href'),
+      primary_cta_kwargs=hero_config.get('primary_cta_kwargs'),
+      first_outline_text=hero_config.get('first_outline_text'),
+      first_outline_href=hero_config.get('first_outline_href'),
+      first_outline_kwargs=hero_config.get('first_outline_kwargs'),
+      second_outline_text=hero_config.get('second_outline_text'),
+      second_outline_href=hero_config.get('second_outline_href'),
+      second_outline_kwargs=hero_config.get('second_outline_kwargs'),
+    ) }}
+    {% endif %}
 
     <main class="container mb-5" style="max-width: 65ch">
       {% if doc.breadcrumbs %}
@@ -160,8 +166,8 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"></script>
     {% if show_navbar %}
     <script>
-      window.addEventListener("DOMContentLoaded", () => {
-        const hero = document.querySelector(".hero-header");
+        window.addEventListener("DOMContentLoaded", () => {
+          const hero = document.querySelector(".flashoffer-hero");
         const titleEl = document.querySelector(".navbar .page-title");
         if (!titleEl) return;
         if (!hero) {


### PR DESCRIPTION
## Summary
- replace the default site hero with `pie.flashoffer.hero_banner` and allow front matter overrides
- let `hero_banner` omit CTAs when not configured and refresh Flashoffer docs
- style the Flashoffer hero and add unit tests covering the new banner behaviour

## Testing
- pytest app/shell/py/pie/tests/test_flashoffer.py

------
https://chatgpt.com/codex/tasks/task_e_68d840c2c934832186db9ef257bd1e4e