### PR TITLE
Fix hypertable primary key definition

### DIFF
--- a/app/analytics-backend/analytics_backend/db.py
+++ b/app/analytics-backend/analytics_backend/db.py
@@ -88,14 +88,15 @@ class TimescaleDB:
                 cur.execute(
                     """
                     CREATE TABLE IF NOT EXISTS engagement_events (
-                        id BIGSERIAL PRIMARY KEY,
+                        id BIGSERIAL NOT NULL,
                         site TEXT NOT NULL,
                         session_id UUID NOT NULL,
                         event_type TEXT NOT NULL,
                         target TEXT NOT NULL,
                         occurred_at TIMESTAMPTZ NOT NULL,
                         meta JSONB NOT NULL,
-                        received_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                        received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                        PRIMARY KEY (occurred_at, id)
                     )
                     """
                 )


### PR DESCRIPTION
## Summary
- include the occurred_at partition column in the engagement_events primary key so the hypertable can be created

## Testing
- pytest app/analytics-backend/tests *(fails: ModuleNotFoundError: No module named 'analytics_backend')*

------
https://chatgpt.com/codex/tasks/task_e_68dad80d5d1483218dd79e448f7affe5