### PR TITLE
Ensure flashoffer entrypoint installs dev dependencies

### DIFF
--- a/app/flashoffer/entrypoint.sh
+++ b/app/flashoffer/entrypoint.sh
@@ -4,15 +4,24 @@ set -euo pipefail
 ROOT_DIR="${FLASHOFFER_ROOT:-/workspace}"
 PORT="${PORT:-4173}"
 
-cd "${ROOT_DIR}/app/flashoffer-react"
-if [ ! -d node_modules ]; then
-  npm ci
-fi
-npm run build
+ensure_dependencies() {
+  local package_dir="$1"
+  cd "${package_dir}"
 
-cd "${ROOT_DIR}/app/flashoffer-demo"
-if [ ! -d node_modules ]; then
-  npm ci
-fi
-npm run build
+  if [ ! -d node_modules ] || [ ! -x node_modules/.bin/vite ]; then
+    npm ci --include=dev
+  fi
+}
+
+build_package() {
+  local package_dir="$1"
+  cd "${package_dir}"
+  npm run build
+}
+
+ensure_dependencies "${ROOT_DIR}/app/flashoffer-react"
+build_package "${ROOT_DIR}/app/flashoffer-react"
+
+ensure_dependencies "${ROOT_DIR}/app/flashoffer-demo"
+build_package "${ROOT_DIR}/app/flashoffer-demo"
 exec npm run preview -- --host 0.0.0.0 --port "${PORT}"


### PR DESCRIPTION
## Summary
- ensure the flashoffer entrypoint reinstalls dependencies when Vite is missing
- refactor the entrypoint script to reuse dependency-install and build helpers for both apps

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9cbb25308832186fc11b0cc75e124