### PR TITLE
Add Flashoffer demo container support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ All project documentation lives under [docs/](docs/). Start with the
 [guides](docs/guides/README.md) for step-by-step workflows and see the
 [reference](docs/reference/README.md) for technical details.
 
+## Flashoffer demo container
+
+Build and run the Flashoffer demo with docker compose:
+
+```bash
+docker compose up flashoffer
+```
+
+The container compiles `app/flashoffer-react` and `app/flashoffer-demo` before
+serving a production preview. Access the demo at
+<http://localhost:4173>. Rebuild the image after dependency changes to keep the
+container environment in sync.
+
 ## Testing
 
 Run the test suite inside the same container used for development:

--- a/app/flashoffer/.dockerignore
+++ b/app/flashoffer/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+**/node_modules
+**/dist
+**/.vite
+**/.cache
+.git
+.gitignore
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store

--- a/app/flashoffer/Dockerfile
+++ b/app/flashoffer/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.6
+
+FROM node:22-slim AS base
+WORKDIR /workspace
+
+FROM base AS flashoffer-react-deps
+WORKDIR /workspace/app/flashoffer-react
+COPY app/flashoffer-react/package.json app/flashoffer-react/package-lock.json ./
+RUN npm ci
+
+FROM flashoffer-react-deps AS flashoffer-react-build
+COPY app/flashoffer-react ./
+RUN npm run build
+
+FROM flashoffer-react-build AS flashoffer-demo-build
+WORKDIR /workspace/app/flashoffer-demo
+COPY app/flashoffer-demo/package.json app/flashoffer-demo/package-lock.json ./
+RUN npm ci
+COPY app/flashoffer-demo ./
+RUN npm run build
+
+FROM node:22-slim AS runner
+ENV NODE_ENV=production
+ENV PORT=4173
+WORKDIR /workspace
+COPY --from=flashoffer-react-build /workspace/app/flashoffer-react /workspace/app/flashoffer-react
+COPY --from=flashoffer-demo-build /workspace/app/flashoffer-demo /workspace/app/flashoffer-demo
+COPY app/flashoffer/entrypoint.sh /usr/local/bin/flashoffer-entrypoint
+RUN chmod +x /usr/local/bin/flashoffer-entrypoint
+EXPOSE 4173
+ENTRYPOINT ["flashoffer-entrypoint"]

--- a/app/flashoffer/entrypoint.sh
+++ b/app/flashoffer/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${FLASHOFFER_ROOT:-/workspace}"
+PORT="${PORT:-4173}"
+
+cd "${ROOT_DIR}/app/flashoffer-react"
+if [ ! -d node_modules ]; then
+  npm ci
+fi
+npm run build
+
+cd "${ROOT_DIR}/app/flashoffer-demo"
+if [ ! -d node_modules ]; then
+  npm ci
+fi
+npm run build
+exec npm run preview -- --host 0.0.0.0 --port "${PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,5 +134,17 @@ services:
       - ./app/shell/py/pie:/pie
     profiles: ["pdoc"]
 
+  flashoffer:
+    build:
+      context: .
+      dockerfile: ./app/flashoffer/Dockerfile
+    container_name: press-flashoffer
+    environment:
+      PORT: ${FLASHOFFER_PORT:-4173}
+    ports:
+      - "${FLASHOFFER_PORT:-4173}:4173"
+    volumes:
+      - ./:/workspace
+
 volumes:
   analytics_timescale_data:


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile and entrypoint for building and previewing the Flashoffer demo
- add a docker-compose service that mounts the repository and forwards the preview port
- document how to launch the containerized Flashoffer demo from the root README

## Testing
- docker build -f app/flashoffer/Dockerfile . -t flashoffer-test *(fails: docker not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c199505c8321a4764dc25c59c6d5