### PR TITLE
Adjust midnight theme gradient for hero banner

### DIFF
--- a/app/flashoffer-demo/src/App.test.tsx
+++ b/app/flashoffer-demo/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import App from "./App";
 
 describe("Flashoffer demo", () => {
@@ -30,5 +30,34 @@ describe("Flashoffer demo", () => {
       screen.getAllByRole("link", { name: /explore flashoffer components/i }).length
     ).toBeGreaterThan(0);
     expect(screen.getAllByRole("article")).toHaveLength(3);
+  });
+
+  it("updates the hero banner gradient tokens for the midnight theme", async () => {
+    render(<App />);
+
+    const paletteSelect = screen.getByLabelText(/select theme palette/i);
+    fireEvent.change(paletteSelect, { target: { value: "midnight" } });
+
+    const heroBanner = await screen.findByRole("banner", {
+      name: /launch coordinated offers/i
+    });
+    const heroWrapper = document.querySelector(
+      '[data-track-id="hero-banner"]'
+    ) as HTMLElement | null;
+
+    expect(heroWrapper).not.toBeNull();
+
+    await waitFor(() => {
+      expect(
+        getComputedStyle(heroWrapper as HTMLElement).getPropertyValue(
+          "--flashoffer-hero-gradient-start"
+        ).trim()
+      ).toBe("#1e293b");
+      expect(
+        getComputedStyle(heroWrapper as HTMLElement).getPropertyValue(
+          "--flashoffer-hero-gradient-stop"
+        ).trim()
+      ).toBe("#0f172a");
+    });
   });
 });

--- a/app/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer-demo/src/App.tsx
@@ -121,6 +121,7 @@ export default function App() {
               heroAlignment={heroAlignment}
               heroMeta={heroMeta}
               heroMedia={heroMedia}
+              palettePreset={palettePreset}
             />
             <OverviewSection overviewMeta={overviewMeta} />
             <CtaShowcaseSection />

--- a/app/flashoffer-demo/src/sections/HeroShowcaseSection.tsx
+++ b/app/flashoffer-demo/src/sections/HeroShowcaseSection.tsx
@@ -1,24 +1,51 @@
 import Box from "@mui/material/Box";
 import { HeroBanner, Section } from "flashoffer-react";
 import type { ReactNode } from "react";
-import type { HeroAlignment } from "./types";
+import type { HeroAlignment, ThemePreset } from "./types";
+
+type HeroGradientVariable =
+  | "--flashoffer-hero-gradient-start"
+  | "--flashoffer-hero-gradient-stop";
+
+const HERO_GRADIENT_OVERRIDES: Record<
+  ThemePreset,
+  Partial<Record<HeroGradientVariable, string>>
+> = {
+  ocean: {
+    "--flashoffer-hero-gradient-start": "rgba(37, 99, 235, 0.08)",
+    "--flashoffer-hero-gradient-stop": "rgba(59, 130, 246, 0.16)"
+  },
+  sunset: {
+    "--flashoffer-hero-gradient-start": "rgba(249, 115, 22, 0.18)",
+    "--flashoffer-hero-gradient-stop": "rgba(234, 88, 12, 0.26)"
+  },
+  midnight: {
+    "--flashoffer-hero-gradient-start": "#1e293b",
+    "--flashoffer-hero-gradient-stop": "#0f172a"
+  }
+};
 
 export interface HeroShowcaseSectionProps {
   heroAlignment: HeroAlignment;
   heroMeta: string;
   heroMedia: ReactNode;
+  palettePreset: ThemePreset;
 }
 
 export function HeroShowcaseSection({
   heroAlignment,
   heroMeta,
-  heroMedia
+  heroMedia,
+  palettePreset
 }: HeroShowcaseSectionProps) {
+  const heroGradientOverrides = HERO_GRADIENT_OVERRIDES[palettePreset];
+
   return (
     <Box
       data-track-id="hero-banner"
       data-track-label="Hero banner"
       data-track-meta={heroMeta}
+      sx={heroGradientOverrides}
     >
       <HeroBanner
         align={heroAlignment}


### PR DESCRIPTION
## Summary
- update the hero showcase to publish palette-specific gradient tokens so the HeroBanner responds to the midnight preset
- pass the current palette through App and cover the midnight gradient behavior with a vitest check

## Testing
- `cd app/flashoffer-demo && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68dd5f11f384832183b5a280bc316292