### PR TITLE
Fix analytics backend gunicorn startup

### DIFF
--- a/app/analytics-backend/entrypoint.sh
+++ b/app/analytics-backend/entrypoint.sh
@@ -40,6 +40,7 @@ gunicorn \
   --workers "$GUNICORN_WORKERS" \
   --access-logfile - \
   --error-logfile - \
+  --factory \
   analytics_backend.app:create_app &
 GUNICORN_PID=$!
 


### PR DESCRIPTION
## Summary
- add the gunicorn `--factory` flag in the analytics backend entrypoint so the application factory is invoked correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc11ead7f083219794e9ec4fd54ae3