### PR TITLE
Increase coverage for update index error handling

### DIFF
--- a/app/shell/py/pie/tests/update/test_update_index.py
+++ b/app/shell/py/pie/tests/update/test_update_index.py
@@ -1,8 +1,11 @@
 import hashlib
 import json
 import os
+import runpy
 import sys
 import threading
+import warnings
+from types import SimpleNamespace
 
 import fakeredis
 import pytest
@@ -214,6 +217,135 @@ def test_main_missing_id_generates(tmp_path, monkeypatch):
         os.chdir("/tmp")
 
     assert fake.get("doc.title") == "T"
+
+
+def test_metadata_schema_reads_nested_press_section():
+    """_metadata_schema finds schema nested under the press key."""
+
+    metadata = {"press": {"schema": "v1"}}
+
+    assert update_index._metadata_schema(metadata) == "v1"
+
+
+def test_flatten_index_logs_missing_source(tmp_path, monkeypatch):
+    """Missing source files log a warning without interrupting processing."""
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        missing_index = {"doc": {"path": ["missing.md"], "title": "T"}}
+        warnings_logged = []
+
+        def fake_warning(message, **kwargs):
+            warnings_logged.append((message, kwargs))
+
+        monkeypatch.setattr(update_index.logger, "warning", fake_warning)
+
+        entries = list(update_index.flatten_index(missing_index))
+    finally:
+        os.chdir(cwd)
+
+    assert ("doc.title", "T") in entries
+    assert any(msg == "Source file missing" for msg, _ in warnings_logged)
+
+
+def test_load_directory_index_skips_invalid_and_missing(tmp_path, monkeypatch):
+    """Non-metadata files and empty metadata entries are ignored."""
+
+    src = tmp_path / "src"
+    src.mkdir()
+
+    def fake_walk(path):
+        yield (str(src), [], ["doc.yml", "doc.md", "ignore.txt", "skip.yml"])
+
+    monkeypatch.setattr(update_index.os, "walk", fake_walk)
+
+    def fake_loader(path):
+        if path.name == "skip.yml":
+            return {}
+        return {"id": path.stem, "title": path.stem}
+
+    monkeypatch.setattr(update_index, "load_metadata_pair", fake_loader)
+
+    index, processed = update_index.load_directory_index(src)
+
+    assert index == {"doc": {"id": "doc", "title": "doc"}}
+    assert processed == 2
+
+
+def test_load_index_from_path_errors_without_metadata(tmp_path, monkeypatch):
+    """Single metadata file with no parsed data aborts the update."""
+
+    meta = tmp_path / "doc.yml"
+    meta.write_text("title: Test\n", encoding="utf-8")
+
+    monkeypatch.setattr(update_index, "load_metadata_pair", lambda path: None)
+
+    errors = []
+
+    def fake_error(message, **kwargs):
+        errors.append((message, kwargs))
+
+    monkeypatch.setattr(update_index.logger, "error", fake_error)
+
+    with pytest.raises(SystemExit):
+        update_index.load_index_from_path(meta)
+
+    assert any(msg == "No metadata found" for msg, _ in errors)
+
+
+def test_load_index_from_path_requires_document_id(tmp_path, monkeypatch):
+    """Missing document ids emit a warning and abort."""
+
+    meta = tmp_path / "doc.yml"
+    meta.write_text("title: Test\n", encoding="utf-8")
+
+    monkeypatch.setattr(update_index, "load_metadata_pair", lambda path: {"title": "T"})
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(SystemExit):
+            update_index.load_index_from_path(meta)
+
+    assert any("Missing 'id' field" in str(w.message) for w in caught)
+
+
+def test_load_index_from_path_rejects_unknown_suffix(tmp_path, monkeypatch):
+    """Unsupported file types raise a SystemExit with a logged error."""
+
+    doc = tmp_path / "doc.txt"
+    doc.write_text("irrelevant", encoding="utf-8")
+
+    errors = []
+
+    def fake_error(message, **kwargs):
+        errors.append((message, kwargs))
+
+    monkeypatch.setattr(update_index.logger, "error", fake_error)
+
+    with pytest.raises(SystemExit):
+        update_index.load_index_from_path(doc)
+
+    assert any(msg == "Unsupported file type" for msg, _ in errors)
+
+
+def test_main_entrypoint_executes_when_run_as_script(tmp_path, monkeypatch):
+    """Running the module as a script triggers main() exactly once."""
+
+    idx = tmp_path / "index.json"
+    idx.write_text('{"doc": {"title": "T"}}', encoding="utf-8")
+
+    fake_redis = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setitem(sys.modules, "redis", SimpleNamespace(Redis=lambda *a, **kw: fake_redis))
+
+    argv = sys.argv
+    sys.argv = ["update-index", str(idx)]
+    try:
+        runpy.run_path(update_index.__file__, run_name="__main__")
+    finally:
+        sys.argv = argv
+
+    assert fake_redis.get("doc.title") == "T"
 
 
 def test_directory_processed_in_parallel(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add targeted tests that cover metadata schema fallbacks and missing source warnings
- exercise directory scanning edge cases and error paths for single-file loads
- execute the module as a script to ensure the `__main__` guard is covered

## Testing
- `cd press/app/shell/py && pytest pie/tests/update/test_update_index.py`


------
https://chatgpt.com/codex/tasks/task_e_68dac0088a108321937ef2c3882a1bee