### PR TITLE
Prevent AutoTrack hangs during dynamic theme changes

### DIFF
--- a/app/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer-demo/src/App.tsx
@@ -161,6 +161,11 @@ export default function App() {
     []
   );
 
+  const pageMeta = useMemo(
+    () => JSON.stringify({ palette: palettePreset }),
+    [palettePreset]
+  );
+
   return (
     <FlashofferThemeProvider themeOptions={themeOptions}>
       <Box
@@ -169,6 +174,9 @@ export default function App() {
           color: "var(--flashoffer-color-text-primary)",
           minHeight: "100vh"
         }}
+        data-track-id="flashoffer-demo-surface"
+        data-track-label="Flashoffer demo surface"
+        data-track-meta={pageMeta}
       >
         <Container maxWidth="lg" sx={{ py: { xs: 6, md: 10 } }}>
           <Stack spacing={10}>

--- a/app/flashoffer-react/src/analytics/AutoTrack.tsx
+++ b/app/flashoffer-react/src/analytics/AutoTrack.tsx
@@ -3,6 +3,13 @@ import { useEngagement } from "./EngagementProvider";
 
 const DEFAULT_SELECTOR = "[data-track-id]";
 
+const scheduleMicrotask =
+  typeof queueMicrotask === "function"
+    ? queueMicrotask
+    : (callback: () => void) => {
+        void Promise.resolve().then(callback);
+      };
+
 function parseMeta(element: HTMLElement): Record<string, unknown> {
   const meta: Record<string, unknown> = {};
   const label = element.getAttribute("data-track-label");
@@ -38,9 +45,13 @@ export function AutoTrack({ selector = DEFAULT_SELECTOR }: AutoTrackProps) {
     }
 
     const tracked = new Map<HTMLElement, () => void>();
+    const pendingConnects = new Set<HTMLElement>();
+    const pendingDisconnects = new Set<HTMLElement>();
+    let flushScheduled = false;
+    let disposed = false;
 
-    const connect = (element: Element | null) => {
-      if (!(element instanceof HTMLElement)) {
+    const connectNow = (element: Element | null) => {
+      if (!(element instanceof HTMLElement) || disposed) {
         return;
       }
       const trackId = element.getAttribute("data-track-id");
@@ -51,7 +62,7 @@ export function AutoTrack({ selector = DEFAULT_SELECTOR }: AutoTrackProps) {
       tracked.set(element, cleanup);
     };
 
-    const disconnect = (element: Element | null) => {
+    const disconnectNow = (element: Element | null) => {
       if (!(element instanceof HTMLElement)) {
         return;
       }
@@ -64,26 +75,89 @@ export function AutoTrack({ selector = DEFAULT_SELECTOR }: AutoTrackProps) {
       }
     };
 
+    const flushPending = () => {
+      if (disposed) {
+        pendingConnects.clear();
+        pendingDisconnects.clear();
+        return;
+      }
+      pendingDisconnects.forEach((element) => {
+        disconnectNow(element);
+      });
+      pendingDisconnects.clear();
+      pendingConnects.forEach((element) => {
+        connectNow(element);
+      });
+      pendingConnects.clear();
+    };
+
+    const scheduleFlush = () => {
+      if (flushScheduled || disposed) {
+        return;
+      }
+      flushScheduled = true;
+      scheduleMicrotask(() => {
+        flushScheduled = false;
+        flushPending();
+      });
+    };
+
+    const queueDisconnect = (
+      element: Element | null,
+      { preserve }: { preserve?: boolean } = {}
+    ) => {
+      if (!(element instanceof HTMLElement) || disposed) {
+        return;
+      }
+      if (!preserve) {
+        pendingConnects.delete(element);
+      }
+      pendingDisconnects.add(element);
+      scheduleFlush();
+    };
+
+    const queueConnect = (
+      element: Element | null,
+      { preserve }: { preserve?: boolean } = {}
+    ) => {
+      if (!(element instanceof HTMLElement) || disposed) {
+        return;
+      }
+      if (!preserve) {
+        pendingDisconnects.delete(element);
+      }
+      pendingConnects.add(element);
+      scheduleFlush();
+    };
+
+    const visitMatches = (
+      node: HTMLElement,
+      visitor: (element: HTMLElement) => void
+    ) => {
+      if (node.matches(selector)) {
+        visitor(node);
+      }
+      node.querySelectorAll(selector).forEach((child) => {
+        if (child instanceof HTMLElement) {
+          visitor(child);
+        }
+      });
+    };
+
     document.querySelectorAll(selector).forEach((node) => {
-      connect(node);
+      connectNow(node);
     });
 
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         mutation.addedNodes.forEach((node) => {
           if (node instanceof HTMLElement) {
-            if (node.matches(selector)) {
-              connect(node);
-            }
-            node.querySelectorAll(selector).forEach((child) => connect(child));
+            visitMatches(node, (element) => queueConnect(element));
           }
         });
         mutation.removedNodes.forEach((node) => {
           if (node instanceof HTMLElement) {
-            if (node.matches(selector)) {
-              disconnect(node);
-            }
-            node.querySelectorAll(selector).forEach((child) => disconnect(child));
+            visitMatches(node, (element) => queueDisconnect(element));
           }
         });
         if (
@@ -91,8 +165,14 @@ export function AutoTrack({ selector = DEFAULT_SELECTOR }: AutoTrackProps) {
           mutation.target instanceof HTMLElement &&
           mutation.target.matches(selector)
         ) {
-          disconnect(mutation.target);
-          connect(mutation.target);
+          queueDisconnect(mutation.target, { preserve: true });
+          queueConnect(mutation.target, { preserve: true });
+        } else if (
+          mutation.type === "attributes" &&
+          mutation.target instanceof HTMLElement &&
+          !mutation.target.matches(selector)
+        ) {
+          queueDisconnect(mutation.target);
         }
       });
     });
@@ -105,6 +185,10 @@ export function AutoTrack({ selector = DEFAULT_SELECTOR }: AutoTrackProps) {
     });
 
     return () => {
+      disposed = true;
+      flushScheduled = false;
+      pendingConnects.clear();
+      pendingDisconnects.clear();
       observer.disconnect();
       tracked.forEach((cleanup) => cleanup());
       tracked.clear();

--- a/app/flashoffer-react/src/analytics/EngagementProvider.tsx
+++ b/app/flashoffer-react/src/analytics/EngagementProvider.tsx
@@ -280,7 +280,10 @@ export function EngagementProvider({
       }
       trackedElementsRef.current.set(element, { trackId, meta });
       if (element instanceof HTMLElement) {
-        element.setAttribute("data-track-id", trackId);
+        const currentTrackId = element.getAttribute("data-track-id");
+        if (currentTrackId !== trackId) {
+          element.setAttribute("data-track-id", trackId);
+        }
       }
       observer.observe(element as Element);
       return () => detachElement(element);

--- a/app/flashoffer-react/src/analytics/__tests__/AutoTrack.test.tsx
+++ b/app/flashoffer-react/src/analytics/__tests__/AutoTrack.test.tsx
@@ -1,0 +1,70 @@
+import { render, waitFor } from "@testing-library/react";
+import AutoTrack from "../AutoTrack";
+
+const detachElement = jest.fn<void, [Element | null]>();
+const attachElement = jest.fn<
+  () => void,
+  [string, Element | null, Record<string, unknown> | undefined]
+>();
+
+jest.mock("../EngagementProvider", () => ({
+  useEngagement: () => ({
+    attachElement,
+    detachElement,
+  }),
+}));
+
+describe("AutoTrack", () => {
+  beforeEach(() => {
+    attachElement.mockReset();
+    detachElement.mockReset();
+    attachElement.mockImplementation((_, element) => () => {
+      detachElement(element);
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("reconnects tracked nodes once when metadata changes", async () => {
+    const container = document.createElement("div");
+    container.innerHTML = `
+      <div data-track-id="alpha" data-track-meta='{"palette":"ocean"}'></div>
+      <section data-track-id="beta" data-track-meta='{"palette":"ocean"}'>
+        <button data-track-id="beta-cta" data-track-meta='{"palette":"ocean"}'>CTA</button>
+      </section>
+    `;
+    document.body.appendChild(container);
+
+    const view = render(<AutoTrack />);
+
+    await waitFor(() => {
+      expect(attachElement).toHaveBeenCalledTimes(3);
+    });
+
+    attachElement.mockClear();
+    detachElement.mockClear();
+
+    const trackedNodes = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-track-id]")
+    );
+    trackedNodes.forEach((node, index) => {
+      node.setAttribute(
+        "data-track-meta",
+        JSON.stringify({ palette: "sunset", index })
+      );
+    });
+
+    await waitFor(() => {
+      expect(detachElement).toHaveBeenCalledTimes(trackedNodes.length);
+      expect(attachElement).toHaveBeenCalledTimes(trackedNodes.length);
+    });
+
+    await waitFor(() => {
+      expect(detachElement).toHaveBeenCalledTimes(trackedNodes.length);
+    });
+
+    view.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- batch AutoTrack connect and disconnect work to avoid detaching loops during rapid DOM churn
- skip redundant data-track-id writes and add demo surface tracking metadata for palette changes
- cover AutoTrack reattachment behaviour with a dedicated unit test

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dd5a3ee4188321903265cec25af6b4