### PR TITLE
Build Flashoffer Bootstrap bundle from downloaded sources

### DIFF
--- a/makefile
+++ b/makefile
@@ -66,8 +66,13 @@ HTMLS := $(patsubst $(SRC_DIR)/%.md, $(BUILD_DIR)/%.html, $(MARKDOWNS))
 # Sort and define build subdirectories based on HTML files
 BUILD_SUBDIRS := $(sort $(dir $(HTMLS))) $(LOG_DIR) $(BUILD_DIR)/static $(BUILD_DIR)/css
 
-CSS_SRC := $(wildcard $(SRC_DIR)/css/*.css)
-CSS := $(patsubst $(SRC_DIR)/css/%.css,$(BUILD_DIR)/css/%.css, $(CSS_SRC))
+CSS_SRC := $(shell find $(SRC_DIR)/css -name '*.css' | sort)
+CSS := $(patsubst $(SRC_DIR)/css/%, $(BUILD_DIR)/css/%, $(CSS_SRC))
+
+BOOTSTRAP_VERSION := 5.3.8
+BOOTSTRAP_TARBALL := https://github.com/twbs/bootstrap/archive/refs/tags/v$(BOOTSTRAP_VERSION).tar.gz
+BOOTSTRAP_SRC_DIR := $(BUILD_DIR)/bootstrap-$(BOOTSTRAP_VERSION)
+BOOTSTRAP_MARKER := $(BOOTSTRAP_SRC_DIR)/.extracted
 
 # Nginx permalink redirect configuration
 PERMALINKS_CONF := $(BUILD_DIR)/permalinks.conf
@@ -142,9 +147,26 @@ $(BUILD_SUBDIRS):
 	$(call status,Create directory $@)
 	$(Q)mkdir -p $@
 
+# Download Bootstrap sources for the Flashoffer bundle on demand
+$(BOOTSTRAP_MARKER):
+	$(call status,Download Bootstrap v$(BOOTSTRAP_VERSION))
+	$(Q)rm -rf $(BOOTSTRAP_SRC_DIR)
+	$(Q)mkdir -p $(BUILD_DIR)
+	$(Q)curl -sSL $(BOOTSTRAP_TARBALL) | tar -xz -C $(BUILD_DIR)
+	$(Q)touch $@
+
+FLASHOFFER_BOOTSTRAP_SRC := $(SRC_DIR)/css/flashoffer/flashoffer-bootstrap.css
+FLASHOFFER_BOOTSTRAP_BUILD := $(BUILD_DIR)/css/flashoffer/flashoffer-bootstrap.css
+
+$(FLASHOFFER_BOOTSTRAP_BUILD): $(FLASHOFFER_BOOTSTRAP_SRC) $(BOOTSTRAP_MARKER)
+	$(call status,Compile Flashoffer Bootstrap bundle)
+	$(Q)mkdir -p $(dir $@)
+	$(Q)pysassc --style compressed -I $(BOOTSTRAP_SRC_DIR)/scss $< $@
+
 # Compile SCSS files to the build directory
 $(BUILD_DIR)/css/%.css: $(SRC_DIR)/css/%.css | $(BUILD_DIR)/css
 	$(call status,Compile SCSS $<)
+	$(Q)mkdir -p $(dir $@)
 	$(Q)pysassc $< $@
 
 # Include and preprocess Markdown files up to three levels deep

--- a/src/css/flashoffer/README.md
+++ b/src/css/flashoffer/README.md
@@ -1,0 +1,11 @@
+# Flashoffer Bootstrap bundle
+
+The Flashoffer Bootstrap build is compiled from Bootstrap v5.3.8 sources. The
+Makefile downloads and extracts the release tarball on demand during the
+Sass compile so we do not vendor upstream assets.
+
+To rebuild the stylesheet locally run:
+
+```
+make build/css/flashoffer/flashoffer-bootstrap.css
+```

--- a/src/css/flashoffer/flashoffer-bootstrap.css
+++ b/src/css/flashoffer/flashoffer-bootstrap.css
@@ -1,0 +1,47 @@
+/*!
+ * Flashoffer-specific Bootstrap bundle.
+ *
+ * Builds a trimmed Bootstrap v5.3.8 subset that matches the Flashoffer
+ * palette and typography. The Sass compiler resolves imports against a
+ * downloaded Bootstrap source tree so this bundle can be rebuilt without
+ * committing upstream assets.
+ */
+
+@import "functions";
+
+$font-family-sans-serif: system-ui, -apple-system, BlinkMacSystemFont,
+  "Segoe UI", sans-serif;
+$font-family-base: $font-family-sans-serif;
+$font-size-root: 1.05rem;
+$font-size-base: 1.1025rem;
+$body-font-size: $font-size-base;
+$line-height-base: 1.65;
+$btn-font-weight: 600;
+$display-font-weight: 600;
+$headings-font-weight: 600;
+$headings-line-height: 1.25;
+$body-bg: #090b10;
+$body-color: #f8f9fa;
+$body-secondary-color: #ced4da;
+$link-color: #ff5c5c;
+$link-hover-color: #e14242;
+$primary: #ff5c5c;
+$primary-text: #090b10;
+$light: #f8f9fa;
+$dark: #090b10;
+$enable-negative-margins: false;
+
+@import "variables";
+@import "maps";
+@import "mixins";
+@import "utilities";
+
+@import "root";
+@import "reboot";
+@import "type";
+@import "containers";
+@import "grid";
+@import "buttons";
+@import "card";
+@import "helpers";
+@import "utilities/api";

--- a/src/examples/flashoffer.yml
+++ b/src/examples/flashoffer.yml
@@ -9,6 +9,9 @@ doc:
   citation: flashoffer
   pubdate: Sep 27, 2025
   title: Flashoffer CTA Helpers
+css:
+- /css/style.css
+- /css/flashoffer-bootstrap.css
 id: flashoffer
 schema: v1
 html:


### PR DESCRIPTION
## Summary
- remove the vendored Bootstrap sources and fetch v5.3.8 on demand during the build
- compile the Flashoffer Sass bundle against the downloaded tree and emit a compressed stylesheet
- document the bundle and ensure nested CSS targets generate their directories before compilation

## Testing
- make build/css/flashoffer/flashoffer-bootstrap.css *(fails: picasso not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8b478e17c8321a33a35667cf8cc5b