### PR TITLE
Add loguru logging for analytics backend CORS configuration

### DIFF
--- a/app/analytics-backend/Dockerfile
+++ b/app/analytics-backend/Dockerfile
@@ -11,7 +11,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY analytics_backend ./analytics_backend
 COPY tests ./tests
 
-ENV FLASK_APP=analytics_backend.app:create_app
+ENV FLASK_APP=analytics_backend.app:create_app \
+    CORS_ALLOW_ORIGINS=
 
 EXPOSE 8000
 

--- a/app/analytics-backend/analytics_backend/app.py
+++ b/app/analytics-backend/analytics_backend/app.py
@@ -9,6 +9,7 @@ import time
 from typing import Any, Dict, Iterable, Set
 
 from flask import Flask, Response, jsonify, request
+from loguru import logger
 
 from .db import DatabaseConfig, TimescaleDB
 
@@ -63,11 +64,19 @@ def create_app() -> Flask:
     atexit.register(storage.close)
     app.config["DB_POOL"] = storage
 
+    cors_logger = logger.bind(component="cors")
+    cors_allow_origins = os.getenv("CORS_ALLOW_ORIGINS", "")
+    cors_logger.info("Loaded CORS_ALLOW_ORIGINS value", value=cors_allow_origins)
+
     allowed_origins: Set[str] = {
         origin.strip()
-        for origin in os.getenv("CORS_ALLOW_ORIGINS", "").split(",")
+        for origin in cors_allow_origins.split(",")
         if origin.strip()
     }
+    cors_logger.info(
+        "Configured allowed origins",
+        allowed_origins=sorted(allowed_origins),
+    )
 
     def apply_cors(response: Response) -> Response:
         if allowed_origins:

--- a/app/analytics-backend/requirements.txt
+++ b/app/analytics-backend/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.3.3
+loguru==0.7.2
 psycopg2-binary==2.9.9
 pytest==7.4.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
       DATABASE_USER: analytics
       DATABASE_PASSWORD: analytics
       DATABASE_NAME: analytics
-      CORS_ALLOW_ORIGINS: http://localhost:5173,http://localhost:4173
+      CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS:-http://localhost:5173,http://localhost:4173}
     depends_on:
       - analytics-db
     ports:


### PR DESCRIPTION
## Summary
- add Loguru as a dependency and log the configured CORS values during app start
- default the CORS_ALLOW_ORIGINS environment variable in the Docker image and compose service

## Testing
- PYTHONPATH=. pytest *(fails: requires database service environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf371ff348321887185d1b7bff3f1