### PR TITLE
Add flashoffer development docker service

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ serving a production preview. Access the demo at
 <http://localhost:4173>. Rebuild the image after dependency changes to keep the
 container environment in sync.
 
+For hot reloading with the Vite development server, start the dedicated dev
+service instead:
+
+```bash
+docker compose up flashoffer-dev
+```
+
+The dev container serves the demo in development mode at
+<http://localhost:5173>, so component names remain unminified for tools like
+React DevTools. Changes made to the local filesystem are reflected in the
+running container automatically.
+
 ## Testing
 
 Run the test suite inside the same container used for development:

--- a/app/flashoffer/entrypoint.sh
+++ b/app/flashoffer/entrypoint.sh
@@ -2,7 +2,20 @@
 set -euo pipefail
 
 ROOT_DIR="${FLASHOFFER_ROOT:-/workspace}"
-PORT="${PORT:-4173}"
+MODE="${FLASHOFFER_MODE:-preview}"
+
+case "${MODE}" in
+  dev)
+    PORT="${PORT:-5173}"
+    ;;
+  preview)
+    PORT="${PORT:-4173}"
+    ;;
+  *)
+    echo "Unsupported FLASHOFFER_MODE: ${MODE}" >&2
+    exit 1
+    ;;
+esac
 
 ensure_dependencies() {
   local package_dir="$1"
@@ -20,8 +33,13 @@ build_package() {
 }
 
 ensure_dependencies "${ROOT_DIR}/app/flashoffer-react"
-build_package "${ROOT_DIR}/app/flashoffer-react"
-
 ensure_dependencies "${ROOT_DIR}/app/flashoffer-demo"
+
+if [ "${MODE}" = "dev" ]; then
+  cd "${ROOT_DIR}/app/flashoffer-demo"
+  exec npm run dev -- --host 0.0.0.0 --port "${PORT}"
+fi
+
+build_package "${ROOT_DIR}/app/flashoffer-react"
 build_package "${ROOT_DIR}/app/flashoffer-demo"
 exec npm run preview -- --host 0.0.0.0 --port "${PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,5 +147,20 @@ services:
       - ./:/workspace
     network_mode: host
 
+  flashoffer-dev:
+    build:
+      context: .
+      dockerfile: ./app/flashoffer/Dockerfile
+    container_name: press-flashoffer-dev
+    environment:
+      FLASHOFFER_MODE: dev
+      PORT: ${FLASHOFFER_DEV_PORT:-5173}
+      CHOKIDAR_USEPOLLING: "true"
+    ports:
+      - "${FLASHOFFER_DEV_PORT:-5173}:5173"
+    volumes:
+      - ./:/workspace
+    network_mode: host
+
 volumes:
   analytics_timescale_data:


### PR DESCRIPTION
## Summary
- add a flashoffer-dev docker compose service that runs the Vite dev server with local hot reloading
- extend the flashoffer entrypoint to support a development mode without minifying output
- document how to launch the new dev container in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac9c897848321a984f8cc562adf09