### PR TITLE
Add tests for Flashoffer section header helper

### DIFF
--- a/app/shell/py/pie/pie/flashoffer.py
+++ b/app/shell/py/pie/pie/flashoffer.py
@@ -19,6 +19,7 @@ __all__ = [
     "primary_cta",
     "outline_cta",
     "hero_banner",
+    "section_header",
     "preview_card",
     "footer",
 ]
@@ -283,6 +284,54 @@ def _coerce_optional_html(value: str | Markup | None) -> Markup:
     if value is None:
         return Markup("")
     return _coerce_html(value)
+
+
+def section_header(
+    *,
+    eyebrow: str | Markup | None = None,
+    title: str | Markup | None = None,
+    body_html: str | Markup | None = None,
+) -> Markup:
+    """Render a centered section header."""
+
+    eyebrow_block = ""
+    if eyebrow is not None:
+        eyebrow_html = _coerce_html(eyebrow)
+        eyebrow_block = (
+            '    <span class="eyebrow mb-3 d-inline-block text-white-50">\n'
+            f"      {eyebrow_html}\n"
+            "    </span>\n"
+        )
+
+    title_block = ""
+    if title is not None:
+        title_html = _coerce_html(title)
+        title_block = (
+            '    <h2 class="fw-semibold mb-3">\n'
+            f"      {title_html}\n"
+            "    </h2>\n"
+        )
+
+    body_block = ""
+    if body_html is not None:
+        body_markup = _coerce_html(body_html)
+        body_block = (
+            '    <p class="mb-0 text-white-50">\n'
+            f"      {body_markup}\n"
+            "    </p>\n"
+        )
+
+    return Markup(
+        (
+            '<div class="row justify-content-center mb-5 text-center">\n'
+            '  <div class="col-lg-8">\n'
+            f"{eyebrow_block}"
+            f"{title_block}"
+            f"{body_block}"
+            "  </div>\n"
+            "</div>"
+        )
+    )
 
 
 def footer(

--- a/app/shell/py/pie/tests/test_flashoffer.py
+++ b/app/shell/py/pie/tests/test_flashoffer.py
@@ -218,6 +218,42 @@ def test_preview_card_requires_expected_card_keys(missing_key):
         flashoffer.preview_card(card)
 
 
+def test_section_header_renders_all_fields_and_escapes_strings():
+    html = flashoffer.section_header(
+        eyebrow="Studio <mark>news</mark>",
+        title="Fresh & inspiring",
+        body_html="Browse <strong>stories</strong>",
+    )
+    assert html == Markup(
+        '<div class="row justify-content-center mb-5 text-center">\n'
+        '  <div class="col-lg-8">\n'
+        '    <span class="eyebrow mb-3 d-inline-block text-white-50">\n'
+        '      Studio &lt;mark&gt;news&lt;/mark&gt;\n'
+        "    </span>\n"
+        '    <h2 class="fw-semibold mb-3">\n'
+        '      Fresh &amp; inspiring\n'
+        "    </h2>\n"
+        '    <p class="mb-0 text-white-50">\n'
+        '      Browse &lt;strong&gt;stories&lt;/strong&gt;\n'
+        "    </p>\n"
+        "  </div>\n"
+        "</div>"
+    )
+
+
+def test_section_header_omits_missing_parts_and_preserves_markup():
+    html = flashoffer.section_header(title=Markup("Featured <em>Sessions</em>"))
+    assert html == Markup(
+        '<div class="row justify-content-center mb-5 text-center">\n'
+        '  <div class="col-lg-8">\n'
+        '    <h2 class="fw-semibold mb-3">\n'
+        '      Featured <em>Sessions</em>\n'
+        "    </h2>\n"
+        "  </div>\n"
+        "</div>"
+    )
+
+
 def test_footer_renders_expected_markup():
     html = flashoffer.footer()
     assert html == Markup(

--- a/docs/guides/flashoffer-codex-instructions.md
+++ b/docs/guides/flashoffer-codex-instructions.md
@@ -13,6 +13,9 @@ agents know how to render landing page buttons using `pie.flashoffer`.
   Configure the eyebrow, heading, description, and each call-to-action via the
   helper parameters or pass keyword argument dictionaries through to the CTA
   helpers.
+- Use `pie.flashoffer.section_header(eyebrow=None, title=None, body_html=None)`
+  to render centered section headers. Each argument may be omitted, plain text,
+  or trusted `Markup` when inline HTML is required.
 - Use `pie.flashoffer.preview_card(card, overlay_text="...",
   overlay_button_text="...")` to render the preview card markup. The `card`
   mapping must include `image_url`, `alt_text`, `link_href`, and `caption`
@@ -57,3 +60,13 @@ classes (`order-2`, `order-3`, and so on) via the same dictionaries.
 The hero container ships with a gradient background that mirrors the Press
 theme. Override it by setting a custom `--flashoffer-hero-background` value in
 your CSS when a landing page needs different art direction.
+
+## Section header parameters
+
+`pie.flashoffer.section_header` renders a centered heading stack that mirrors
+the Jinja macro used in Flashoffer templates. Supply any combination of
+`eyebrow`, `title`, and `body_html` values to control which elements are shown.
+When you pass plain strings they are escaped automatically; wrap inline HTML in
+`markupsafe.Markup` to opt into trusted markup. The helper keeps the same
+spacing, text alignment, and color treatments as the original macro so it can
+drop into landing sections without extra CSS overrides.


### PR DESCRIPTION
## Summary
- add unit coverage for the Flashoffer section_header helper, including escaping and optional segments

## Testing
- pytest app/shell/py/pie/tests/test_flashoffer.py

------
https://chatgpt.com/codex/tasks/task_e_68d89f741f408321b8c9ce5546042bb7