### PR TITLE
Document Node.js package manifest policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@
   sync.
 - When modifying Flashoffer methods, ensure any text rendered to end users is
   configurable via function parameters.
+- Node.js projects: modify `package.json` and `package-lock.json` only when
+  the dependency list changes.
 
 ## Checker Scripts
 


### PR DESCRIPTION
## Summary
- document the policy for updating Node.js package manifest files only when dependencies change

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68dd53845e548321934a12c2a4a14dc0