### PR TITLE
Add Flashoffer dev Dockerfile for Vite hot reload

### DIFF
--- a/app/flashoffer/Dockerfile
+++ b/app/flashoffer/Dockerfile
@@ -23,10 +23,16 @@ FROM node:22-slim AS runner
 ENV NODE_ENV=production
 ENV PORT=4173
 WORKDIR /workspace
-RUN npm install -g vite
 COPY --from=flashoffer-react-build /workspace/app/flashoffer-react /workspace/app/flashoffer-react
 COPY --from=flashoffer-demo-build /workspace/app/flashoffer-demo /workspace/app/flashoffer-demo
 COPY app/flashoffer/entrypoint.sh /usr/local/bin/flashoffer-entrypoint
 RUN chmod +x /usr/local/bin/flashoffer-entrypoint
 EXPOSE 4173
 ENTRYPOINT ["flashoffer-entrypoint"]
+
+FROM nginx:1.27-alpine AS production
+WORKDIR /usr/share/nginx/html
+COPY app/flashoffer/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=flashoffer-demo-build /workspace/app/flashoffer-demo/dist ./
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/app/flashoffer/Dockerfile.dev
+++ b/app/flashoffer/Dockerfile.dev
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1.6
+
+FROM node:22-slim AS base
+WORKDIR /workspace
+ENV NODE_ENV=development
+
+FROM base AS flashoffer-react-deps
+WORKDIR /workspace/app/flashoffer-react
+COPY app/flashoffer-react/package.json app/flashoffer-react/package-lock.json ./
+RUN npm ci --include=dev
+
+FROM base AS flashoffer-demo-deps
+WORKDIR /workspace/app/flashoffer-demo
+COPY app/flashoffer-demo/package.json app/flashoffer-demo/package-lock.json ./
+RUN npm ci --include=dev
+
+FROM base AS dev
+ENV FLASHOFFER_MODE=dev
+WORKDIR /workspace
+COPY app/flashoffer/entrypoint.sh /usr/local/bin/flashoffer-entrypoint
+RUN chmod +x /usr/local/bin/flashoffer-entrypoint
+COPY app/flashoffer-react/package.json app/flashoffer-react/package-lock.json \
+  app/flashoffer-react/
+COPY --from=flashoffer-react-deps /workspace/app/flashoffer-react/node_modules \
+  /workspace/app/flashoffer-react/node_modules
+COPY app/flashoffer-demo/package.json app/flashoffer-demo/package-lock.json \
+  app/flashoffer-demo/
+COPY --from=flashoffer-demo-deps /workspace/app/flashoffer-demo/node_modules \
+  /workspace/app/flashoffer-demo/node_modules
+COPY app/flashoffer-react /workspace/app/flashoffer-react
+COPY app/flashoffer-demo /workspace/app/flashoffer-demo
+EXPOSE 5173
+ENTRYPOINT ["flashoffer-entrypoint"]

--- a/app/flashoffer/nginx.conf
+++ b/app/flashoffer/nginx.conf
@@ -1,0 +1,30 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Strict-Transport-Security
+        "max-age=31536000; includeSubDomains"
+        always;
+
+    # Compression and caching
+    gzip on;
+    gzip_types
+        text/plain
+        text/css
+        application/javascript
+        application/json
+        image/svg+xml;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,7 @@ services:
     build:
       context: .
       dockerfile: ./app/flashoffer/Dockerfile
+      target: runner
     environment:
       PORT: ${FLASHOFFER_PORT:-4173}
       VITE_FLASHOFFER_ANALYTICS_ENDPOINT: ${FLASHOFFER_ANALYTICS_ENDPOINT:-http://localhost:8001/events}
@@ -149,7 +150,7 @@ services:
   flashoffer-dev:
     build:
       context: .
-      dockerfile: ./app/flashoffer/Dockerfile
+      dockerfile: ./app/flashoffer/Dockerfile.dev
     environment:
       FLASHOFFER_MODE: dev
       PORT: ${FLASHOFFER_DEV_PORT:-5173}


### PR DESCRIPTION
## Summary
- add a dedicated Dockerfile.dev that runs the Flashoffer demo with the Vite dev server for hot reload
- copy the built demo dist directory into the production nginx image
- configure docker-compose to build the preview container from the runner stage and use the new dev Dockerfile

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68db5de28ce48321a9d1a7f36db833ef