### PR TITLE
flashoffer-react: halt engagement after consecutive failures

### DIFF
--- a/app/flashoffer-react/src/analytics/EngagementProvider.tsx
+++ b/app/flashoffer-react/src/analytics/EngagementProvider.tsx
@@ -9,6 +9,8 @@ import {
 } from "react";
 import type { ElementType, ReactNode } from "react";
 
+const MAX_CONSECUTIVE_FAILURES = 10;
+
 export interface EngagementEvent {
   type: string;
   target: string;
@@ -109,6 +111,35 @@ export function EngagementProvider({
   const intersectionHandlerRef = useRef<
     (entries: IntersectionObserverEntry[]) => void
   >(() => undefined);
+  const failureCountRef = useRef(0);
+  const disabledRef = useRef(false);
+
+  const disableTracking = useCallback(() => {
+    if (disabledRef.current) {
+      return;
+    }
+    disabledRef.current = true;
+    queueRef.current = [];
+    trackedElementsRef.current.clear();
+    activeTargetsRef.current.clear();
+    activeViewsRef.current.clear();
+    failureCountRef.current = 0;
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    }
+  }, []);
+
+  const registerFailure = useCallback(() => {
+    failureCountRef.current += 1;
+    if (failureCountRef.current >= MAX_CONSECUTIVE_FAILURES) {
+      disableTracking();
+    }
+  }, [disableTracking]);
+
+  const resetFailure = useCallback(() => {
+    failureCountRef.current = 0;
+  }, []);
 
   useEffect(() => {
     maxBatchRef.current = maxBatch;
@@ -116,6 +147,9 @@ export function EngagementProvider({
 
   const enqueue = useCallback(
     (event: EngagementEvent) => {
+      if (disabledRef.current) {
+        return;
+      }
       queueRef.current.push(event);
       if (queueRef.current.length >= maxBatchRef.current) {
         flushRef.current?.("capacity");
@@ -126,6 +160,14 @@ export function EngagementProvider({
 
   const flush = useCallback(
     async (reason = "interval", { sync = false }: { sync?: boolean } = {}) => {
+      if (disabledRef.current) {
+        queueRef.current = [];
+        return;
+      }
+      if (failureCountRef.current >= MAX_CONSECUTIVE_FAILURES) {
+        disableTracking();
+        return;
+      }
       if (!endpoint || queueRef.current.length === 0) {
         return;
       }
@@ -139,7 +181,12 @@ export function EngagementProvider({
       if (sync && typeof navigator !== "undefined" && "sendBeacon" in navigator) {
         const ok = navigator.sendBeacon(endpoint, body);
         if (!ok) {
-          queueRef.current.unshift(...events);
+          registerFailure();
+          if (!disabledRef.current) {
+            queueRef.current.unshift(...events);
+          }
+        } else {
+          resetFailure();
         }
         return;
       }
@@ -154,13 +201,17 @@ export function EngagementProvider({
         if (!response.ok) {
           throw new Error(`Unexpected status ${response.status}`);
         }
+        resetFailure();
       } catch (error) {
         // eslint-disable-next-line no-console
         console.warn("Failed to flush engagement events", error);
-        queueRef.current.unshift(...events);
+        registerFailure();
+        if (!disabledRef.current) {
+          queueRef.current.unshift(...events);
+        }
       }
     },
-    [endpoint, site]
+    [disableTracking, endpoint, registerFailure, resetFailure, site]
   );
 
   useEffect(() => {
@@ -199,6 +250,9 @@ export function EngagementProvider({
   }, []);
 
   const ensureObserver = useCallback(() => {
+    if (disabledRef.current) {
+      return null;
+    }
     if (observerRef.current) {
       return observerRef.current;
     }
@@ -215,6 +269,9 @@ export function EngagementProvider({
   }, []);
 
   intersectionHandlerRef.current = (entries: IntersectionObserverEntry[]) => {
+    if (disabledRef.current) {
+      return;
+    }
     const timestamp = typeof performance !== "undefined" ? performance.now() : 0;
     entries.forEach((entry) => {
       const info = trackedElementsRef.current.get(entry.target);
@@ -268,6 +325,9 @@ export function EngagementProvider({
 
   const attachElement = useCallback(
     (trackId: string, element: Element | null, meta: Record<string, unknown> = {}) => {
+      if (disabledRef.current) {
+        return () => undefined;
+      }
       if (!trackId || !element) {
         return () => undefined;
       }
@@ -299,6 +359,9 @@ export function EngagementProvider({
 
   const recordInteraction = useCallback(
     (target: string, data: Record<string, unknown> = {}) => {
+      if (disabledRef.current) {
+        return;
+      }
       if (!target) {
         return;
       }

--- a/app/flashoffer-react/src/analytics/__tests__/EngagementProvider.test.tsx
+++ b/app/flashoffer-react/src/analytics/__tests__/EngagementProvider.test.tsx
@@ -1,0 +1,95 @@
+import { act, render } from "@testing-library/react";
+import type { MutableRefObject } from "react";
+import {
+  EngagementProvider,
+  useRecordInteraction,
+} from "../EngagementProvider";
+
+type RecordFn = (target?: string, meta?: Record<string, unknown>) => void;
+
+function Recorder({
+  recordRef,
+}: {
+  recordRef: MutableRefObject<RecordFn>;
+}) {
+  recordRef.current = useRecordInteraction();
+  return null;
+}
+
+type GlobalWithOptionalFetch = typeof globalThis & { fetch?: typeof fetch };
+
+describe("EngagementProvider connection failure handling", () => {
+  const globalScope = globalThis as GlobalWithOptionalFetch;
+  const originalFetch = globalScope.fetch;
+  let fetchMock: jest.MockedFunction<typeof fetch>;
+  beforeEach(() => {
+    fetchMock = jest
+      .fn(async () => {
+        throw new Error("network failure");
+      })
+      .mockName("fetch") as jest.MockedFunction<typeof fetch>;
+    globalScope.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalScope.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("stops sending events after 10 consecutive connection failures", async () => {
+    const recordRef = {
+      current: (() => undefined) as RecordFn,
+    } as MutableRefObject<RecordFn>;
+
+    const view = render(
+      <EngagementProvider
+        endpoint="/engagement"
+        site="test"
+        maxBatch={1}
+        flushInterval={null}
+        heartbeatInterval={60_000}
+        idleTimeout={60_000}
+        scrollThresholds={[]}
+        viewThresholds={[]}
+      >
+        <Recorder recordRef={recordRef} />
+      </EngagementProvider>
+    );
+
+    const expectFetchIncrease = async (run: () => void) => {
+      const before = fetchMock.mock.calls.length;
+      await act(async () => {
+        run();
+        await Promise.resolve();
+      });
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(before);
+    };
+
+    const expectNoFetchIncrease = async (run: () => void) => {
+      const before = fetchMock.mock.calls.length;
+      await act(async () => {
+        run();
+        await Promise.resolve();
+      });
+      expect(fetchMock.mock.calls.length).toBe(before);
+    };
+
+    for (let i = 0; i < 10; i += 1) {
+      await expectFetchIncrease(() => {
+        recordRef.current(`event-${i}`);
+      });
+    }
+
+    fetchMock.mockClear();
+
+    await expectNoFetchIncrease(() => {
+      recordRef.current("post-failure");
+    });
+
+    await expectNoFetchIncrease(() => {
+      recordRef.current("post-failure-2");
+    });
+
+    view.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the connection timeout tracking with a cap of 10 consecutive flush failures before disabling engagement calls
- avoid requeueing events once the provider has been disabled so suppressed queues stay empty
- update the regression test to simulate 10 failed requests and verify further interactions skip remote calls

## Testing
- cd app/flashoffer-react && npx jest --runInBand src/analytics/__tests__/EngagementProvider.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd5ed6f9f4832180db2e8101358c8b