### PR TITLE
Configure Flashoffer demo analytics endpoints

### DIFF
--- a/app/flashoffer-demo/src/main.tsx
+++ b/app/flashoffer-demo/src/main.tsx
@@ -4,6 +4,12 @@ import { AutoTrack, EngagementProvider } from "flashoffer-react";
 import App from "./App";
 import "./index.css";
 
+const analyticsEndpoint =
+  typeof import.meta.env.VITE_FLASHOFFER_ANALYTICS_ENDPOINT === "string" &&
+  import.meta.env.VITE_FLASHOFFER_ANALYTICS_ENDPOINT.trim() !== ""
+    ? import.meta.env.VITE_FLASHOFFER_ANALYTICS_ENDPOINT
+    : undefined;
+
 const rootElement = document.getElementById("root");
 
 if (!rootElement) {
@@ -12,7 +18,7 @@ if (!rootElement) {
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <EngagementProvider site="flashoffer-demo">
+    <EngagementProvider site="flashoffer-demo" endpoint={analyticsEndpoint}>
       <App />
       <AutoTrack />
     </EngagementProvider>

--- a/app/flashoffer-demo/src/vite-env.d.ts
+++ b/app/flashoffer-demo/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_FLASHOFFER_ANALYTICS_ENDPOINT?: string;
+  readonly VITE_FLASHOFFER_ANALYTICS_RECENT_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       DATABASE_USER: analytics
       DATABASE_PASSWORD: analytics
       DATABASE_NAME: analytics
-      CORS_ALLOW_ORIGINS: http://localhost:5173
+      CORS_ALLOW_ORIGINS: http://localhost:5173,http://localhost:4173
     depends_on:
       - analytics-timescaledb
     ports:
@@ -141,6 +141,8 @@ services:
     container_name: press-flashoffer
     environment:
       PORT: ${FLASHOFFER_PORT:-4173}
+      VITE_FLASHOFFER_ANALYTICS_ENDPOINT: ${FLASHOFFER_ANALYTICS_ENDPOINT:-http://localhost:8001/events}
+      VITE_FLASHOFFER_ANALYTICS_RECENT_URL: ${FLASHOFFER_ANALYTICS_RECENT_URL:-http://localhost:8001/events/recent}
     ports:
       - "${FLASHOFFER_PORT:-4173}:4173"
     volumes:
@@ -156,6 +158,8 @@ services:
       FLASHOFFER_MODE: dev
       PORT: ${FLASHOFFER_DEV_PORT:-5173}
       CHOKIDAR_USEPOLLING: "true"
+      VITE_FLASHOFFER_ANALYTICS_ENDPOINT: ${FLASHOFFER_ANALYTICS_ENDPOINT:-http://localhost:8001/events}
+      VITE_FLASHOFFER_ANALYTICS_RECENT_URL: ${FLASHOFFER_ANALYTICS_RECENT_URL:-http://localhost:8001/events/recent}
     ports:
       - "${FLASHOFFER_DEV_PORT:-5173}:5173"
     volumes:

--- a/docs/reference/analytics-stack.md
+++ b/docs/reference/analytics-stack.md
@@ -178,6 +178,17 @@ application reaches the API through the host-mapped port.
   The Vite build emits ESM and CommonJS bundles so applications can import the
   helpers directly or publish a compiled asset for static sites.
 
+### flashoffer / flashoffer-dev
+- **Purpose** – Serve the Flashoffer marketing demo either as a static preview
+  (`flashoffer`) or via the Vite dev server (`flashoffer-dev`).
+- **Analytics wiring** – Compose exports
+  `VITE_FLASHOFFER_ANALYTICS_ENDPOINT` and
+  `VITE_FLASHOFFER_ANALYTICS_RECENT_URL` so the demo posts batched events to
+  `analytics-backend` at `http://localhost:8001` by default.
+- **Overrides** – Set `FLASHOFFER_ANALYTICS_ENDPOINT` or
+  `FLASHOFFER_ANALYTICS_RECENT_URL` in your environment to target alternate
+  ingestion hosts without editing Compose files.
+
 ## Local workflow
 1. Start the database and ingestion API:
    ```bash


### PR DESCRIPTION
## Summary
- expose analytics endpoint configuration to the flashoffer and flashoffer-dev Compose services while permitting the preview origin in analytics-backend CORS
- pass the configured endpoint into the flashoffer demo engagement provider and document the available environment variables

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dad10f85008321b1964e50e73fb5fb