### PR TITLE
Add hero banner support to the base template

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -142,6 +142,66 @@ main > nav[aria-label="Page navigation"] {
   margin-bottom: var(--press-space-2xs);
 }
 
+.hero-banner {
+  padding-inline: clamp(
+    var(--press-space-sm),
+    6vw,
+    var(--press-space-2xl)
+  );
+  margin-bottom: var(--press-space-2xl);
+}
+
+.hero-banner .section {
+  padding-block: clamp(
+    var(--press-space-xl),
+    12vh,
+    var(--press-space-2xl)
+  );
+}
+
+.hero-banner .surface {
+  background: radial-gradient(
+      circle at 10% -10%,
+      rgba(255, 92, 92, 0.18),
+      transparent 45%
+    ),
+    radial-gradient(
+      circle at 110% 20%,
+      rgba(34, 139, 230, 0.14),
+      transparent 55%
+    ),
+    rgba(9, 11, 16, 0.86);
+  border-radius: clamp(2rem, 6vw, 3rem);
+  border: 1px solid rgba(248, 249, 250, 0.08);
+  box-shadow: 0 38px 70px rgba(9, 11, 16, 0.5);
+  color: var(--press-foreground);
+}
+
+.hero-banner .eyebrow {
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: rgba(248, 249, 250, 0.66);
+}
+
+.hero-banner .lead {
+  color: var(--press-muted);
+}
+
+.hero-banner .hero-cta .btn {
+  min-width: 11.25rem;
+  box-shadow: 0 12px 30px rgba(9, 11, 16, 0.35);
+  border-radius: 999px;
+}
+
+.hero-banner .hero-cta .btn-outline-light {
+  border-color: rgba(248, 249, 250, 0.35);
+}
+
+.hero-banner + main {
+  margin-top: calc(var(--press-space-2xl) * -0.25);
+}
+
 .hero-header + main {
   margin-top: calc(var(--press-space-2xl) * -0.3);
 }
@@ -276,6 +336,10 @@ pre code {
 @media (max-width: 768px) {
   main {
     padding-inline: var(--press-space-sm);
+  }
+
+  .hero-banner .section {
+    padding-block: var(--press-space-xl);
   }
 
   .hero-header {

--- a/src/examples/flashoffer.yml
+++ b/src/examples/flashoffer.yml
@@ -14,3 +14,22 @@ schema: v1
 html:
   scripts: []
   navbar: false
+hero_banner:
+  eyebrow: Seattle-born figure reference
+  title: Stone Canvas
+  description: >-
+    Build stronger drawings with Stone Canvas reference bundles created by
+    Seattle models and artists. Each pack keeps studies aligned with atelier
+    methods, community collaborations, and clear licensing.
+  primary_cta_text: Explore Stone Canvas
+  primary_cta_href: https://seattlefigurestudio.com/shop/stone-canvas-medusa
+  primary_cta_kwargs:
+    data_tracking_id: hero-primary
+  first_outline_text: Email to collaborate
+  first_outline_href: mailto:brian@seattlefigurestudio.com
+  first_outline_kwargs:
+    data_tracking_id: hero-secondary
+  second_outline_text: Meet Seattle Figure Studio
+  second_outline_href: https://seattlefigurestudio.com/about-us
+  second_outline_kwargs:
+    data_tracking_id: hero-secondary

--- a/src/templates/template.html.jinja
+++ b/src/templates/template.html.jinja
@@ -43,8 +43,64 @@
     </nav>
     {% endif %}
 
+    {% set hero_config = None %}
+    {% if hero_banner is defined and hero_banner %}
+    {% set hero_config = hero_banner %}
+    {% elif html is defined and html.hero_banner is defined and html.hero_banner %}
+    {% set hero_config = html.hero_banner %}
+    {% endif %}
+
+    {% if hero_config
+      and hero_config.primary_cta_text is defined
+      and hero_config.primary_cta_href is defined
+      and hero_config.first_outline_text is defined
+      and hero_config.first_outline_href is defined
+      and hero_config.second_outline_text is defined
+      and hero_config.second_outline_href is defined %}
+    <div class="hero-banner" data-hero-root>
+      {{ pie.flashoffer.hero_banner(
+        eyebrow=(
+          hero_config.eyebrow
+          if hero_config.eyebrow is defined
+          else (doc.author if doc.author else "")
+        ),
+        title=(
+          hero_config.title
+          if hero_config.title is defined
+          else (page_heading if page_heading else doc.title)
+        ),
+        description=(
+          hero_config.description
+          if hero_config.description is defined
+          else (description if description else "")
+        ),
+        primary_cta_text=hero_config.primary_cta_text,
+        primary_cta_href=hero_config.primary_cta_href,
+        primary_cta_kwargs=(
+          hero_config.primary_cta_kwargs
+          if hero_config.primary_cta_kwargs is defined
+          else {}
+        ),
+        first_outline_text=hero_config.first_outline_text,
+        first_outline_href=hero_config.first_outline_href,
+        first_outline_kwargs=(
+          hero_config.first_outline_kwargs
+          if hero_config.first_outline_kwargs is defined
+          else {}
+        ),
+        second_outline_text=hero_config.second_outline_text,
+        second_outline_href=hero_config.second_outline_href,
+        second_outline_kwargs=(
+          hero_config.second_outline_kwargs
+          if hero_config.second_outline_kwargs is defined
+          else {}
+        ),
+      ) }}
+    </div>
+    {% else %}
     <header
       class="hero-header mb-5 text-white border-bottom position-relative bg-black d-flex align-items-center"
+      data-hero-root
     >
       {% if header and header.get("src") %}
       {% set hero_image_styles = [] %}
@@ -78,6 +134,7 @@
         </h1>
       </div>
     </header>
+    {% endif %}
 
     <main class="container mb-5" style="max-width: 65ch">
       {% if doc.breadcrumbs %}
@@ -161,7 +218,7 @@
     {% if show_navbar %}
     <script>
       window.addEventListener("DOMContentLoaded", () => {
-        const hero = document.querySelector(".hero-header");
+        const hero = document.querySelector("[data-hero-root]");
         const titleEl = document.querySelector(".navbar .page-title");
         if (!titleEl) return;
         if (!hero) {


### PR DESCRIPTION
## Summary
- render the Flashoffer hero banner when hero_banner metadata provides CTA details and keep the legacy header as a fallback
- style the new hero banner container and update the navbar intersection observer to track the shared data attribute
- seed the Flashoffer example metadata with hero banner content so the component renders in that page

## Testing
- make build/examples/flashoffer.html *(fails: picasso: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8436333f0832188ec22786020946f