### PR TITLE
Document Flashoffer hero banner helper

### DIFF
--- a/docs/guides/flashoffer-codex-instructions.md
+++ b/docs/guides/flashoffer-codex-instructions.md
@@ -25,3 +25,29 @@ agents know how to render landing page buttons using `pie.flashoffer`.
   markup in `markupsafe.Markup` if you need to opt out of escaping. The preview
   card preserves `Markup` captions while escaping plain text strings.
 ```
+
+## Hero banner parameters
+
+`pie.flashoffer.hero_banner` renders the landing hero with an eyebrow, heading,
+supporting copy, and up to three CTAs. The helper accepts:
+
+- `eyebrow`, `title`, and `description` – either plain strings or trusted
+  `Markup`. Use `Markup` when the layout needs inline emphasis, just as you
+  would for preview captions in the
+  [preview card example](../../src/examples/flashoffer.md#preview-card).
+- `primary_cta_text` and `primary_cta_href` – populate the filled CTA. Extend
+  or override button attributes with `primary_cta_kwargs`, which forwards keys
+  like `extra_classes`, `rel`, and `target` to
+  [`pie.flashoffer.primary_cta`](../../src/examples/flashoffer.md#primary-cta).
+  Link labels should align with the footer language described in the
+  [Flashoffer footer](../../src/examples/flashoffer.md#footer) guidance.
+- `first_outline_text`/`href` and `second_outline_text`/`href` – populate the
+  outline CTAs. Each CTA also accepts a `*_kwargs` mapping. These dictionaries
+  are passed straight into `pie.flashoffer.outline_cta`, so you can add
+  tracking attributes or reuse the same label overrides that appear alongside
+  the [preview card helper](../../src/examples/flashoffer.md#preview-card).
+
+To hide a CTA entirely, supply a utility class through the corresponding
+`*_kwargs`, for example `{"extra_classes": "d-none"}`. You can also reorder
+buttons inside the responsive flex container by assigning Bootstrap order
+classes (`order-2`, `order-3`, and so on) via the same dictionaries.

--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -32,6 +32,14 @@ for details on the structure of this metadata.
   render the landing page call-to-action buttons. Both helpers mirror the
   original Jinja macros, support optional `rel`/`target` parameters, and accept
   arbitrary HTML attributes via keyword arguments.
+- `pie.flashoffer.hero_banner(...)` – render the hero section composed of an
+  eyebrow, `h1` title, supporting `<p>` description, and a flex container with
+  one primary CTA plus two outline CTAs. Provide `eyebrow`, `title`,
+  `description`, `primary_cta_text`, and `primary_cta_href`. Outline CTAs are
+  optional and configured with `first_outline_text`/`href` and
+  `second_outline_text`/`href`. Pass `primary_cta_kwargs` and the outline
+  `*_kwargs` dictionaries to forward keyword arguments directly into the CTA
+  helpers when you need to adjust labels, tracking attributes, or button order.
 - `pie.flashoffer.preview_card(card)` – render the Flashoffer preview card.
   Provide a mapping with `image_url`, `alt_text`, `link_href`, and `caption`
   entries to populate the image, overlay link, and caption text.

--- a/src/examples/flashoffer.md
+++ b/src/examples/flashoffer.md
@@ -74,6 +74,94 @@ renders as:
     data_tracking_id="hero-secondary",
 ) }}
 
+## Hero banner
+
+Combine the hero banner with the CTA helpers when you need a landing intro
+section that links to supporting content. Reuse the same keyword arguments
+described in the [Primary CTA](#primary-cta) and [Outline CTA](#outline-cta)
+sections to set analytics attributes or alter the button order. Linking the
+first outline CTA to `#preview-card` keeps the hero aligned with the
+[Preview card](#preview-card) gallery, while the second outline CTA can mirror
+compliance language documented in the [Footer](#footer).
+
+```jinja
+{% set primary_kwargs = {
+    "extra_classes": "shadow-lg",
+    "data_tracking_id": "hero-primary",
+} %}
+{% set first_outline_kwargs = {
+    "extra_classes": "order-3 order-sm-2",
+    "data_tracking_id": "hero-preview",
+} %}
+{% set second_outline_kwargs = {
+    "extra_classes": "order-2 order-sm-3",
+    "data_tracking_id": "hero-compliance",
+} %}
+{{ pie.flashoffer.hero_banner(
+    eyebrow="Limited-run bundles",
+    title="Stone Canvas: Medusa release",
+    description="Pair live session studies with downloadable references tuned "
+    "for the Stone Canvas Medusa campaign.",
+    primary_cta_text="Start your free trial",
+    primary_cta_href="/signup",
+    primary_cta_kwargs=primary_kwargs,
+    first_outline_text="See preview gallery",
+    first_outline_href="#preview-card",
+    first_outline_kwargs=first_outline_kwargs,
+    second_outline_text="Read studio policies",
+    second_outline_href="/policies",
+    second_outline_kwargs=second_outline_kwargs,
+) }}
+```
+
+renders as:
+
+```html
+<section class="section">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-lg-10">
+        <div class="surface p-4 p-md-5 text-center">
+          <span class="eyebrow mb-3 d-inline-block">
+            Limited-run bundles
+          </span>
+          <h1 class="display-5 fw-semibold mb-3">
+            Stone Canvas: Medusa release
+          </h1>
+          <p class="lead mx-auto mb-4" style="max-width: 38rem;">
+            Pair live session studies with downloadable references tuned for the
+            Stone Canvas Medusa campaign.
+          </p>
+          <div class="hero-cta d-grid gap-3 d-sm-flex justify-content-center">
+            <a
+              class="btn btn-primary btn-lg px-4 shadow-lg"
+              href="/signup"
+              data_tracking_id="hero-primary"
+            >
+              Start your free trial
+            </a>
+            <a
+              class="btn btn-outline-light btn-lg px-4 order-3 order-sm-2"
+              href="#preview-card"
+              data_tracking_id="hero-preview"
+            >
+              See preview gallery
+            </a>
+            <a
+              class="btn btn-outline-light btn-lg px-4 order-2 order-sm-3"
+              href="/policies"
+              data_tracking_id="hero-compliance"
+            >
+              Read studio policies
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+```
+
 ## Preview card
 
 Combine the preview card with CTA helpers when a template needs to hide the


### PR DESCRIPTION
## Summary
- add dedicated hero banner guidance and cross-links to the Codex instructions
- document the pie.flashoffer.hero_banner global in the Jinja reference
- expand the Flashoffer example with hero banner inputs and rendered output

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d8428f000c8321a3330f80d30dcf07