### PR TITLE
Expose Flashoffer CSS variables for layout customization

### DIFF
--- a/app/shell/py/pie/pie/flashoffer.py
+++ b/app/shell/py/pie/pie/flashoffer.py
@@ -154,6 +154,9 @@ def hero_banner(
     second_outline_text: str | Markup = "Meet Seattle Figure Studio",
     second_outline_href: str = "https://seattlefigurestudio.com/about-us",
     second_outline_kwargs: Mapping[str, Any] | None = None,
+    hero_image_url: str | None = None,
+    hero_image_alt: str | Markup | None = None,
+    hero_image_kwargs: Mapping[str, Any] | None = None,
 ) -> Markup:
     """Render the Flashoffer hero banner with configurable CTAs."""
 
@@ -212,6 +215,42 @@ def hero_banner(
         )
     )
     description_paragraph.add(raw(str(description_html)))
+
+    if hero_image_url is not None:
+        image_wrapper = surface.add(
+            tags.div(_class="hero-visual-wrapper mx-auto mb-4")
+        )
+        image_attrs = _coerce_mapping(hero_image_kwargs)
+        image_classes = "hero-visual img-fluid"
+        extra_classes = image_attrs.pop("class", "")
+        if extra_classes:
+            image_classes = f"{image_classes} {extra_classes}"
+        extra_classes = image_attrs.pop("extra_classes", "")
+        if extra_classes:
+            image_classes = f"{image_classes} {extra_classes}"
+
+        hero_image_alt_value = "" if hero_image_alt is None else hero_image_alt
+
+        sanitized_attrs: dict[str, str] = {
+            "src": _escape_attr_value(hero_image_url),
+            "alt": _escape_attr_value(hero_image_alt_value),
+        }
+
+        loading_value = image_attrs.pop("loading", "lazy")
+        if loading_value is not None:
+            sanitized_attrs["loading"] = _escape_attr_value(loading_value)
+
+        for name, value in image_attrs.items():
+            if value is None:
+                continue
+            sanitized_attrs[name] = _escape_attr_value(value)
+
+        image_wrapper.add(
+            tags.img(
+                _class=image_classes,
+                **sanitized_attrs,
+            )
+        )
 
     cta_container = surface.add(
         tags.div(_class="hero-cta d-grid gap-3 d-sm-flex justify-content-center")

--- a/app/shell/py/pie/tests/test_flashoffer.py
+++ b/app/shell/py/pie/tests/test_flashoffer.py
@@ -87,6 +87,24 @@ def test_hero_banner_uses_theme_background():
     assert expected_style in html
 
 
+def test_hero_banner_supports_optional_image():
+    html = flashoffer.hero_banner(
+        hero_image_url="https://cdn.example.com/hero.png",
+        hero_image_alt='Hero "quote"',
+        hero_image_kwargs={
+            "data_tracking_id": "hero-visual",
+            "extra_classes": "rounded-5",
+            "loading": "eager",
+        },
+    )
+    assert '<div class="hero-visual-wrapper mx-auto mb-4">' in html
+    assert 'class="hero-visual img-fluid rounded-5"' in html
+    assert 'src="https://cdn.example.com/hero.png"' in html
+    assert 'alt="Hero &quot;quote&quot;"' in html
+    assert 'data_tracking_id="hero-visual"' in html
+    assert 'loading="eager"' in html
+
+
 def test_preview_card_renders_expected_markup():
     html = flashoffer.preview_card(
         {

--- a/docs/guides/flashoffer-codex-instructions.md
+++ b/docs/guides/flashoffer-codex-instructions.md
@@ -54,6 +54,10 @@ supporting copy, and up to three CTAs. The helper accepts:
   are passed straight into `pie.flashoffer.outline_cta`, so you can add
   tracking attributes or reuse the same label overrides that appear alongside
   the [preview card helper](../../src/examples/flashoffer.md#preview-card).
+- `hero_image_url`, `hero_image_alt`, and `hero_image_kwargs` – optionally add a
+  focal image below the body copy. Provide `hero_image_alt` for accessibility
+  text and leverage `hero_image_kwargs` to append custom HTML attributes or
+  override defaults such as the loading behaviour.
 
 To hide a CTA entirely, supply a utility class through the corresponding
 `*_kwargs`, for example `{"extra_classes": "d-none"}`. You can also reorder
@@ -62,7 +66,12 @@ classes (`order-2`, `order-3`, and so on) via the same dictionaries.
 
 The hero container ships with a gradient background that mirrors the Press
 theme. Override it by setting a custom `--flashoffer-hero-background` value in
-your CSS when a landing page needs different art direction.
+your CSS when a landing page needs different art direction. You can also tweak
+the default layout and color treatments by redefining the Flashoffer CSS custom
+properties exposed in `src/css/style.css`. Variables such as
+`--flashoffer-hero-padding-block`, `--flashoffer-hero-visual-shadow`, and
+`--flashoffer-preview-overlay-background` provide override points without
+requiring manual selector overrides.
 
 ## Section header parameters
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -17,6 +17,34 @@
   --press-space-lg: 1.75rem;
   --press-space-xl: 2.5rem;
   --press-space-2xl: clamp(2.75rem, 6vw, 4.25rem);
+  --flashoffer-hero-min-height: 32vh;
+  --flashoffer-hero-padding-block: clamp(
+    var(--press-space-xl),
+    12vh,
+    var(--press-space-2xl)
+  );
+  --flashoffer-hero-padding-inline: clamp(
+    var(--press-space-sm),
+    8vw,
+    var(--press-space-2xl)
+  );
+  --flashoffer-hero-border-color: rgba(248, 249, 250, 0.08);
+  --flashoffer-hero-visual-max-width: min(100%, 28rem);
+  --flashoffer-hero-visual-radius: 1.5rem;
+  --flashoffer-hero-visual-shadow: 0 24px 60px rgba(9, 11, 16, 0.45);
+  --flashoffer-preview-card-min-height: 240px;
+  --flashoffer-preview-card-background: #000;
+  --flashoffer-preview-card-radius: 1.5rem;
+  --flashoffer-preview-card-shadow: 0 24px 60px rgba(9, 11, 16, 0.45);
+  --flashoffer-preview-overlay-background: linear-gradient(
+    180deg,
+    rgba(9, 11, 16, 0.92),
+    rgba(9, 11, 16, 0.88)
+  );
+  --flashoffer-preview-overlay-color: var(--press-foreground);
+  --flashoffer-preview-overlay-padding: var(--press-space-lg);
+  --flashoffer-preview-image-blur: 24px;
+  --flashoffer-preview-image-scale: 1.06;
 }
 
 html {
@@ -163,10 +191,34 @@ main > nav[aria-label="Page navigation"] {
 }
 
 .hero-header {
-  min-height: 32vh;
-  padding-block: clamp(var(--press-space-xl), 12vh, var(--press-space-2xl));
-  padding-inline: clamp(var(--press-space-sm), 8vw, var(--press-space-2xl));
-  border-bottom: 1px solid rgba(248, 249, 250, 0.08);
+  min-height: var(--flashoffer-hero-min-height, 32vh);
+  padding-block: var(
+    --flashoffer-hero-padding-block,
+    clamp(var(--press-space-xl), 12vh, var(--press-space-2xl))
+  );
+  padding-inline: var(
+    --flashoffer-hero-padding-inline,
+    clamp(var(--press-space-sm), 8vw, var(--press-space-2xl))
+  );
+  border-bottom: 1px solid var(
+    --flashoffer-hero-border-color,
+    rgba(248, 249, 250, 0.08)
+  );
+}
+
+.hero-visual-wrapper {
+  max-width: var(
+    --flashoffer-hero-visual-max-width,
+    min(100%, 28rem)
+  );
+}
+
+.hero-visual {
+  border-radius: var(--flashoffer-hero-visual-radius, 1.5rem);
+  box-shadow: var(
+    --flashoffer-hero-visual-shadow,
+    0 24px 60px rgba(9, 11, 16, 0.45)
+  );
 }
 
 .bg-image {
@@ -195,38 +247,47 @@ main > nav[aria-label="Page navigation"] {
 
 .preview-card {
   position: relative;
-  min-height: 240px;
-  background-color: #000;
-  border-radius: 1.5rem;
+  min-height: var(--flashoffer-preview-card-min-height, 240px);
+  background-color: var(--flashoffer-preview-card-background, #000);
+  border-radius: var(--flashoffer-preview-card-radius, 1.5rem);
   overflow: hidden;
-  box-shadow: 0 24px 60px rgba(9, 11, 16, 0.45);
+  box-shadow: var(
+    --flashoffer-preview-card-shadow,
+    0 24px 60px rgba(9, 11, 16, 0.45)
+  );
 }
 
 .preview-image {
-  filter: blur(24px);
-  transform: scale(1.06);
+  filter: blur(var(--flashoffer-preview-image-blur, 24px));
+  transform: scale(var(--flashoffer-preview-image-scale, 1.06));
   transition: filter 0.4s ease, transform 0.4s ease;
 }
 
 .preview-overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(
-    180deg,
-    rgba(9, 11, 16, 0.92),
-    rgba(9, 11, 16, 0.88)
+  background: var(
+    --flashoffer-preview-overlay-background,
+    linear-gradient(
+      180deg,
+      rgba(9, 11, 16, 0.92),
+      rgba(9, 11, 16, 0.88)
+    )
   );
-  color: var(--press-foreground);
+  color: var(--flashoffer-preview-overlay-color, var(--press-foreground));
   display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
   transition: opacity 0.35s ease;
-  padding: var(--press-space-lg);
+  padding: var(
+    --flashoffer-preview-overlay-padding,
+    var(--press-space-lg)
+  );
 }
 
 .preview-overlay p {
-  color: var(--press-foreground);
+  color: var(--flashoffer-preview-overlay-color, var(--press-foreground));
 }
 
 .preview-card.revealed .preview-image {

--- a/src/examples/flashoffer.md
+++ b/src/examples/flashoffer.md
@@ -84,6 +84,11 @@ first outline CTA to `#preview-card` keeps the hero aligned with the
 [Preview card](#preview-card) gallery, while the second outline CTA can mirror
 compliance language documented in the [Footer](#footer).
 
+Add a focal image to the hero by supplying `hero_image_url`. Pass
+`hero_image_alt` to meet accessibility requirements and reuse
+`hero_image_kwargs` for additional HTML attributes such as data tracking IDs or
+`loading="eager"`.
+
 ```jinja
 {% set primary_kwargs = {
     "extra_classes": "shadow-lg",
@@ -111,6 +116,9 @@ compliance language documented in the [Footer](#footer).
     second_outline_text="Read studio policies",
     second_outline_href="/policies",
     second_outline_kwargs=second_outline_kwargs,
+    hero_image_url="https://cdn.example.com/hero-visual.jpg",
+    hero_image_alt="Stone Canvas hero artwork",
+    hero_image_kwargs={"data_tracking_id": "hero-visual"},
 ) }}
 ```
 
@@ -134,7 +142,10 @@ renders as:
 
 The helper applies a gradient background that matches the Press theme. Define a
 `--flashoffer-hero-background` custom property in your stylesheet to supply a
-different background when needed.
+different background when needed. Additional Flashoffer variables such as
+`--flashoffer-hero-padding-block`, `--flashoffer-hero-visual-radius`, and
+`--flashoffer-preview-overlay-background` let you adjust layout spacing,
+shadows, and overlay treatments without writing new selectors.
 
 ## Preview card
 


### PR DESCRIPTION
## Summary
- add Flashoffer-specific CSS custom properties so teams can override hero and preview styling without editing selectors
- document the new override points in the Flashoffer Codex guide and example walkthrough

## Testing
- pytest *(fails: missing analytics_backend, dominate, fakeredis, ruamel dependencies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8c16325188321b56dac2246d73650