### PR TITLE
Update Flashoffer demo with Figure example

### DIFF
--- a/app/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer-demo/src/App.tsx
@@ -8,6 +8,7 @@ import Typography from "@mui/material/Typography";
 import type { ThemeOptions } from "@mui/material/styles";
 import { useMemo, useState } from "react";
 import {
+  Figure,
   FlashofferThemeProvider,
   Footer,
   HeroBanner,
@@ -139,6 +140,11 @@ export default function App() {
 
   const previewMeta = useMemo(
     () => JSON.stringify({ cards: previewCards.length }),
+    []
+  );
+
+  const figureMeta = useMemo(
+    () => JSON.stringify({ orientation: "landscape" }),
     []
   );
 
@@ -331,6 +337,35 @@ export default function App() {
                   );
                 })}
               </Grid>
+            </Box>
+
+            <Box
+              component="section"
+              data-track-id="figure-section"
+              data-track-label="Figure component"
+              data-track-meta={figureMeta}
+            >
+              <SectionHeader
+                eyebrow="MEDIA"
+                title="Pair imagery with supporting context"
+                description="Use Figure to keep visuals responsive across breakpoints while pairing them with captions or attributions."
+              />
+              <Box
+                sx={{
+                  mt: 3,
+                  display: "flex",
+                  justifyContent: "center"
+                }}
+              >
+                <Figure
+                  src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=960&q=80"
+                  alt="Product marketer reviewing launch campaign timelines"
+                  caption="Launch dashboards stay legible on any device thanks to responsive scaling."
+                  sx={{
+                    maxWidth: 560
+                  }}
+                />
+              </Box>
             </Box>
 
             <Box

--- a/app/flashoffer-react/jest.config.ts
+++ b/app/flashoffer-react/jest.config.ts
@@ -5,6 +5,9 @@ const config: Config = {
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/setupTests.ts"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
+  moduleNameMapper: {
+    "\\.(css|less|scss)$": "<rootDir>/test/__mocks__/styleMock.ts"
+  },
   testMatch: ["<rootDir>/src/**/__tests__/**/*.test.(ts|tsx)"]
 };
 

--- a/app/flashoffer-react/src/__tests__/components.test.tsx
+++ b/app/flashoffer-react/src/__tests__/components.test.tsx
@@ -6,6 +6,7 @@ import { OutlineCtaButton } from "../components/OutlineCtaButton";
 import { PreviewCard } from "../components/PreviewCard";
 import { PrimaryCtaButton } from "../components/PrimaryCtaButton";
 import { SectionHeader } from "../components/SectionHeader";
+import { Figure } from "../components/Figure";
 import { useTheme } from "@mui/material/styles";
 import type { ReactElement } from "react";
 
@@ -93,6 +94,37 @@ describe("Flashoffer React primitives", () => {
     renderWithTheme(<OutlineCtaButton />);
     expect(
       screen.getByRole("button", { name: /contact support/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders figure with empty defaults", () => {
+    const { container } = renderWithTheme(
+      <Figure src="https://example.com/test.png" />
+    );
+    const image = container.querySelector("img");
+    if (!(image instanceof HTMLImageElement)) {
+      throw new Error("Expected figure to render an image element");
+    }
+    expect(image).toHaveAttribute("alt", "");
+    expect(image).toHaveAttribute("src", "https://example.com/test.png");
+    const caption = container.querySelector("figcaption");
+    expect(caption).not.toBeNull();
+    expect(caption?.textContent).toBe("");
+  });
+
+  it("supports custom figure caption", () => {
+    renderWithTheme(
+      <Figure
+        src="https://example.com/test.png"
+        alt="Dashboard screenshot"
+        caption="Flashoffer dashboard overview"
+      />
+    );
+    expect(
+      screen.getByText("Flashoffer dashboard overview")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Dashboard screenshot" })
     ).toBeInTheDocument();
   });
 

--- a/app/flashoffer-react/src/components/Figure.tsx
+++ b/app/flashoffer-react/src/components/Figure.tsx
@@ -1,0 +1,59 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import type { SxProps, Theme } from "@mui/material/styles";
+import type { ImgHTMLAttributes, ReactNode } from "react";
+
+export interface FigureProps {
+  /** Image source rendered inside the figure. */
+  src: string;
+  /** Descriptive alt text for the image. Defaults to decorative. */
+  alt?: string;
+  /** Optional caption content rendered below the image. */
+  caption?: ReactNode;
+  /** Custom styles merged into the root figure element. */
+  sx?: SxProps<Theme>;
+  /** Additional props forwarded to the underlying <img> element. */
+  imgProps?: Omit<ImgHTMLAttributes<HTMLImageElement>, "src" | "alt">;
+}
+
+/**
+ * Responsive image container with optional caption support.
+ */
+export function Figure({
+  src,
+  alt = "",
+  caption,
+  sx,
+  imgProps
+}: FigureProps) {
+  return (
+    <Box
+      component="figure"
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 1,
+        my: 0,
+        ...sx
+      }}
+    >
+      <Box
+        component="img"
+        alt={alt}
+        src={src}
+        sx={{
+          display: "block",
+          maxWidth: "100%",
+          width: "100%",
+          height: "auto",
+          objectFit: "contain"
+        }}
+        {...imgProps}
+      />
+      <Typography component="figcaption" variant="caption" color="text.secondary">
+        {caption ?? null}
+      </Typography>
+    </Box>
+  );
+}

--- a/app/flashoffer-react/src/index.ts
+++ b/app/flashoffer-react/src/index.ts
@@ -19,6 +19,9 @@ export type { PreviewCardProps } from "./components/PreviewCard";
 export { Footer } from "./components/Footer";
 export type { FooterProps, FooterLink } from "./components/Footer";
 
+export { Figure } from "./components/Figure";
+export type { FigureProps } from "./components/Figure";
+
 export {
   AutoTrack,
   EngagementProvider,

--- a/app/flashoffer-react/test/__mocks__/styleMock.ts
+++ b/app/flashoffer-react/test/__mocks__/styleMock.ts
@@ -1,0 +1,1 @@
+export default {} as Record<string, string>;


### PR DESCRIPTION
## Summary
- showcase the new Figure component inside the flashoffer demo experience
- add responsive imagery with a captioned figure and analytics metadata

## Testing
- npm test -- --runTestsByPath src/App.test.tsx *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5069ae548321aac39ac2fa139207