### PR TITLE
Add nginx production stage for analytics backend

### DIFF
--- a/app/analytics-backend/Dockerfile
+++ b/app/analytics-backend/Dockerfile
@@ -1,7 +1,9 @@
-FROM python:3.11-slim
+FROM python:3.11-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    FLASK_APP=analytics_backend.app:create_app \
+    CORS_ALLOW_ORIGINS=
 
 WORKDIR /app
 
@@ -9,11 +11,28 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY analytics_backend ./analytics_backend
-COPY tests ./tests
 
-ENV FLASK_APP=analytics_backend.app:create_app \
-    CORS_ALLOW_ORIGINS=
+FROM base AS dev
+COPY tests ./tests
 
 EXPOSE 8000
 
 CMD ["flask", "--app", "analytics_backend.app:create_app", "run", "--host=0.0.0.0", "--port=8000"]
+
+FROM base AS production
+ENV GUNICORN_WORKERS=4 \
+    GUNICORN_BIND=unix:/tmp/gunicorn.sock
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y nginx \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir gunicorn
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8000
+
+CMD ["/entrypoint.sh"]

--- a/app/analytics-backend/entrypoint.sh
+++ b/app/analytics-backend/entrypoint.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+GUNICORN_BIND="${GUNICORN_BIND:-unix:/tmp/gunicorn.sock}"
+GUNICORN_WORKERS="${GUNICORN_WORKERS:-4}"
+SOCKET_PATH="$GUNICORN_BIND"
+case "$GUNICORN_BIND" in
+  unix:*)
+    SOCKET_PATH="${GUNICORN_BIND#unix:}"
+    ;;
+  *)
+    SOCKET_PATH=""
+    ;;
+esac
+
+cleanup() {
+  if [ -n "${GUNICORN_PID:-}" ] && kill -0 "$GUNICORN_PID" 2>/dev/null; then
+    kill "$GUNICORN_PID" 2>/dev/null || true
+    wait "$GUNICORN_PID" 2>/dev/null || true
+  fi
+  if [ -n "${NGINX_PID:-}" ] && kill -0 "$NGINX_PID" 2>/dev/null; then
+    kill "$NGINX_PID" 2>/dev/null || true
+    wait "$NGINX_PID" 2>/dev/null || true
+  fi
+  if [ -n "$SOCKET_PATH" ] && [ -S "$SOCKET_PATH" ]; then
+    rm -f "$SOCKET_PATH"
+  fi
+}
+
+trap cleanup INT TERM EXIT
+
+if [ -n "$SOCKET_PATH" ]; then
+  SOCKET_DIR=$(dirname "$SOCKET_PATH")
+  mkdir -p "$SOCKET_DIR"
+  rm -f "$SOCKET_PATH"
+fi
+
+gunicorn \
+  --bind "$GUNICORN_BIND" \
+  --workers "$GUNICORN_WORKERS" \
+  --access-logfile - \
+  --error-logfile - \
+  analytics_backend.app:create_app &
+GUNICORN_PID=$!
+
+nginx -g 'daemon off;' &
+NGINX_PID=$!
+
+while :; do
+  if ! kill -0 "$GUNICORN_PID" 2>/dev/null; then
+    wait "$GUNICORN_PID"
+    STATUS=$?
+    kill "$NGINX_PID" 2>/dev/null || true
+    wait "$NGINX_PID" 2>/dev/null || true
+    exit $STATUS
+  fi
+
+  if ! kill -0 "$NGINX_PID" 2>/dev/null; then
+    wait "$NGINX_PID"
+    STATUS=$?
+    kill "$GUNICORN_PID" 2>/dev/null || true
+    wait "$GUNICORN_PID" 2>/dev/null || true
+    exit $STATUS
+  fi
+
+  sleep 1
+done

--- a/app/analytics-backend/nginx.conf
+++ b/app/analytics-backend/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 8000;
+    server_name _;
+
+    client_max_body_size 10m;
+
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://unix:/tmp/gunicorn.sock;
+        proxy_redirect off;
+    }
+}


### PR DESCRIPTION
## Summary
- convert the analytics backend Dockerfile into a multi-stage build with separate dev and production targets
- install nginx and gunicorn in the production stage and add an entrypoint to coordinate both processes
- provide an nginx configuration that proxies requests to the gunicorn socket

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbff2b6bac83218c6d870d6566c4d7