### PR TITLE
flashoffer-demo: code-split sections with React.lazy

### DIFF
--- a/app/flashoffer-demo/src/App.test.tsx
+++ b/app/flashoffer-demo/src/App.test.tsx
@@ -2,45 +2,50 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import App from "./App";
 
 describe("Flashoffer demo", () => {
-  it("renders the hero banner from the component library", () => {
+  it("renders the hero banner from the component library", async () => {
     render(<App />);
 
-    expect(screen.getAllByRole("banner").length).toBeGreaterThan(0);
+    const heroBanners = await screen.findAllByRole("banner");
+    expect(heroBanners.length).toBeGreaterThan(0);
     expect(
-      screen.getByRole("heading", {
+      await screen.findByRole("heading", {
         level: 1,
         name: /coordinated offers/i
       })
     ).toBeInTheDocument();
-    expect(
-      screen.getAllByRole("link", { name: /explore flashoffer components/i }).length
-    ).toBeGreaterThan(0);
+    const primaryCtas = await screen.findAllByRole("link", {
+      name: /explore flashoffer components/i
+    });
+    expect(primaryCtas.length).toBeGreaterThan(0);
   });
 
-  it("renders preview cards and CTA examples", () => {
+  it("renders preview cards and CTA examples", async () => {
     render(<App />);
 
     expect(
-      screen.getByRole("heading", {
+      await screen.findByRole("heading", {
         level: 2,
         name: /modular previews for any campaign/i
       })
     ).toBeInTheDocument();
-    expect(
-      screen.getAllByRole("link", { name: /explore flashoffer components/i }).length
-    ).toBeGreaterThan(0);
-    expect(screen.getAllByRole("article")).toHaveLength(3);
+    const previewLinks = await screen.findAllByRole("link", {
+      name: /explore flashoffer components/i
+    });
+    expect(previewLinks.length).toBeGreaterThan(0);
+    const previewCards = await screen.findAllByRole("article");
+    expect(previewCards).toHaveLength(3);
   });
 
   it("updates the hero banner gradient tokens for the midnight theme", async () => {
     render(<App />);
 
-    const paletteSelect = screen.getByLabelText(/select theme palette/i);
+    const paletteSelect = await screen.findByLabelText(/select theme palette/i);
     fireEvent.change(paletteSelect, { target: { value: "midnight" } });
 
     const heroBanner = await screen.findByRole("banner", {
       name: /launch coordinated offers/i
     });
+    expect(heroBanner).toBeInTheDocument();
     const heroWrapper = document.querySelector(
       '[data-track-id="hero-banner"]'
     ) as HTMLElement | null;

--- a/app/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer-demo/src/App.tsx
@@ -2,21 +2,38 @@ import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Stack from "@mui/material/Stack";
 import type { ThemeOptions } from "@mui/material/styles";
-import { startTransition, useMemo, useState } from "react";
+import { Suspense, lazy, startTransition, useMemo, useState } from "react";
 import { FlashofferThemeProvider } from "flashoffer-react";
-import {
-  CtaShowcaseSection,
-  CustomizationControlsSection,
-  FigureSpotlightSection,
-  FooterSection,
-  HeroShowcaseSection,
-  OverviewSection,
-  PreviewShowcaseSection,
-  type HeroAlignment,
-  type ThemePreset,
-  OVERVIEW_PARAGRAPHS,
-  PREVIEW_CARDS
-} from "./sections";
+import type { HeroAlignment, ThemePreset } from "./sections/types";
+import { OVERVIEW_PARAGRAPHS, PREVIEW_CARDS } from "./sections/content";
+
+const CustomizationControlsSection = lazy(async () => ({
+  default: (await import("./sections/CustomizationControlsSection")).CustomizationControlsSection
+}));
+
+const HeroShowcaseSection = lazy(async () => ({
+  default: (await import("./sections/HeroShowcaseSection")).HeroShowcaseSection
+}));
+
+const OverviewSection = lazy(async () => ({
+  default: (await import("./sections/OverviewSection")).OverviewSection
+}));
+
+const CtaShowcaseSection = lazy(async () => ({
+  default: (await import("./sections/CtaShowcaseSection")).CtaShowcaseSection
+}));
+
+const PreviewShowcaseSection = lazy(async () => ({
+  default: (await import("./sections/PreviewShowcaseSection")).PreviewShowcaseSection
+}));
+
+const FigureSpotlightSection = lazy(async () => ({
+  default: (await import("./sections/FigureSpotlightSection")).FigureSpotlightSection
+}));
+
+const FooterSection = lazy(async () => ({
+  default: (await import("./sections/FooterSection")).FooterSection
+}));
 
 const themePresets: Record<ThemePreset, ThemeOptions | undefined> = {
   ocean: undefined,
@@ -102,32 +119,46 @@ export default function App() {
       >
         <Container maxWidth="lg" sx={{ py: { xs: 6, md: 10 } }}>
           <Stack spacing={10}>
-            <CustomizationControlsSection
-              palettePreset={palettePreset}
-              onPalettePresetChange={(nextPreset) => {
-                startTransition(() => {
-                  setPalettePreset(nextPreset);
-                });
-              }}
-              heroAlignment={heroAlignment}
-              onHeroAlignmentChange={(nextAlignment) => {
-                startTransition(() => {
-                  setHeroAlignment(nextAlignment);
-                });
-              }}
-              controlsMeta={controlsMeta}
-            />
-            <HeroShowcaseSection
-              heroAlignment={heroAlignment}
-              heroMeta={heroMeta}
-              heroMedia={heroMedia}
-              palettePreset={palettePreset}
-            />
-            <OverviewSection overviewMeta={overviewMeta} />
-            <CtaShowcaseSection />
-            <PreviewShowcaseSection previewMeta={previewMeta} />
-            <FigureSpotlightSection />
-            <FooterSection />
+            <Suspense fallback={null}>
+              <CustomizationControlsSection
+                palettePreset={palettePreset}
+                onPalettePresetChange={(nextPreset) => {
+                  startTransition(() => {
+                    setPalettePreset(nextPreset);
+                  });
+                }}
+                heroAlignment={heroAlignment}
+                onHeroAlignmentChange={(nextAlignment) => {
+                  startTransition(() => {
+                    setHeroAlignment(nextAlignment);
+                  });
+                }}
+                controlsMeta={controlsMeta}
+              />
+            </Suspense>
+            <Suspense fallback={null}>
+              <HeroShowcaseSection
+                heroAlignment={heroAlignment}
+                heroMeta={heroMeta}
+                heroMedia={heroMedia}
+                palettePreset={palettePreset}
+              />
+            </Suspense>
+            <Suspense fallback={null}>
+              <OverviewSection overviewMeta={overviewMeta} />
+            </Suspense>
+            <Suspense fallback={null}>
+              <CtaShowcaseSection />
+            </Suspense>
+            <Suspense fallback={null}>
+              <PreviewShowcaseSection previewMeta={previewMeta} />
+            </Suspense>
+            <Suspense fallback={null}>
+              <FigureSpotlightSection />
+            </Suspense>
+            <Suspense fallback={null}>
+              <FooterSection />
+            </Suspense>
           </Stack>
         </Container>
       </Box>

--- a/app/flashoffer-demo/src/sections/OverviewSection.tsx
+++ b/app/flashoffer-demo/src/sections/OverviewSection.tsx
@@ -1,10 +1,6 @@
 import Box from "@mui/material/Box";
 import { Section } from "flashoffer-react";
-
-const OVERVIEW_PARAGRAPHS = [
-  "Use the Section component to pair launch announcements, feature guides, or changelog summaries with consistent typography.",
-  "Each paragraph is wrapped in semantic markup and inherits spacing from the Flashoffer design tokens, so marketing teams can focus on messaging."
-];
+import { OVERVIEW_PARAGRAPHS } from "./content";
 
 export interface OverviewSectionProps {
   overviewMeta: string;

--- a/app/flashoffer-demo/src/sections/PreviewShowcaseSection.tsx
+++ b/app/flashoffer-demo/src/sections/PreviewShowcaseSection.tsx
@@ -1,53 +1,7 @@
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
 import { PreviewCard, Section } from "flashoffer-react";
-
-const PREVIEW_CARDS = [
-  {
-    title: "Personalized launch offers",
-    description:
-      "Highlight tailored bundles that can be activated in a few clicks. Swap copy and imagery to match your latest campaign without rebuilding layouts.",
-    media: (
-      <img
-        src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=480&q=80"
-        alt="Two teammates collaborating over a laptop"
-        style={{ width: "100%", borderRadius: "16px" }}
-      />
-    )
-  },
-  {
-    title: "Lifecycle automation",
-    description:
-      "Pair Flashoffer pages with your automation stack to trigger discounts or add-ons in response to usage signals.",
-    media: (
-      <img
-        src="https://images.unsplash.com/photo-1527430253228-e93688616381?auto=format&fit=crop&w=480&q=80"
-        alt="Abstract dashboard charts"
-        style={{ width: "100%", borderRadius: "16px" }}
-      />
-    ),
-    secondaryCta: {
-      label: "View playbook",
-      href: "https://example.com/playbook"
-    }
-  },
-  {
-    title: "Localized experiences",
-    description:
-      "Clone the same structure across regions while tuning content, pricing, and compliance disclosures in minutes.",
-    media: (
-      <img
-        src="https://images.unsplash.com/photo-1521292270410-a8c6788e40cc?auto=format&fit=crop&w=480&q=80"
-        alt="Color swatches and typography samples"
-        style={{ width: "100%", borderRadius: "16px" }}
-      />
-    ),
-    primaryCta: {
-      label: "See localization tips",
-      href: "https://example.com/localization"
-    }
-  }
-];
+import { PREVIEW_CARDS } from "./content";
 
 function toTrackId(value: string): string {
   return value

--- a/app/flashoffer-demo/src/sections/content.tsx
+++ b/app/flashoffer-demo/src/sections/content.tsx
@@ -1,0 +1,51 @@
+export const OVERVIEW_PARAGRAPHS = [
+  "Use the Section component to pair launch announcements, feature guides, or changelog summaries with consistent typography.",
+  "Each paragraph is wrapped in semantic markup and inherits spacing from the Flashoffer design tokens, so marketing teams can focus on messaging."
+];
+
+export const PREVIEW_CARDS = [
+  {
+    title: "Personalized launch offers",
+    description:
+      "Highlight tailored bundles that can be activated in a few clicks. Swap copy and imagery to match your latest campaign without rebuilding layouts.",
+    media: (
+      <img
+        src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=480&q=80"
+        alt="Two teammates collaborating over a laptop"
+        style={{ width: "100%", borderRadius: "16px" }}
+      />
+    )
+  },
+  {
+    title: "Lifecycle automation",
+    description:
+      "Pair Flashoffer pages with your automation stack to trigger discounts or add-ons in response to usage signals.",
+    media: (
+      <img
+        src="https://images.unsplash.com/photo-1527430253228-e93688616381?auto=format&fit=crop&w=480&q=80"
+        alt="Abstract dashboard charts"
+        style={{ width: "100%", borderRadius: "16px" }}
+      />
+    ),
+    secondaryCta: {
+      label: "View playbook",
+      href: "https://example.com/playbook"
+    }
+  },
+  {
+    title: "Localized experiences",
+    description:
+      "Clone the same structure across regions while tuning content, pricing, and compliance disclosures in minutes.",
+    media: (
+      <img
+        src="https://images.unsplash.com/photo-1521292270410-a8c6788e40cc?auto=format&fit=crop&w=480&q=80"
+        alt="Color swatches and typography samples"
+        style={{ width: "100%", borderRadius: "16px" }}
+      />
+    ),
+    primaryCta: {
+      label: "See localization tips",
+      href: "https://example.com/localization"
+    }
+  }
+];


### PR DESCRIPTION
## Summary
- lazily load each demo section in the Flashoffer showcase to enable route-level code splitting
- extract shared section copy into a content module so meta calculations remain eager without loading components
- update Vitest expectations to wait for Suspense boundaries before asserting on the DOM

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dd618e278883219b600d1540b8bc13