### PR TITLE
Align Section component with Flashoffer theme tokens

### DIFF
--- a/app/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer-demo/src/App.tsx
@@ -14,6 +14,7 @@ import {
   OutlineCtaButton,
   PreviewCard,
   PrimaryCtaButton,
+  Section,
   SectionHeader
 } from "flashoffer-react";
 
@@ -110,6 +111,13 @@ const footerLinks = [
   { label: "Support", href: "mailto:support@example.com" }
 ];
 
+const overviewParagraphs = [
+  "Use the Section component to pair launch announcements, feature guides, " +
+    "or changelog summaries with consistent typography.",
+  "Each paragraph is wrapped in semantic markup and inherits spacing from the " +
+    "Flashoffer design tokens, so marketing teams can focus on messaging."
+];
+
 const heroMedia = (
   <img
     src="https://images.unsplash.com/photo-1553877522-43269d4ea984?auto=format&fit=crop&w=720&q=80"
@@ -139,6 +147,11 @@ export default function App() {
 
   const previewMeta = useMemo(
     () => JSON.stringify({ cards: previewCards.length }),
+    []
+  );
+
+  const overviewMeta = useMemo(
+    () => JSON.stringify({ paragraphs: overviewParagraphs.length }),
     []
   );
 
@@ -260,6 +273,20 @@ export default function App() {
                   "data-track-meta": heroMeta
                 }}
                 media={heroMedia}
+              />
+            </Box>
+
+            <Box
+              data-track-id="overview-section"
+              data-track-label="Section overview"
+              data-track-meta={overviewMeta}
+            >
+              <Section
+                align="left"
+                eyebrow="OVERVIEW"
+                title="Narrate launches with reusable sections"
+                description="Combine headlines and supporting copy without rebuilding layouts from scratch."
+                paragraphs={overviewParagraphs}
               />
             </Box>
 

--- a/app/flashoffer-react/jest.config.ts
+++ b/app/flashoffer-react/jest.config.ts
@@ -5,7 +5,10 @@ const config: Config = {
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/setupTests.ts"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
-  testMatch: ["<rootDir>/src/**/__tests__/**/*.test.(ts|tsx)"]
+  testMatch: ["<rootDir>/src/**/__tests__/**/*.test.(ts|tsx)"],
+  moduleNameMapper: {
+    "\\.(css|less|sass|scss)$": "<rootDir>/test/__mocks__/styleMock.ts"
+  }
 };
 
 export default config;

--- a/app/flashoffer-react/src/__tests__/components.test.tsx
+++ b/app/flashoffer-react/src/__tests__/components.test.tsx
@@ -5,6 +5,7 @@ import { HeroBanner } from "../components/HeroBanner";
 import { OutlineCtaButton } from "../components/OutlineCtaButton";
 import { PreviewCard } from "../components/PreviewCard";
 import { PrimaryCtaButton } from "../components/PrimaryCtaButton";
+import { Section } from "../components/Section";
 import { SectionHeader } from "../components/SectionHeader";
 import { useTheme } from "@mui/material/styles";
 import type { ReactElement } from "react";
@@ -74,19 +75,58 @@ describe("Flashoffer React primitives", () => {
   it("renders supporting components with defaults", () => {
     renderWithTheme(
       <>
+        <Section />
         <SectionHeader />
         <PreviewCard />
         <Footer />
       </>
     );
     expect(
-      screen.getByRole("heading", { level: 2, name: /reusable content blocks/i })
-    ).toBeInTheDocument();
+      screen.getAllByRole("heading", {
+        level: 2,
+        name: /reusable content blocks/i
+      })
+    ).toHaveLength(2);
     expect(
       screen.getByRole("heading", { level: 3, name: /preview a flashoffer/i })
     ).toBeInTheDocument();
     expect(screen.getByRole("contentinfo")).toBeInTheDocument();
     expect(screen.getAllByRole("link").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders supplied paragraphs inside section", () => {
+    renderWithTheme(
+      <Section
+        align="left"
+        title="Release highlights"
+        paragraphs={["First paragraph", "Second paragraph"]}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Release highlights" })
+    ).toBeVisible();
+    const paragraphs = screen.getAllByText(/paragraph$/);
+    expect(paragraphs).toHaveLength(2);
+    paragraphs.forEach((paragraph) => {
+      expect(paragraph.tagName.toLowerCase()).toBe("p");
+    });
+  });
+
+  it("applies themed palette colors to section copy", () => {
+    render(
+      <FlashofferThemeProvider
+        applyCssBaseline={false}
+        themeOptions={{
+          palette: { text: { primary: "#111827", secondary: "#0ea5e9" } }
+        }}
+      >
+        <Section title="Themed section" paragraphs={["Custom paragraph"]} />
+      </FlashofferThemeProvider>
+    );
+
+    const paragraph = screen.getByText("Custom paragraph");
+    expect(window.getComputedStyle(paragraph).color).toBe("rgb(14, 165, 233)");
   });
 
   it("supports Outline CTA default label", () => {

--- a/app/flashoffer-react/src/components/Section.tsx
+++ b/app/flashoffer-react/src/components/Section.tsx
@@ -1,0 +1,71 @@
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { useTheme } from "@mui/material/styles";
+import type { ReactNode } from "react";
+import { SectionHeader } from "./SectionHeader";
+import type { SectionHeaderProps } from "./SectionHeader";
+
+export interface SectionProps extends SectionHeaderProps {
+  /**
+   * Body copy rendered under the section header. Each entry is wrapped in a
+   * paragraph-level Typography component.
+   */
+  paragraphs?: ReactNode[];
+  /** Optional custom id applied to the underlying section element. */
+  id?: string;
+}
+
+const DEFAULT_PARAGRAPHS: ReactNode[] = [
+  "Flashoffer sections pair concise headlines with digestible copy blocks so " +
+    "marketing teams can narrate launches without bespoke layouts.",
+  "Swap the content as needed while retaining consistent spacing, typography, " +
+    "and accessible markup across campaigns."
+];
+
+/**
+ * High-level section wrapper that combines SectionHeader with supporting copy.
+ */
+export function Section({
+  paragraphs = DEFAULT_PARAGRAPHS,
+  align = "center",
+  id,
+  ...headerProps
+}: SectionProps) {
+  const theme = useTheme();
+  const hasParagraphs = paragraphs && paragraphs.length > 0;
+  const textAlign = align;
+  const alignItems = align === "center" ? "center" : "flex-start";
+  const paragraphColor = theme.palette.text.secondary;
+  const sectionTextColor = theme.palette.text.primary;
+  const paragraphMarginTop = theme.spacing(3);
+
+  return (
+    <Box component="section" id={id} sx={{ color: sectionTextColor }}>
+      <SectionHeader align={align} {...headerProps} />
+      {hasParagraphs ? (
+        <Stack
+          spacing={2}
+          sx={{
+            mt: paragraphMarginTop,
+            maxWidth: "65ch",
+            mx: align === "center" ? "auto" : undefined
+          }}
+          alignItems={alignItems}
+          textAlign={textAlign}
+        >
+          {paragraphs.map((paragraph, index) => (
+            <Typography
+              key={index}
+              component="p"
+              variant="body1"
+              sx={{ color: paragraphColor }}
+            >
+              {paragraph}
+            </Typography>
+          ))}
+        </Stack>
+      ) : null}
+    </Box>
+  );
+}

--- a/app/flashoffer-react/src/index.ts
+++ b/app/flashoffer-react/src/index.ts
@@ -13,6 +13,9 @@ export type { HeroBannerProps } from "./components/HeroBanner";
 export { SectionHeader } from "./components/SectionHeader";
 export type { SectionHeaderProps } from "./components/SectionHeader";
 
+export { Section } from "./components/Section";
+export type { SectionProps } from "./components/Section";
+
 export { PreviewCard } from "./components/PreviewCard";
 export type { PreviewCardProps } from "./components/PreviewCard";
 

--- a/app/flashoffer-react/test/__mocks__/styleMock.ts
+++ b/app/flashoffer-react/test/__mocks__/styleMock.ts
@@ -1,0 +1,1 @@
+export default {};


### PR DESCRIPTION
## Summary
- update Section to read palette and spacing from the Flashoffer theme provider
- cover the themed Section copy with a regression test

## Testing
- npm test -- --runTestsByPath src/__tests__/components.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd5082ba608321ac55c6d13f345bcc