### PR TITLE
feat: code-split flashoffer demo sections

### DIFF
--- a/app/flashoffer-demo/src/App.test.tsx
+++ b/app/flashoffer-demo/src/App.test.tsx
@@ -2,33 +2,33 @@ import { render, screen } from "@testing-library/react";
 import App from "./App";
 
 describe("Flashoffer demo", () => {
-  it("renders the hero banner from the component library", () => {
+  it("renders the hero banner from the component library", async () => {
     render(<App />);
 
-    expect(screen.getAllByRole("banner").length).toBeGreaterThan(0);
+    expect((await screen.findAllByRole("banner")).length).toBeGreaterThan(0);
     expect(
-      screen.getByRole("heading", {
+      await screen.findByRole("heading", {
         level: 1,
         name: /coordinated offers/i
       })
     ).toBeInTheDocument();
     expect(
-      screen.getAllByRole("link", { name: /explore flashoffer components/i }).length
+      (await screen.findAllByRole("link", { name: /explore flashoffer components/i })).length
     ).toBeGreaterThan(0);
   });
 
-  it("renders preview cards and CTA examples", () => {
+  it("renders preview cards and CTA examples", async () => {
     render(<App />);
 
     expect(
-      screen.getByRole("heading", {
+      await screen.findByRole("heading", {
         level: 2,
         name: /modular previews for any campaign/i
       })
     ).toBeInTheDocument();
     expect(
-      screen.getAllByRole("link", { name: /explore flashoffer components/i }).length
+      (await screen.findAllByRole("link", { name: /explore flashoffer components/i })).length
     ).toBeGreaterThan(0);
-    expect(screen.getAllByRole("article")).toHaveLength(3);
+    expect(await screen.findAllByRole("article")).toHaveLength(3);
   });
 });

--- a/app/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer-demo/src/App.tsx
@@ -2,21 +2,85 @@ import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Stack from "@mui/material/Stack";
 import type { ThemeOptions } from "@mui/material/styles";
-import { startTransition, useMemo, useState } from "react";
 import { FlashofferThemeProvider } from "flashoffer-react";
+import type { ComponentType } from "react";
 import {
-  CtaShowcaseSection,
-  CustomizationControlsSection,
-  FigureSpotlightSection,
-  FooterSection,
-  HeroShowcaseSection,
-  OverviewSection,
-  PreviewShowcaseSection,
-  type HeroAlignment,
-  type ThemePreset,
-  OVERVIEW_PARAGRAPHS,
-  PREVIEW_CARDS
-} from "./sections";
+  Suspense,
+  lazy,
+  startTransition,
+  useMemo,
+  useState
+} from "react";
+import type { CustomizationControlsSectionProps } from "./sections/CustomizationControlsSection";
+import type { HeroAlignment, ThemePreset } from "./sections/types";
+
+const CustomizationControlsSection = lazy(
+  () =>
+    import("./sections/CustomizationControlsSection").then((module) => ({
+      default: module.CustomizationControlsSection
+    })) as Promise<{
+      default: ComponentType<CustomizationControlsSectionProps>;
+    }>
+);
+
+const HeroShowcaseSection = lazy(() =>
+  import("./sections/HeroShowcaseSection").then((module) => ({
+    default: module.HeroShowcaseSection
+  }))
+);
+
+const OverviewSection = lazy(() =>
+  import("./sections/OverviewSection").then((module) => ({
+    default: module.OverviewSection
+  }))
+);
+
+const CtaShowcaseSection = lazy(() =>
+  import("./sections/CtaShowcaseSection").then((module) => ({
+    default: module.CtaShowcaseSection
+  }))
+);
+
+const PreviewShowcaseSection = lazy(() =>
+  import("./sections/PreviewShowcaseSection").then((module) => ({
+    default: module.PreviewShowcaseSection
+  }))
+);
+
+const FigureSpotlightSection = lazy(() =>
+  import("./sections/FigureSpotlightSection").then((module) => ({
+    default: module.FigureSpotlightSection
+  }))
+);
+
+const FooterSection = lazy(() =>
+  import("./sections/FooterSection").then((module) => ({
+    default: module.FooterSection
+  }))
+);
+
+function SectionPlaceholder({ label }: { label: string }) {
+  return (
+    <Box
+      component="section"
+      role="status"
+      aria-live="polite"
+      sx={{
+        borderRadius: 3,
+        border: "1px solid",
+        borderColor: "divider",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: 200,
+        color: "text.secondary",
+        typography: "body2"
+      }}
+    >
+      Loading {label}…
+    </Box>
+  );
+}
 
 const themePresets: Record<ThemePreset, ThemeOptions | undefined> = {
   ocean: undefined,
@@ -63,26 +127,6 @@ export default function App() {
     [palettePreset]
   );
 
-  const controlsMeta = useMemo(
-    () => JSON.stringify({ palette: palettePreset, heroAlignment }),
-    [heroAlignment, palettePreset]
-  );
-
-  const heroMeta = useMemo(
-    () => JSON.stringify({ alignment: heroAlignment, palette: palettePreset }),
-    [heroAlignment, palettePreset]
-  );
-
-  const previewMeta = useMemo(
-    () => JSON.stringify({ cards: PREVIEW_CARDS.length }),
-    []
-  );
-
-  const overviewMeta = useMemo(
-    () => JSON.stringify({ paragraphs: OVERVIEW_PARAGRAPHS.length }),
-    []
-  );
-
   const pageMeta = useMemo(
     () => JSON.stringify({ palette: palettePreset }),
     [palettePreset]
@@ -102,31 +146,44 @@ export default function App() {
       >
         <Container maxWidth="lg" sx={{ py: { xs: 6, md: 10 } }}>
           <Stack spacing={10}>
-            <CustomizationControlsSection
-              palettePreset={palettePreset}
-              onPalettePresetChange={(nextPreset) => {
-                startTransition(() => {
-                  setPalettePreset(nextPreset);
-                });
-              }}
-              heroAlignment={heroAlignment}
-              onHeroAlignmentChange={(nextAlignment) => {
-                startTransition(() => {
-                  setHeroAlignment(nextAlignment);
-                });
-              }}
-              controlsMeta={controlsMeta}
-            />
-            <HeroShowcaseSection
-              heroAlignment={heroAlignment}
-              heroMeta={heroMeta}
-              heroMedia={heroMedia}
-            />
-            <OverviewSection overviewMeta={overviewMeta} />
-            <CtaShowcaseSection />
-            <PreviewShowcaseSection previewMeta={previewMeta} />
-            <FigureSpotlightSection />
-            <FooterSection />
+            <Suspense fallback={<SectionPlaceholder label="Customization controls" />}>
+              <CustomizationControlsSection
+                palettePreset={palettePreset}
+                onPalettePresetChange={(nextPreset) => {
+                  startTransition(() => {
+                    setPalettePreset(nextPreset);
+                  });
+                }}
+                heroAlignment={heroAlignment}
+                onHeroAlignmentChange={(nextAlignment) => {
+                  startTransition(() => {
+                    setHeroAlignment(nextAlignment);
+                  });
+                }}
+              />
+            </Suspense>
+            <Suspense fallback={<SectionPlaceholder label="Hero" />}>
+              <HeroShowcaseSection
+                heroAlignment={heroAlignment}
+                heroMedia={heroMedia}
+                palettePreset={palettePreset}
+              />
+            </Suspense>
+            <Suspense fallback={<SectionPlaceholder label="Overview" />}>
+              <OverviewSection />
+            </Suspense>
+            <Suspense fallback={<SectionPlaceholder label="CTA showcase" />}>
+              <CtaShowcaseSection />
+            </Suspense>
+            <Suspense fallback={<SectionPlaceholder label="Preview cards" />}>
+              <PreviewShowcaseSection />
+            </Suspense>
+            <Suspense fallback={<SectionPlaceholder label="Figure spotlight" />}>
+              <FigureSpotlightSection />
+            </Suspense>
+            <Suspense fallback={<SectionPlaceholder label="Footer" />}>
+              <FooterSection />
+            </Suspense>
           </Stack>
         </Container>
       </Box>

--- a/app/flashoffer-demo/src/sections/CustomizationControlsSection.tsx
+++ b/app/flashoffer-demo/src/sections/CustomizationControlsSection.tsx
@@ -4,6 +4,7 @@ import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { Section } from "flashoffer-react";
+import { useMemo } from "react";
 import type { HeroAlignment, ThemePreset } from "./types";
 
 export interface CustomizationControlsSectionProps {
@@ -11,16 +12,19 @@ export interface CustomizationControlsSectionProps {
   onPalettePresetChange: (nextPreset: ThemePreset) => void;
   heroAlignment: HeroAlignment;
   onHeroAlignmentChange: (nextAlignment: HeroAlignment) => void;
-  controlsMeta: string;
 }
 
 export function CustomizationControlsSection({
   palettePreset,
   onPalettePresetChange,
   heroAlignment,
-  onHeroAlignmentChange,
-  controlsMeta
+  onHeroAlignmentChange
 }: CustomizationControlsSectionProps) {
+  const controlsMeta = useMemo(
+    () => JSON.stringify({ palette: palettePreset, heroAlignment }),
+    [heroAlignment, palettePreset]
+  );
+
   return (
     <Paper
       elevation={0}

--- a/app/flashoffer-demo/src/sections/HeroShowcaseSection.tsx
+++ b/app/flashoffer-demo/src/sections/HeroShowcaseSection.tsx
@@ -1,19 +1,25 @@
 import Box from "@mui/material/Box";
 import { HeroBanner, Section } from "flashoffer-react";
+import { useMemo } from "react";
 import type { ReactNode } from "react";
-import type { HeroAlignment } from "./types";
+import type { HeroAlignment, ThemePreset } from "./types";
 
 export interface HeroShowcaseSectionProps {
   heroAlignment: HeroAlignment;
-  heroMeta: string;
   heroMedia: ReactNode;
+  palettePreset: ThemePreset;
 }
 
 export function HeroShowcaseSection({
   heroAlignment,
-  heroMeta,
-  heroMedia
+  heroMedia,
+  palettePreset
 }: HeroShowcaseSectionProps) {
+  const heroMeta = useMemo(
+    () => JSON.stringify({ alignment: heroAlignment, palette: palettePreset }),
+    [heroAlignment, palettePreset]
+  );
+
   return (
     <Box
       data-track-id="hero-banner"

--- a/app/flashoffer-demo/src/sections/OverviewSection.tsx
+++ b/app/flashoffer-demo/src/sections/OverviewSection.tsx
@@ -6,11 +6,9 @@ const OVERVIEW_PARAGRAPHS = [
   "Each paragraph is wrapped in semantic markup and inherits spacing from the Flashoffer design tokens, so marketing teams can focus on messaging."
 ];
 
-export interface OverviewSectionProps {
-  overviewMeta: string;
-}
+export function OverviewSection() {
+  const overviewMeta = JSON.stringify({ paragraphs: OVERVIEW_PARAGRAPHS.length });
 
-export function OverviewSection({ overviewMeta }: OverviewSectionProps) {
   return (
     <Box
       data-track-id="overview-section"

--- a/app/flashoffer-demo/src/sections/PreviewShowcaseSection.tsx
+++ b/app/flashoffer-demo/src/sections/PreviewShowcaseSection.tsx
@@ -57,11 +57,9 @@ function toTrackId(value: string): string {
     .replace(/-{2,}/g, "-");
 }
 
-export interface PreviewShowcaseSectionProps {
-  previewMeta: string;
-}
+export function PreviewShowcaseSection() {
+  const previewMeta = JSON.stringify({ cards: PREVIEW_CARDS.length });
 
-export function PreviewShowcaseSection({ previewMeta }: PreviewShowcaseSectionProps) {
   return (
     <Box
       component="section"


### PR DESCRIPTION
## Summary
- lazy load the Flashoffer demo sections and add placeholders so each chunk loads on demand
- localize section tracking metadata calculations to reduce eager imports during boot
- update the demo tests to await lazy loaded content and confirm bundling succeeds

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd5f4e7a1483218a1d801c667da6ee