### PR TITLE
Align Flashoffer defaults across Python, docs, and React surfaces

### DIFF
--- a/app/flashoffer-demo/src/App.test.tsx
+++ b/app/flashoffer-demo/src/App.test.tsx
@@ -9,11 +9,11 @@ describe("Flashoffer demo", () => {
     expect(
       screen.getByRole("heading", {
         level: 1,
-        name: /flashoffer pages/i
+        name: /coordinated offers/i
       })
     ).toBeInTheDocument();
     expect(
-      screen.getAllByRole("link", { name: /view component source/i }).length
+      screen.getAllByRole("link", { name: /explore flashoffer components/i }).length
     ).toBeGreaterThan(0);
   });
 
@@ -27,7 +27,7 @@ describe("Flashoffer demo", () => {
       })
     ).toBeInTheDocument();
     expect(
-      screen.getAllByRole("link", { name: /start a sandbox/i }).length
+      screen.getAllByRole("link", { name: /explore flashoffer components/i }).length
     ).toBeGreaterThan(0);
     expect(screen.getAllByRole("article")).toHaveLength(3);
   });

--- a/app/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer-demo/src/App.tsx
@@ -97,9 +97,9 @@ const previewCards = [
 ];
 
 const footerLinks = [
-  { label: "Component docs", href: "https://example.com/docs" },
-  { label: "Brand assets", href: "https://example.com/brand" },
-  { label: "Support", href: "mailto:flashoffer@example.com" }
+  { label: "Docs", href: "https://example.com/docs" },
+  { label: "Status", href: "https://status.example.com" },
+  { label: "Support", href: "mailto:support@example.com" }
 ];
 
 const heroMedia = (
@@ -200,17 +200,17 @@ export default function App() {
 
             <HeroBanner
               align={heroAlignment}
-              title="Launch high-converting Flashoffer pages in minutes."
-              subtitle="Use the ready-made hero, CTA, and showcase blocks to build polished marketing surfaces that reflect your brand."
+              title="Launch coordinated offers in minutes."
+              subtitle="Flashoffer ships reusable hero, CTA, and preview components so teams can publish landing experiments without bespoke design cycles."
               primaryCta={{
-                label: "View component source",
-                href: "https://example.com/component-source",
+                label: "Explore Flashoffer components",
+                href: "https://example.com/flashoffer",
                 target: "_blank",
                 rel: "noreferrer"
               }}
               secondaryCta={{
-                label: "Download spec",
-                href: "https://example.com/spec"
+                label: "Contact support",
+                href: "mailto:support@example.com"
               }}
               media={heroMedia}
             />
@@ -228,11 +228,11 @@ export default function App() {
                 alignItems="center"
                 justifyContent="center"
               >
-                <PrimaryCtaButton href="https://example.com/signup">
-                  Start a sandbox
+                <PrimaryCtaButton href="https://example.com/flashoffer">
+                  Explore Flashoffer components
                 </PrimaryCtaButton>
-                <OutlineCtaButton href="https://example.com/contact">
-                  Talk with our team
+                <OutlineCtaButton href="mailto:support@example.com">
+                  Contact support
                 </OutlineCtaButton>
               </Stack>
             </Box>
@@ -255,7 +255,7 @@ export default function App() {
 
             <Footer
               links={footerLinks}
-              copyrightText="© 2025 Flashoffer demo experience"
+              copyrightText="© 2025 Flashoffer. All rights reserved."
             />
           </Stack>
         </Container>

--- a/app/flashoffer-react/src/__tests__/components.test.tsx
+++ b/app/flashoffer-react/src/__tests__/components.test.tsx
@@ -20,7 +20,7 @@ describe("Flashoffer React primitives", () => {
   it("renders primary CTA with default copy", () => {
     renderWithTheme(<PrimaryCtaButton />);
     expect(
-      screen.getByRole("button", { name: /get started/i })
+      screen.getByRole("button", { name: /explore flashoffer components/i })
     ).toBeInTheDocument();
   });
 
@@ -47,9 +47,15 @@ describe("Flashoffer React primitives", () => {
     if (headingId) {
       const heading = document.getElementById(headingId);
       expect(heading).not.toBeNull();
-      expect(heading).toHaveTextContent(/limited-time offers/i);
+      expect(heading).toHaveTextContent(/coordinated offers/i);
     }
     expect(banner).toHaveAttribute("aria-describedby");
+    expect(
+      screen.getByRole("link", { name: /explore flashoffer components/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /contact support/i })
+    ).toBeInTheDocument();
   });
 
   it("allows hero banner CTA overrides", () => {
@@ -86,7 +92,7 @@ describe("Flashoffer React primitives", () => {
   it("supports Outline CTA default label", () => {
     renderWithTheme(<OutlineCtaButton />);
     expect(
-      screen.getByRole("button", { name: /learn more/i })
+      screen.getByRole("button", { name: /contact support/i })
     ).toBeInTheDocument();
   });
 

--- a/app/flashoffer-react/src/components/Footer.tsx
+++ b/app/flashoffer-react/src/components/Footer.tsx
@@ -19,12 +19,12 @@ export interface FooterProps {
 }
 
 const DEFAULT_LINKS: FooterLink[] = [
-  { label: "Docs", href: "https://presslabs.com/docs" },
-  { label: "Status", href: "https://status.presslabs.com" },
-  { label: "Support", href: "mailto:support@presslabs.com" }
+  { label: "Docs", href: "https://example.com/docs" },
+  { label: "Status", href: "https://status.example.com" },
+  { label: "Support", href: "mailto:support@example.com" }
 ];
 
-const DEFAULT_COPYRIGHT = "© Flashoffer by Presslabs";
+const DEFAULT_COPYRIGHT = "© Flashoffer. All rights reserved.";
 
 /**
  * Footer component that renders navigation links and attribution text.

--- a/app/flashoffer-react/src/components/HeroBanner.tsx
+++ b/app/flashoffer-react/src/components/HeroBanner.tsx
@@ -18,15 +18,15 @@ export interface HeroBannerProps {
   /** Props passed to the primary CTA button. */
   primaryCta?: PrimaryCtaButtonProps;
   /** Props passed to the secondary CTA button. */
-  secondaryCta?: OutlineCtaButtonProps;
+  secondaryCta?: OutlineCtaButtonProps | null;
   /** Aligns content horizontally. */
   align?: "left" | "center";
 }
 
-const DEFAULT_TITLE = "Create limited-time offers that convert.";
+const DEFAULT_TITLE = "Launch coordinated offers in minutes.";
 const DEFAULT_SUBTITLE =
-  "Flashoffer ships with sensible defaults so marketing teams can stand up " +
-  "campaign pages without design bottlenecks.";
+  "Flashoffer ships reusable hero, CTA, and preview components so teams " +
+  "can publish landing experiments without bespoke design cycles.";
 
 /**
  * Promotional hero unit with sensible defaults for copy and layout.
@@ -35,8 +35,14 @@ export function HeroBanner({
   title = DEFAULT_TITLE,
   subtitle = DEFAULT_SUBTITLE,
   media,
-  primaryCta,
-  secondaryCta,
+  primaryCta = {
+    label: "Explore Flashoffer components",
+    href: "https://example.com/flashoffer"
+  },
+  secondaryCta = {
+    label: "Contact support",
+    href: "mailto:support@example.com"
+  },
   align = "center"
 }: HeroBannerProps) {
   const headingId = useId();

--- a/app/flashoffer-react/src/components/OutlineCtaButton.tsx
+++ b/app/flashoffer-react/src/components/OutlineCtaButton.tsx
@@ -15,7 +15,7 @@ export interface OutlineCtaButtonProps
  * Secondary call-to-action button that defaults to an outlined style.
  */
 export function OutlineCtaButton({
-  label = "Learn more",
+  label = "Contact support",
   children,
   ...props
 }: OutlineCtaButtonProps) {

--- a/app/flashoffer-react/src/components/PrimaryCtaButton.tsx
+++ b/app/flashoffer-react/src/components/PrimaryCtaButton.tsx
@@ -15,7 +15,7 @@ export interface PrimaryCtaButtonProps
  * Primary call-to-action button styled with the Flashoffer theme.
  */
 export function PrimaryCtaButton({
-  label = "Get started",
+  label = "Explore Flashoffer components",
   children,
   ...props
 }: PrimaryCtaButtonProps) {

--- a/app/shell/py/pie/pie/flashoffer.py
+++ b/app/shell/py/pie/pie/flashoffer.py
@@ -138,21 +138,20 @@ def _coerce_mapping(mapping: Mapping[str, Any] | None) -> dict[str, Any]:
 
 def hero_banner(
     *,
-    eyebrow: str | Markup = "Seattle-born figure reference",
-    title: str | Markup = "Stone Canvas",
+    eyebrow: str | Markup = "Campaign toolkit",
+    title: str | Markup = "Launch coordinated offers in minutes",
     description: str | Markup = (
-        "Build stronger drawings with Stone Canvas reference bundles created by "
-        "Seattle models and artists. Each pack keeps studies aligned with atelier "
-        "methods, community collaborations, and clear licensing."
+        "Flashoffer ships reusable hero, CTA, and preview components so teams "
+        "can publish landing experiments without bespoke design cycles."
     ),
-    primary_cta_text: str | Markup = "Explore Stone Canvas",
-    primary_cta_href: str = "https://seattlefigurestudio.com/shop/stone-canvas-medusa",
+    primary_cta_text: str | Markup = "Explore Flashoffer components",
+    primary_cta_href: str = "https://example.com/flashoffer",
     primary_cta_kwargs: Mapping[str, Any] | None = None,
-    first_outline_text: str | Markup = "Email to collaborate",
-    first_outline_href: str = "mailto:brian@seattlefigurestudio.com",
+    first_outline_text: str | Markup = "Contact support",
+    first_outline_href: str = "mailto:support@example.com",
     first_outline_kwargs: Mapping[str, Any] | None = None,
-    second_outline_text: str | Markup = "Meet Seattle Figure Studio",
-    second_outline_href: str = "https://seattlefigurestudio.com/about-us",
+    second_outline_text: str | Markup = "View documentation",
+    second_outline_href: str = "https://example.com/docs",
     second_outline_kwargs: Mapping[str, Any] | None = None,
     hero_image_url: str | None = None,
     hero_image_alt: str | Markup | None = None,
@@ -284,7 +283,7 @@ def _coerce_html(value: Any) -> Markup:
 def preview_card(
     card: Mapping[str, Any],
     *,
-    overlay_text: str | Markup = "Tap to reveal this artistic nude pose.",
+    overlay_text: str | Markup = "Tap to preview this image.",
     overlay_button_text: str | Markup = "View image",
 ) -> Markup:
     """Render the Flashoffer preview card partial."""
@@ -379,11 +378,11 @@ def footer(
     *,
     container_id: str = "contact",
     left_prefix: str | Markup | None = Markup("©&nbsp;"),
-    site_name: str | Markup = "Seattle Figure Studio",
-    site_href: str = "https://seattlefigurestudio.com",
+    site_name: str | Markup = "Flashoffer",
+    site_href: str = "https://example.com/flashoffer",
     rights_statement: str | Markup = "All rights reserved.",
-    email_label: str | Markup = "brian@seattlefigurestudio.com",
-    email_href: str = "mailto:brian@seattlefigurestudio.com",
+    email_label: str | Markup = "support@example.com",
+    email_href: str = "mailto:support@example.com",
 ) -> Markup:
     """Render the Flashoffer footer snippet."""
 

--- a/app/shell/py/pie/tests/test_flashoffer.py
+++ b/app/shell/py/pie/tests/test_flashoffer.py
@@ -101,7 +101,7 @@ def test_hero_banner_supports_optional_image():
     assert 'class="hero-visual img-fluid rounded-5"' in html
     assert 'src="https://cdn.example.com/hero.png"' in html
     assert 'alt="Hero &quot;quote&quot;"' in html
-    assert 'data_tracking_id="hero-visual"' in html
+    assert 'data-tracking-id="hero-visual"' in html
     assert 'loading="eager"' in html
 
 
@@ -123,7 +123,7 @@ def test_preview_card_renders_expected_markup():
                   <img alt="Hero image" class="img-fluid w-100 h-auto preview-image" loading="lazy" src="https://cdn.example.com/image.jpg">
                   <div class="preview-overlay">
                     <div class="text-center px-3">
-                      <p class="mb-2 fw-semibold">Tap to reveal this artistic nude pose.</p>
+                      <p class="mb-2 fw-semibold">Tap to preview this image.</p>
                       <a class="btn btn-outline-light btn-sm preview-toggle" href="https://example.com/gallery" role="button">View image</a>
                     </div>
                   </div>
@@ -156,7 +156,7 @@ def test_preview_card_escapes_attribute_values_and_caption_text():
                   <img alt="Alt &quot;quote&quot;" class="img-fluid w-100 h-auto preview-image" loading="lazy" src="/img?tag=&quot;x&quot;">
                   <div class="preview-overlay">
                     <div class="text-center px-3">
-                      <p class="mb-2 fw-semibold">Tap to reveal this artistic nude pose.</p>
+                      <p class="mb-2 fw-semibold">Tap to preview this image.</p>
                       <a class="btn btn-outline-light btn-sm preview-toggle" href="/preview?ref=&quot;full&quot;" role="button">View image</a>
                     </div>
                   </div>
@@ -273,10 +273,10 @@ def test_footer_renders_expected_markup():
             <footer class="container py-4 small" id="contact">
               <div class="row gy-3 align-items-center">
                 <div class="col-12 col-md">©&nbsp;
-                  <a class="link-dark text-decoration-none" href="https://seattlefigurestudio.com">Seattle Figure Studio</a>. All rights reserved.
+                  <a class="link text-decoration-none" href="https://example.com/flashoffer">Flashoffer</a>. All rights reserved.
                 </div>
                 <div class="col-12 col-md-auto">
-                  <a class="fw-semibold" href="mailto:brian@seattlefigurestudio.com">brian@seattlefigurestudio.com</a>
+                  <a class="fw-semibold" href="mailto:support@example.com">support@example.com</a>
                 </div>
               </div>
             </footer>

--- a/docs/guides/flashoffer-codex-instructions.md
+++ b/docs/guides/flashoffer-codex-instructions.md
@@ -20,9 +20,12 @@ agents know how to render landing page buttons using `pie.flashoffer`.
   overlay_button_text="...")` to render the preview card markup. The `card`
   mapping must include `image_url`, `alt_text`, `link_href`, and `caption`
   keys. Override `overlay_text` and `overlay_button_text` to customise the
-  overlay messaging while keeping HTML escaping intact.
+  overlay messaging while keeping HTML escaping intact. The defaults prompt
+  visitors with "Tap to preview this image." and "View image".
 - Use `pie.flashoffer.footer(...)` to render the Flashoffer footer snippet.
-  All visible text segments are configurable through the helper arguments.
+  All visible text segments are configurable through the helper arguments. The
+  defaults render "Flashoffer" linked to `https://example.com/flashoffer` and
+  the contact address `support@example.com`.
 - Pass any additional keyword arguments to append raw HTML attributes (for
   example, `data_tracking_id="hero"`).
 - Provide `rel` and `target` explicitly when linking to external destinations.
@@ -47,13 +50,15 @@ supporting copy, and up to three CTAs. The helper accepts:
   or override button attributes with `primary_cta_kwargs`, which forwards keys
   like `extra_classes`, `rel`, and `target` to
   [`pie.flashoffer.primary_cta`](../../src/examples/flashoffer.md#primary-cta).
-  Link labels should align with the footer language described in the
-  [Flashoffer footer](../../src/examples/flashoffer.md#footer) guidance.
+  The defaults link to `https://example.com/flashoffer` with the label
+  "Explore Flashoffer components" so documentation mirrors demo copy.
 - `first_outline_text`/`href` and `second_outline_text`/`href` – populate the
   outline CTAs. Each CTA also accepts a `*_kwargs` mapping. These dictionaries
   are passed straight into `pie.flashoffer.outline_cta`, so you can add
   tracking attributes or reuse the same label overrides that appear alongside
   the [preview card helper](../../src/examples/flashoffer.md#preview-card).
+  Default copy references "Contact support" and "View documentation" to keep
+  the hero aligned with footer contact details.
 - `hero_image_url`, `hero_image_alt`, and `hero_image_kwargs` – optionally add a
   focal image below the body copy. Provide `hero_image_alt` for accessibility
   text and leverage `hero_image_kwargs` to append custom HTML attributes or

--- a/src/examples/flashoffer/hero-banner.md
+++ b/src/examples/flashoffer/hero-banner.md
@@ -28,21 +28,21 @@ Add a focal image to the hero by supplying `hero_image_url`. Pass
     "data_tracking_id": "hero-compliance",
 } %}
 {{ pie.flashoffer.hero_banner(
-    eyebrow="Limited-run bundles",
-    title="Stone Canvas: Medusa release",
-    description="Pair live session studies with downloadable references tuned "
-    "for the Stone Canvas Medusa campaign.",
-    primary_cta_text="Start your free trial",
-    primary_cta_href="/signup",
+    eyebrow="CAMPAIGN TOOLKIT",
+    title="Launch coordinated offers in minutes.",
+    description="Flashoffer ships reusable hero, CTA, and preview components "
+    "so teams can publish landing experiments without bespoke design cycles.",
+    primary_cta_text="Explore Flashoffer components",
+    primary_cta_href="https://example.com/flashoffer",
     primary_cta_kwargs=primary_kwargs,
-    first_outline_text="See preview gallery",
-    first_outline_href="#preview-card",
+    first_outline_text="Contact support",
+    first_outline_href="mailto:support@example.com",
     first_outline_kwargs=first_outline_kwargs,
-    second_outline_text="Read studio policies",
-    second_outline_href="/policies",
+    second_outline_text="View documentation",
+    second_outline_href="https://example.com/docs",
     second_outline_kwargs=second_outline_kwargs,
-    hero_image_url="https://seattlefigurestudio.sfo3.cdn.digitaloceanspaces.com/landing/favicon-48x48.png",
-    hero_image_alt="Stone Canvas hero artwork",
+    hero_image_url="https://picsum.photos/seed/flashoffer-hero/720/480",
+    hero_image_alt="Mock dashboard showcasing offer performance",
     hero_image_kwargs={"data_tracking_id": "hero-visual"},
 ) }}
 {% endraw %}
@@ -63,21 +63,21 @@ renders as:
     "data_tracking_id": "hero-compliance",
 } %}
 {{ pie.flashoffer.hero_banner(
-    eyebrow="Limited-run bundles",
-    title="Stone Canvas: Medusa release",
-    description="Pair live session studies with downloadable references tuned "
-    "for the Stone Canvas Medusa campaign.",
-    primary_cta_text="Start your free trial",
-    primary_cta_href="/signup",
+    eyebrow="CAMPAIGN TOOLKIT",
+    title="Launch coordinated offers in minutes.",
+    description="Flashoffer ships reusable hero, CTA, and preview components "
+    "so teams can publish landing experiments without bespoke design cycles.",
+    primary_cta_text="Explore Flashoffer components",
+    primary_cta_href="https://example.com/flashoffer",
     primary_cta_kwargs=primary_kwargs,
-    first_outline_text="See preview gallery",
-    first_outline_href="#preview-card",
+    first_outline_text="Contact support",
+    first_outline_href="mailto:support@example.com",
     first_outline_kwargs=first_outline_kwargs,
-    second_outline_text="Read studio policies",
-    second_outline_href="/policies",
+    second_outline_text="View documentation",
+    second_outline_href="https://example.com/docs",
     second_outline_kwargs=second_outline_kwargs,
-    hero_image_url="https://seattlefigurestudio.sfo3.cdn.digitaloceanspaces.com/landing/favicon-48x48.png",
-    hero_image_alt="Stone Canvas hero artwork",
+    hero_image_url="https://picsum.photos/seed/flashoffer-hero/720/480",
+    hero_image_alt="Mock dashboard showcasing offer performance",
     hero_image_kwargs={"data_tracking_id": "hero-visual"},
 ) }}
 

--- a/src/examples/flashoffer/index.md
+++ b/src/examples/flashoffer/index.md
@@ -29,13 +29,13 @@ Use the primary helper for your most important action.
 
 ```jinja
 {% raw %}
-{{ pie.flashoffer.primary_cta("Start your free trial", "/signup") }}
+{{ pie.flashoffer.primary_cta("Explore Flashoffer components", "https://example.com/flashoffer") }}
 {% endraw %}
 ```
 
 renders as:
 
-{{ pie.flashoffer.primary_cta("Start your free trial", "/signup") }}
+{{ pie.flashoffer.primary_cta("Explore Flashoffer components", "https://example.com/flashoffer") }}
 
 ## Outline CTA
 
@@ -43,13 +43,13 @@ Pair the outline helper with the primary button to offer a secondary action.
 
 ```jinja
 {% raw %}
-{{ pie.flashoffer.outline_cta("Talk to sales", "/contact") }}
+{{ pie.flashoffer.outline_cta("Contact support", "mailto:support@example.com") }}
 {% endraw %}
 ```
 
 renders as:
 
-{{ pie.flashoffer.outline_cta("Talk to sales", "/contact") }}
+{{ pie.flashoffer.outline_cta("Contact support", "mailto:support@example.com") }}
 
 ## Customize attributes
 
@@ -111,17 +111,17 @@ needed.
 {% raw %}
 {{ pie.flashoffer.preview_card(
     preview,
-    overlay_text="Tap to reveal the <em>full pose</em>",
-    overlay_button_text="Open reference",
+    overlay_text="Tap to preview the <em>full layout</em>",
+    overlay_button_text="Open preview",
 ) }}
 {% endraw %}
 ```
 
 {% set preview = {
-    "image_url": "https://seattlefigurestudio.sfo3.cdn.digitaloceanspaces.com/landing/favicon-48x48.png",
-    "alt_text": "Seattle Figure Studio Favicon",
-    "link_href": "https://seattlefigurestudio.com",
-    "caption": "a cool place",
+    "image_url": "https://picsum.photos/seed/flashoffer-logo/96/96",
+    "alt_text": "Flashoffer logomark",
+    "link_href": "https://example.com/flashoffer",
+    "caption": "Explore reusable marketing components.",
 } %}
 {{ pie.flashoffer.preview_card(preview) }}
 
@@ -240,10 +240,10 @@ Use the footer helper to render the contact information block.
 {% raw %}
 {{ pie.flashoffer.footer(
     left_prefix="© ",
-    site_name="Seattle Figure Studio",
-    site_href="https://seattlefigurestudio.com",
+    site_name="Flashoffer",
+    site_href="https://example.com/flashoffer",
     rights_statement="All rights reserved.",
-    email_label="brian@seattlefigurestudio.com",
+    email_label="support@example.com",
 ) }}
 {% endraw %}
 ```
@@ -252,8 +252,8 @@ renders as:
 
 {{ pie.flashoffer.footer(
     left_prefix="© ",
-    site_name="Seattle Figure Studio",
-    site_href="https://seattlefigurestudio.com",
+    site_name="Flashoffer",
+    site_href="https://example.com/flashoffer",
     rights_statement="All rights reserved.",
-    email_label="brian@seattlefigurestudio.com",
+    email_label="support@example.com",
 ) }}


### PR DESCRIPTION
## Summary
- update Flashoffer Python defaults, documentation, and examples with neutral hero, CTA, overlay, and footer messaging
- sync React component props, tests, and demo content with the new default copy so every surface matches
- refresh Flashoffer Codex guide and hero example to reflect the generic messaging and links

## Testing
- pytest app/shell/py/pie/tests/test_flashoffer.py
- npm test -- --runTestsByPath src/__tests__/components.test.tsx (app/flashoffer-react)
- npm test -- src/App.test.tsx (app/flashoffer-demo)

------
https://chatgpt.com/codex/tasks/task_e_68d9ac941e90832196716e2a9f47643e