### PR TITLE
Allow preview_card overlay text customization

### DIFF
--- a/app/shell/py/pie/pie/flashoffer.py
+++ b/app/shell/py/pie/pie/flashoffer.py
@@ -221,13 +221,20 @@ def _coerce_html(value: Any) -> Markup:
     return escape(value)
 
 
-def preview_card(card: Mapping[str, Any]) -> Markup:
+def preview_card(
+    card: Mapping[str, Any],
+    *,
+    overlay_text: str | Markup = "Tap to reveal this artistic nude pose.",
+    overlay_button_text: str | Markup = "View image",
+) -> Markup:
     """Render the Flashoffer preview card partial."""
 
     image_url = _escape_attr_value(_require_card_value(card, "image_url"))
     alt_text = _escape_attr_value(_require_card_value(card, "alt_text"))
     link_href = _escape_attr_value(_require_card_value(card, "link_href"))
     caption = _coerce_html(_require_card_value(card, "caption"))
+    overlay_html = _coerce_html(overlay_text)
+    overlay_button_html = _coerce_html(overlay_button_text)
 
     return Markup(
         (
@@ -244,9 +251,9 @@ def preview_card(card: Mapping[str, Any]) -> Markup:
             '      />\n'
             '      <div class="preview-overlay">\n'
             '        <div class="text-center px-3">\n'
-            '          <p class="mb-2 fw-semibold">Tap to reveal this artistic nude pose.</p>\n'
+            f'          <p class="mb-2 fw-semibold">{overlay_html}</p>\n'
             f'          <a class="btn btn-outline-light btn-sm preview-toggle" href="{link_href}" role="button">\n'
-            '            View image\n'
+            f'            {overlay_button_html}\n'
             '          </a>\n'
             '        </div>\n'
             '      </div>\n'

--- a/app/shell/py/pie/tests/test_flashoffer.py
+++ b/app/shell/py/pie/tests/test_flashoffer.py
@@ -161,6 +161,36 @@ def test_preview_card_preserves_markup_caption():
     assert "<strong>markup</strong>" in html
 
 
+def test_preview_card_allows_custom_overlay_content():
+    html = flashoffer.preview_card(
+        {
+            "image_url": "image.jpg",
+            "alt_text": "Alt",
+            "link_href": "link",
+            "caption": "Caption",
+        },
+        overlay_text="Tap <em>gently</em> to reveal",
+        overlay_button_text="Open <strong>preview</strong>",
+    )
+    assert "Tap &lt;em&gt;gently&lt;/em&gt; to reveal" in html
+    assert "Open &lt;strong&gt;preview&lt;/strong&gt;" in html
+
+
+def test_preview_card_preserves_markup_overlay_content():
+    html = flashoffer.preview_card(
+        {
+            "image_url": "image.jpg",
+            "alt_text": "Alt",
+            "link_href": "link",
+            "caption": "Caption",
+        },
+        overlay_text=Markup("Tap to reveal <em>now</em>"),
+        overlay_button_text=Markup("<strong>Reveal</strong>"),
+    )
+    assert "Tap to reveal <em>now</em>" in html
+    assert ">\n            <strong>Reveal</strong>\n" in html
+
+
 @pytest.mark.parametrize("missing_key", ["image_url", "alt_text", "link_href", "caption"])
 def test_preview_card_requires_expected_card_keys(missing_key):
     card = {

--- a/docs/guides/flashoffer-codex-instructions.md
+++ b/docs/guides/flashoffer-codex-instructions.md
@@ -13,9 +13,11 @@ agents know how to render landing page buttons using `pie.flashoffer`.
   Configure the eyebrow, heading, description, and each call-to-action via the
   helper parameters or pass keyword argument dictionaries through to the CTA
   helpers.
-- Use `pie.flashoffer.preview_card(card)` to render the preview card markup.
-  The `card` mapping must include `image_url`, `alt_text`, `link_href`, and
-  `caption` keys.
+- Use `pie.flashoffer.preview_card(card, overlay_text="...",
+  overlay_button_text="...")` to render the preview card markup. The `card`
+  mapping must include `image_url`, `alt_text`, `link_href`, and `caption`
+  keys. Override `overlay_text` and `overlay_button_text` to customise the
+  overlay messaging while keeping HTML escaping intact.
 - Use `pie.flashoffer.footer(...)` to render the Flashoffer footer snippet.
   All visible text segments are configurable through the helper arguments.
 - Pass any additional keyword arguments to append raw HTML attributes (for

--- a/docs/reference/jinja-globals.md
+++ b/docs/reference/jinja-globals.md
@@ -32,9 +32,12 @@ for details on the structure of this metadata.
   render the landing page call-to-action buttons. Both helpers mirror the
   original Jinja macros, support optional `rel`/`target` parameters, and accept
   arbitrary HTML attributes via keyword arguments.
-- `pie.flashoffer.preview_card(card)` – render the Flashoffer preview card.
-  Provide a mapping with `image_url`, `alt_text`, `link_href`, and `caption`
-  entries to populate the image, overlay link, and caption text.
+- `pie.flashoffer.preview_card(card, overlay_text="...",
+  overlay_button_text="...")` – render the Flashoffer preview card. Provide a
+  mapping with `image_url`, `alt_text`, `link_href`, and `caption` entries to
+  populate the image, overlay link, and caption text. Override the overlay
+  keyword arguments to customise the message and button label without giving up
+  HTML escaping.
 - `pie.flashoffer.footer(...)` – render the Flashoffer footer layout. All text
   displayed to users can be customized through keyword arguments while the
   helper continues to escape plain strings safely.

--- a/src/examples/flashoffer.md
+++ b/src/examples/flashoffer.md
@@ -88,6 +88,20 @@ full image behind a tap target.
 } %}
 {{ pie.flashoffer.preview_card(preview) }}
 ```
+
+Pass `overlay_text` or `overlay_button_text` to tailor the message revealed on
+hover or tap. Both parameters escape plain strings while preserving
+`markupsafe.Markup` instances, so you can safely inject trusted HTML when
+needed.
+
+```jinja
+{{ pie.flashoffer.preview_card(
+    preview,
+    overlay_text="Tap to reveal the <em>full pose</em>",
+    overlay_button_text="Open reference",
+) }}
+```
+
 {% set preview = {
     "image_url": "https://seattlefigurestudio.sfo3.cdn.digitaloceanspaces.com/landing/favicon-48x48.png",
     "alt_text": "Seattle Figure Studio Favicon",
@@ -105,8 +119,8 @@ each card carries consistent Flashoffer styling.
 
 The overlay button created by `pie.flashoffer.preview_card` is wired up by the
 base template's JavaScript in `src/templates/template.html.jinja`, so visitors
-must click **View image** before any NSFW content is revealed. No additional
-script is required inside your page.
+must click the configured overlay button before any NSFW content is revealed.
+No additional script is required inside your page.
 
 The reusable partial at
 `src/templates/examples/flashoffer-card-grid.html.jinja` iterates through


### PR DESCRIPTION
## Summary
- allow callers to override the Flashoffer preview card overlay message and button label
- extend preview card unit tests to cover both the defaults and custom overlay content
- document the new customization options in the Flashoffer guides and examples

## Testing
- pytest app/shell/py/pie/tests/test_flashoffer.py


------
https://chatgpt.com/codex/tasks/task_e_68d8437df3bc8321bdfca83d042c85e6