### PR TITLE
Clarify pre block formatting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 - Wrap **paragraph text** at 80 characters.
   (Code, tables, and lists are exempt.)
+- Within `<pre>` blocks:
+  - Use two spaces for indentation.
+  - Prefer breaking lines at 80 characters on word boundaries.
+  - If no suitable word boundary exists, leave the line unbroken.
 - Metadata:
   - `description`: plain text only
   - `id`: use `_` instead of `-` when modifying


### PR DESCRIPTION
## Summary
- restore the original paragraph wrapping description in AGENTS.md
- scope the two-space indentation and 80-character word-boundary wrapping rules to `<pre>` blocks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9847d2f5c832190c449c796a51d5c