### PR TITLE
Align Flashoffer hero banner background with theme

### DIFF
--- a/app/shell/py/pie/pie/flashoffer.py
+++ b/app/shell/py/pie/pie/flashoffer.py
@@ -172,13 +172,25 @@ def hero_banner(
         **second_outline,
     )
 
+    hero_background_style = (
+        "background: var("
+        "--flashoffer-hero-background, "
+        "radial-gradient(circle at 10% -10%, "
+        "rgba(255, 92, 92, 0.18), transparent 45%), "
+        "radial-gradient(circle at 110% 20%, "
+        "rgba(34, 139, 230, 0.16), transparent 55%), "
+        "var(--press-background, #090b10)"
+        ");"
+    )
+
     return Markup(
         (
             '<section class="section">\n'
             '  <div class="container">\n'
             '    <div class="row justify-content-center">\n'
             '      <div class="col-lg-10">\n'
-            '        <div class="surface p-4 p-md-5 text-center">\n'
+            f'        <div class="surface p-4 p-md-5 text-center" '
+            f'style="{hero_background_style}">\n'
             '          <span class="eyebrow mb-3 d-inline-block">\n'
             f'            {eyebrow_html}\n'
             '          </span>\n'

--- a/app/shell/py/pie/tests/test_flashoffer.py
+++ b/app/shell/py/pie/tests/test_flashoffer.py
@@ -73,6 +73,20 @@ def test_cta_preserves_markup_text():
     )
 
 
+def test_hero_banner_uses_theme_background():
+    html = flashoffer.hero_banner()
+    expected_style = (
+        'style="background: var('
+        "--flashoffer-hero-background, "
+        "radial-gradient(circle at 10% -10%, rgba(255, 92, 92, 0.18), "
+        "transparent 45%), "
+        "radial-gradient(circle at 110% 20%, rgba(34, 139, 230, 0.16), "
+        "transparent 55%), "
+        'var(--press-background, #090b10));"'
+    )
+    assert expected_style in html
+
+
 def test_preview_card_renders_expected_markup():
     html = flashoffer.preview_card(
         {

--- a/docs/guides/flashoffer-codex-instructions.md
+++ b/docs/guides/flashoffer-codex-instructions.md
@@ -53,3 +53,7 @@ To hide a CTA entirely, supply a utility class through the corresponding
 `*_kwargs`, for example `{"extra_classes": "d-none"}`. You can also reorder
 buttons inside the responsive flex container by assigning Bootstrap order
 classes (`order-2`, `order-3`, and so on) via the same dictionaries.
+
+The hero container ships with a gradient background that mirrors the Press
+theme. Override it by setting a custom `--flashoffer-hero-background` value in
+your CSS when a landing page needs different art direction.

--- a/src/examples/flashoffer.md
+++ b/src/examples/flashoffer.md
@@ -132,6 +132,10 @@ renders as:
     second_outline_kwargs=second_outline_kwargs,
 ) }}
 
+The helper applies a gradient background that matches the Press theme. Define a
+`--flashoffer-hero-background` custom property in your stylesheet to supply a
+different background when needed.
+
 ## Preview card
 
 Combine the preview card with CTA helpers when a template needs to hide the


### PR DESCRIPTION
## Summary
- update the Flashoffer hero banner markup to use a gradient background that matches the Press theme and allow overrides via CSS
- add a regression test and documentation guidance covering the new background styling

## Testing
- pytest pie/tests/test_flashoffer.py


------
https://chatgpt.com/codex/tasks/task_e_68d8458b3d1083219805d25a2143622e