### PR TITLE
Add bastion SSH service

### DIFF
--- a/app/bastion/Dockerfile
+++ b/app/bastion/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM debian:bookworm-slim
+
+LABEL maintainer="press maintainers"
+
+ARG AUTHORIZED_KEYS_FILE=app/bastion/authorized_keys.example
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends openssh-server \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /var/run/sshd /root/.ssh \
+    && chmod 700 /root/.ssh
+
+COPY app/bastion/sshd_config /etc/ssh/sshd_config
+
+COPY ${AUTHORIZED_KEYS_FILE} /root/.ssh/authorized_keys
+RUN chmod 600 /root/.ssh/authorized_keys
+
+RUN ssh-keygen -A
+
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/app/bastion/README.md
+++ b/app/bastion/README.md
@@ -1,0 +1,29 @@
+# Bastion Host
+
+This image provisions an OpenSSH bastion host for internal development use.
+
+## Building
+
+The build copies a local authorized keys file into `/root/.ssh/authorized_keys`.
+By default the Dockerfile copies `app/bastion/authorized_keys.example`. Supply a
+custom file when running `docker build`:
+
+```bash
+docker build \
+  --build-arg AUTHORIZED_KEYS_FILE=path/to/authorized_keys \
+  -t press-bastion .
+```
+
+`AUTHORIZED_KEYS_FILE` must be relative to the repository root because the
+compose file uses the repository as the build context.
+
+## Running
+
+The bastion service is available through docker compose:
+
+```bash
+docker compose up bastion
+```
+
+SSH listens on port `22` inside the container. The compose service exposes it as
+`2222` on the host machine.

--- a/app/bastion/authorized_keys.example
+++ b/app/bastion/authorized_keys.example
@@ -1,0 +1,2 @@
+# Replace this file or provide your own during build.
+# ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEexampleexampleexampleexampleexample example@host

--- a/app/bastion/sshd_config
+++ b/app/bastion/sshd_config
@@ -1,0 +1,16 @@
+Include /etc/ssh/sshd_config.d/*.conf
+
+Port 22
+Protocol 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+PermitRootLogin prohibit-password
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+UsePAM yes
+X11Forwarding no
+PrintMotd no
+AcceptEnv LANG LC_*
+Subsystem sftp /usr/lib/openssh/sftp-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,14 @@ services:
       - ./app/shell/py/pie/tests:/press/py/pie/tests
       - ./src/templates/:/press/templates/
 
+  bastion:
+    build:
+      context: .
+      dockerfile: ./app/bastion/Dockerfile
+    container_name: press-bastion
+    ports:
+      - "2222:22"
+
   release:
     image: press-release
     build:


### PR DESCRIPTION
## Summary
- add a bastion Docker image with OpenSSH configured for key-based root access
- document how to supply authorized keys during the image build
- expose the bastion host through docker compose on port 2222

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbf40fe3cc83218dd5f18b49337345