### PR TITLE
Add TypeDoc documentation for flashoffer React components

### DIFF
--- a/app/flashoffer-react/README.md
+++ b/app/flashoffer-react/README.md
@@ -163,6 +163,20 @@ export function LandingWithAnalytics() {
   events and renders them inside a developer-focused console, which is helpful
   when verifying instrumentation in staging environments.
 
+## API documentation
+
+Run the TypeDoc pipeline to generate Markdown reference files for every
+component and helper exported from the library. The output lands in
+`docs/reference/flashoffer-react` so the Press documentation build can surface
+the latest props and usage guidance.
+
+```bash
+npm run docs
+```
+
+The command reads configuration from `typedoc.json` and reuses the standard
+TypeScript project settings defined in `tsconfig.docs.json`.
+
 ## Development
 
 - `npm test`: run Jest and React Testing Library suites.

--- a/app/flashoffer-react/dep.mk
+++ b/app/flashoffer-react/dep.mk
@@ -6,6 +6,11 @@ ALL_FLASHOFFER_ASSETS := \
         build/static/js/flashoffer-react.cjs.js \
         build/types/flashoffer-react/index.d.ts
 
+FLASHOFFER_TYPEDOC_STAMP := app/flashoffer-react/.typedoc
+
+.PHONY: docs
+docs: $(FLASHOFFER_TYPEDOC_STAMP)
+
 all: $(ALL_FLASHOFFER_ASSETS)
 
 build/static/js:
@@ -35,9 +40,17 @@ app/flashoffer-react/.built: app/flashoffer-react/.init \
         app/flashoffer-react/tsconfig.json \
         app/flashoffer-react/tsconfig.node.json \
         app/flashoffer-react/package.json
-	cd app/flashoffer-react; npm run build
-	touch $@
+        cd app/flashoffer-react; npm run build
+        touch $@
 
 app/flashoffer-react/.init:
-	cd app/flashoffer-react; npm install
-	touch $@
+        cd app/flashoffer-react; npm install
+        touch $@
+
+$(FLASHOFFER_TYPEDOC_STAMP): app/flashoffer-react/.init \
+        $(wildcard app/flashoffer-react/src/**/*) \
+        app/flashoffer-react/package.json \
+        app/flashoffer-react/typedoc.json \
+        app/flashoffer-react/tsconfig.docs.json
+        cd app/flashoffer-react; npm run docs
+        touch $@

--- a/app/flashoffer-react/docs/reference/flashoffer-react/README.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/README.md
@@ -1,0 +1,47 @@
+**flashoffer-react**
+
+***
+
+# flashoffer-react
+
+## Interfaces
+
+- [AutoTrackProps](interfaces/AutoTrackProps.md)
+- [EngagementEvent](interfaces/EngagementEvent.md)
+- [EngagementProviderProps](interfaces/EngagementProviderProps.md)
+- [EngagementContextValue](interfaces/EngagementContextValue.md)
+- [ViewTrackerProps](interfaces/ViewTrackerProps.md)
+- [EventConsoleProps](interfaces/EventConsoleProps.md)
+- [FigureProps](interfaces/FigureProps.md)
+- [FooterLink](interfaces/FooterLink.md)
+- [FooterProps](interfaces/FooterProps.md)
+- [HeroBannerProps](interfaces/HeroBannerProps.md)
+- [PreviewCardProps](interfaces/PreviewCardProps.md)
+- [SectionProps](interfaces/SectionProps.md)
+- [SectionHeaderProps](interfaces/SectionHeaderProps.md)
+- [FlashofferThemeProviderProps](interfaces/FlashofferThemeProviderProps.md)
+
+## Type Aliases
+
+- [OutlineCtaButtonProps](type-aliases/OutlineCtaButtonProps.md)
+- [PrimaryCtaButtonProps](type-aliases/PrimaryCtaButtonProps.md)
+
+## Functions
+
+- [AutoTrack](functions/AutoTrack.md)
+- [EngagementProvider](functions/EngagementProvider.md)
+- [useEngagement](functions/useEngagement.md)
+- [useViewTracker](functions/useViewTracker.md)
+- [ViewTracker](functions/ViewTracker.md)
+- [useRecordInteraction](functions/useRecordInteraction.md)
+- [EventConsole](functions/EventConsole.md)
+- [Figure](functions/Figure.md)
+- [Footer](functions/Footer.md)
+- [HeroBanner](functions/HeroBanner.md)
+- [OutlineCtaButton](functions/OutlineCtaButton.md)
+- [PreviewCard](functions/PreviewCard.md)
+- [PrimaryCtaButton](functions/PrimaryCtaButton.md)
+- [Section](functions/Section.md)
+- [SectionHeader](functions/SectionHeader.md)
+- [createFlashofferTheme](functions/createFlashofferTheme.md)
+- [FlashofferThemeProvider](functions/FlashofferThemeProvider.md)

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/AutoTrack.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/AutoTrack.md
@@ -1,0 +1,19 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: AutoTrack()
+
+> **AutoTrack**(`__namedParameters`): `null`
+
+Defined in: src/analytics/AutoTrack.tsx:39
+
+## Parameters
+
+### \_\_namedParameters
+
+[`AutoTrackProps`](../interfaces/AutoTrackProps.md)
+
+## Returns
+
+`null`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/EngagementProvider.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/EngagementProvider.md
@@ -1,0 +1,19 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: EngagementProvider()
+
+> **EngagementProvider**(`__namedParameters`): `Element`
+
+Defined in: src/analytics/EngagementProvider.tsx:84
+
+## Parameters
+
+### \_\_namedParameters
+
+[`EngagementProviderProps`](../interfaces/EngagementProviderProps.md)
+
+## Returns
+
+`Element`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/EventConsole.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/EventConsole.md
@@ -1,0 +1,19 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: EventConsole()
+
+> **EventConsole**(`__namedParameters`): `Element`
+
+Defined in: src/analytics/EventConsole.tsx:55
+
+## Parameters
+
+### \_\_namedParameters
+
+[`EventConsoleProps`](../interfaces/EventConsoleProps.md)
+
+## Returns
+
+`Element`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/Figure.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/Figure.md
@@ -1,0 +1,21 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: Figure()
+
+> **Figure**(`__namedParameters`): `Element`
+
+Defined in: src/components/Figure.tsx:22
+
+Responsive image container with optional caption support.
+
+## Parameters
+
+### \_\_namedParameters
+
+[`FigureProps`](../interfaces/FigureProps.md)
+
+## Returns
+
+`Element`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/FlashofferThemeProvider.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/FlashofferThemeProvider.md
@@ -1,0 +1,21 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: FlashofferThemeProvider()
+
+> **FlashofferThemeProvider**(`__namedParameters`): `Element`
+
+Defined in: src/theme/FlashofferThemeProvider.tsx:92
+
+Theme provider exposing CSS-token aware defaults for Flashoffer surfaces.
+
+## Parameters
+
+### \_\_namedParameters
+
+[`FlashofferThemeProviderProps`](../interfaces/FlashofferThemeProviderProps.md)
+
+## Returns
+
+`Element`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/Footer.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/Footer.md
@@ -1,0 +1,21 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: Footer()
+
+> **Footer**(`__namedParameters`): `Element`
+
+Defined in: src/components/Footer.tsx:32
+
+Footer component that renders navigation links and attribution text.
+
+## Parameters
+
+### \_\_namedParameters
+
+[`FooterProps`](../interfaces/FooterProps.md)
+
+## Returns
+
+`Element`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/HeroBanner.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/HeroBanner.md
@@ -1,0 +1,21 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: HeroBanner()
+
+> **HeroBanner**(`__namedParameters`): `Element`
+
+Defined in: src/components/HeroBanner.tsx:34
+
+Promotional hero unit with sensible defaults for copy and layout.
+
+## Parameters
+
+### \_\_namedParameters
+
+[`HeroBannerProps`](../interfaces/HeroBannerProps.md)
+
+## Returns
+
+`Element`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/OutlineCtaButton.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/OutlineCtaButton.md
@@ -1,0 +1,21 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: OutlineCtaButton()
+
+> **OutlineCtaButton**(`__namedParameters`): `Element`
+
+Defined in: src/components/OutlineCtaButton.tsx:16
+
+Secondary call-to-action button that defaults to an outlined style.
+
+## Parameters
+
+### \_\_namedParameters
+
+[`OutlineCtaButtonProps`](../type-aliases/OutlineCtaButtonProps.md)
+
+## Returns
+
+`Element`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/PreviewCard.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/PreviewCard.md
@@ -1,0 +1,21 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: PreviewCard()
+
+> **PreviewCard**(`__namedParameters`): `Element`
+
+Defined in: src/components/PreviewCard.tsx:34
+
+Compact preview card with optional media and CTA controls.
+
+## Parameters
+
+### \_\_namedParameters
+
+[`PreviewCardProps`](../interfaces/PreviewCardProps.md)
+
+## Returns
+
+`Element`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/PrimaryCtaButton.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/PrimaryCtaButton.md
@@ -1,0 +1,21 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: PrimaryCtaButton()
+
+> **PrimaryCtaButton**(`__namedParameters`): `Element`
+
+Defined in: src/components/PrimaryCtaButton.tsx:16
+
+Primary call-to-action button styled with the Flashoffer theme.
+
+## Parameters
+
+### \_\_namedParameters
+
+[`PrimaryCtaButtonProps`](../type-aliases/PrimaryCtaButtonProps.md)
+
+## Returns
+
+`Element`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/Section.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/Section.md
@@ -1,0 +1,21 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: Section()
+
+> **Section**(`__namedParameters`): `Element`
+
+Defined in: src/components/Section.tsx:29
+
+High-level section wrapper that combines SectionHeader with supporting copy.
+
+## Parameters
+
+### \_\_namedParameters
+
+[`SectionProps`](../interfaces/SectionProps.md)
+
+## Returns
+
+`Element`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/SectionHeader.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/SectionHeader.md
@@ -1,0 +1,21 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: SectionHeader()
+
+> **SectionHeader**(`__namedParameters`): `Element`
+
+Defined in: src/components/SectionHeader.tsx:25
+
+Section heading with optional eyebrow and description.
+
+## Parameters
+
+### \_\_namedParameters
+
+[`SectionHeaderProps`](../interfaces/SectionHeaderProps.md)
+
+## Returns
+
+`Element`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/ViewTracker.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/ViewTracker.md
@@ -1,0 +1,19 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: ViewTracker()
+
+> **ViewTracker**(`__namedParameters`): `ReactElement`\<`any`, `string` \| `JSXElementConstructor`\<`any`\>\>
+
+Defined in: src/analytics/EngagementProvider.tsx:567
+
+## Parameters
+
+### \_\_namedParameters
+
+[`ViewTrackerProps`](../interfaces/ViewTrackerProps.md)
+
+## Returns
+
+`ReactElement`\<`any`, `string` \| `JSXElementConstructor`\<`any`\>\>

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/createFlashofferTheme.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/createFlashofferTheme.md
@@ -1,0 +1,21 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: createFlashofferTheme()
+
+> **createFlashofferTheme**(`overrides?`): `Theme`
+
+Defined in: src/theme/FlashofferThemeProvider.tsx:60
+
+Create a Flashoffer design system theme with optional overrides.
+
+## Parameters
+
+### overrides?
+
+`ThemeOptions`
+
+## Returns
+
+`Theme`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/useEngagement.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/useEngagement.md
@@ -1,0 +1,13 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: useEngagement()
+
+> **useEngagement**(): [`EngagementContextValue`](../interfaces/EngagementContextValue.md)
+
+Defined in: src/analytics/EngagementProvider.tsx:525
+
+## Returns
+
+[`EngagementContextValue`](../interfaces/EngagementContextValue.md)

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/useRecordInteraction.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/useRecordInteraction.md
@@ -1,0 +1,37 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: useRecordInteraction()
+
+> **useRecordInteraction**(`defaultTarget?`, `defaultMeta?`): (`target`, `meta`) => `void`
+
+Defined in: src/analytics/EngagementProvider.tsx:582
+
+## Parameters
+
+### defaultTarget?
+
+`string`
+
+### defaultMeta?
+
+`Record`\<`string`, `unknown`\> = `{}`
+
+## Returns
+
+> (`target`, `meta`): `void`
+
+### Parameters
+
+#### target
+
+`string` = `...`
+
+#### meta
+
+`Record`\<`string`, `unknown`\> = `defaultMeta`
+
+### Returns
+
+`void`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/useViewTracker.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/useViewTracker.md
@@ -1,0 +1,33 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: useViewTracker()
+
+> **useViewTracker**(`trackId`, `meta`): (`node`) => `void`
+
+Defined in: src/analytics/EngagementProvider.tsx:533
+
+## Parameters
+
+### trackId
+
+`string`
+
+### meta
+
+`Record`\<`string`, `unknown`\> = `{}`
+
+## Returns
+
+> (`node`): `void`
+
+### Parameters
+
+#### node
+
+`null` | `Element`
+
+### Returns
+
+`void`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/AutoTrackProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/AutoTrackProps.md
@@ -1,0 +1,15 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: AutoTrackProps
+
+Defined in: src/analytics/AutoTrack.tsx:35
+
+## Properties
+
+### selector?
+
+> `optional` **selector**: `string`
+
+Defined in: src/analytics/AutoTrack.tsx:36

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/EngagementContextValue.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/EngagementContextValue.md
@@ -1,0 +1,119 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: EngagementContextValue
+
+Defined in: src/analytics/EngagementProvider.tsx:39
+
+## Properties
+
+### register()
+
+> **register**: (`trackId`, `element`, `meta?`) => () => `void`
+
+Defined in: src/analytics/EngagementProvider.tsx:40
+
+#### Parameters
+
+##### trackId
+
+`string`
+
+##### element
+
+`null` | `Element`
+
+##### meta?
+
+`Record`\<`string`, `unknown`\>
+
+#### Returns
+
+> (): `void`
+
+##### Returns
+
+`void`
+
+***
+
+### attachElement()
+
+> **attachElement**: (`trackId`, `element`, `meta?`) => () => `void`
+
+Defined in: src/analytics/EngagementProvider.tsx:45
+
+#### Parameters
+
+##### trackId
+
+`string`
+
+##### element
+
+`null` | `Element`
+
+##### meta?
+
+`Record`\<`string`, `unknown`\>
+
+#### Returns
+
+> (): `void`
+
+##### Returns
+
+`void`
+
+***
+
+### detachElement()
+
+> **detachElement**: (`element`) => `void`
+
+Defined in: src/analytics/EngagementProvider.tsx:50
+
+#### Parameters
+
+##### element
+
+`null` | `Element`
+
+#### Returns
+
+`void`
+
+***
+
+### recordInteraction()
+
+> **recordInteraction**: (`target`, `meta?`) => `void`
+
+Defined in: src/analytics/EngagementProvider.tsx:51
+
+#### Parameters
+
+##### target
+
+`string`
+
+##### meta?
+
+`Record`\<`string`, `unknown`\>
+
+#### Returns
+
+`void`
+
+***
+
+### getActiveTargets()
+
+> **getActiveTargets**: () => `string`[]
+
+Defined in: src/analytics/EngagementProvider.tsx:52
+
+#### Returns
+
+`string`[]

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/EngagementEvent.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/EngagementEvent.md
@@ -1,0 +1,39 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: EngagementEvent
+
+Defined in: src/analytics/EngagementProvider.tsx:14
+
+## Properties
+
+### type
+
+> **type**: `string`
+
+Defined in: src/analytics/EngagementProvider.tsx:15
+
+***
+
+### target
+
+> **target**: `string`
+
+Defined in: src/analytics/EngagementProvider.tsx:16
+
+***
+
+### meta
+
+> **meta**: `Record`\<`string`, `unknown`\>
+
+Defined in: src/analytics/EngagementProvider.tsx:17
+
+***
+
+### at
+
+> **at**: `string`
+
+Defined in: src/analytics/EngagementProvider.tsx:18

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/EngagementProviderProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/EngagementProviderProps.md
@@ -1,0 +1,79 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: EngagementProviderProps
+
+Defined in: src/analytics/EngagementProvider.tsx:27
+
+## Properties
+
+### endpoint?
+
+> `optional` **endpoint**: `string`
+
+Defined in: src/analytics/EngagementProvider.tsx:28
+
+***
+
+### site
+
+> **site**: `string`
+
+Defined in: src/analytics/EngagementProvider.tsx:29
+
+***
+
+### children
+
+> **children**: `ReactNode`
+
+Defined in: src/analytics/EngagementProvider.tsx:30
+
+***
+
+### flushInterval?
+
+> `optional` **flushInterval**: `null` \| `number`
+
+Defined in: src/analytics/EngagementProvider.tsx:31
+
+***
+
+### heartbeatInterval?
+
+> `optional` **heartbeatInterval**: `number`
+
+Defined in: src/analytics/EngagementProvider.tsx:32
+
+***
+
+### idleTimeout?
+
+> `optional` **idleTimeout**: `number`
+
+Defined in: src/analytics/EngagementProvider.tsx:33
+
+***
+
+### scrollThresholds?
+
+> `optional` **scrollThresholds**: `number`[]
+
+Defined in: src/analytics/EngagementProvider.tsx:34
+
+***
+
+### viewThresholds?
+
+> `optional` **viewThresholds**: `number`[]
+
+Defined in: src/analytics/EngagementProvider.tsx:35
+
+***
+
+### maxBatch?
+
+> `optional` **maxBatch**: `number`
+
+Defined in: src/analytics/EngagementProvider.tsx:36

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/EventConsoleProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/EventConsoleProps.md
@@ -1,0 +1,31 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: EventConsoleProps
+
+Defined in: src/analytics/EventConsole.tsx:5
+
+## Properties
+
+### eventsUrl?
+
+> `optional` **eventsUrl**: `string`
+
+Defined in: src/analytics/EventConsole.tsx:6
+
+***
+
+### pollInterval?
+
+> `optional` **pollInterval**: `number`
+
+Defined in: src/analytics/EventConsole.tsx:7
+
+***
+
+### limit?
+
+> `optional` **limit**: `number`
+
+Defined in: src/analytics/EventConsole.tsx:8

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/FigureProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/FigureProps.md
@@ -1,0 +1,57 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: FigureProps
+
+Defined in: src/components/Figure.tsx:6
+
+## Properties
+
+### src
+
+> **src**: `string`
+
+Defined in: src/components/Figure.tsx:8
+
+Image source rendered inside the figure.
+
+***
+
+### alt?
+
+> `optional` **alt**: `string`
+
+Defined in: src/components/Figure.tsx:10
+
+Descriptive alt text for the image. Defaults to decorative.
+
+***
+
+### caption?
+
+> `optional` **caption**: `ReactNode`
+
+Defined in: src/components/Figure.tsx:12
+
+Optional caption content rendered below the image.
+
+***
+
+### sx?
+
+> `optional` **sx**: `SxProps`\<`Theme`\>
+
+Defined in: src/components/Figure.tsx:14
+
+Custom styles merged into the root figure element.
+
+***
+
+### imgProps?
+
+> `optional` **imgProps**: `Omit`\<`ImgHTMLAttributes`\<`HTMLImageElement`\>, `"alt"` \| `"src"`\>
+
+Defined in: src/components/Figure.tsx:16
+
+Additional props forwarded to the underlying <img> element.

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/FlashofferThemeProviderProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/FlashofferThemeProviderProps.md
@@ -1,0 +1,43 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: FlashofferThemeProviderProps
+
+Defined in: src/theme/FlashofferThemeProvider.tsx:82
+
+## Extends
+
+- `PropsWithChildren`
+
+## Properties
+
+### children?
+
+> `optional` **children**: `ReactNode`
+
+Defined in: node\_modules/@types/react/index.d.ts:1414
+
+#### Inherited from
+
+`PropsWithChildren.children`
+
+***
+
+### themeOptions?
+
+> `optional` **themeOptions**: `ThemeOptions`
+
+Defined in: src/theme/FlashofferThemeProvider.tsx:84
+
+Optional theme overrides merged with the default Flashoffer palette.
+
+***
+
+### applyCssBaseline?
+
+> `optional` **applyCssBaseline**: `boolean`
+
+Defined in: src/theme/FlashofferThemeProvider.tsx:86
+
+Whether to include MUI's CssBaseline.

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/FooterLink.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/FooterLink.md
@@ -1,0 +1,39 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: FooterLink
+
+Defined in: src/components/Footer.tsx:7
+
+## Properties
+
+### label
+
+> **label**: `ReactNode`
+
+Defined in: src/components/Footer.tsx:8
+
+***
+
+### href
+
+> **href**: `string`
+
+Defined in: src/components/Footer.tsx:9
+
+***
+
+### target?
+
+> `optional` **target**: `string`
+
+Defined in: src/components/Footer.tsx:10
+
+***
+
+### rel?
+
+> `optional` **rel**: `string`
+
+Defined in: src/components/Footer.tsx:11

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/FooterProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/FooterProps.md
@@ -1,0 +1,27 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: FooterProps
+
+Defined in: src/components/Footer.tsx:14
+
+## Properties
+
+### links?
+
+> `optional` **links**: [`FooterLink`](FooterLink.md)[]
+
+Defined in: src/components/Footer.tsx:16
+
+Optional set of navigational links rendered in the footer.
+
+***
+
+### copyrightText?
+
+> `optional` **copyrightText**: `ReactNode`
+
+Defined in: src/components/Footer.tsx:18
+
+Copyright or attribution text shown below the links.

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/HeroBannerProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/HeroBannerProps.md
@@ -1,0 +1,67 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: HeroBannerProps
+
+Defined in: src/components/HeroBanner.tsx:11
+
+## Properties
+
+### title?
+
+> `optional` **title**: `ReactNode`
+
+Defined in: src/components/HeroBanner.tsx:13
+
+Main headline for the hero banner.
+
+***
+
+### subtitle?
+
+> `optional` **subtitle**: `ReactNode`
+
+Defined in: src/components/HeroBanner.tsx:15
+
+Supporting copy shown under the title.
+
+***
+
+### media?
+
+> `optional` **media**: `ReactNode`
+
+Defined in: src/components/HeroBanner.tsx:17
+
+Optional media element rendered alongside the copy.
+
+***
+
+### primaryCta?
+
+> `optional` **primaryCta**: [`PrimaryCtaButtonProps`](../type-aliases/PrimaryCtaButtonProps.md)
+
+Defined in: src/components/HeroBanner.tsx:19
+
+Props passed to the primary CTA button.
+
+***
+
+### secondaryCta?
+
+> `optional` **secondaryCta**: `null` \| [`OutlineCtaButtonProps`](../type-aliases/OutlineCtaButtonProps.md)
+
+Defined in: src/components/HeroBanner.tsx:21
+
+Props passed to the secondary CTA button.
+
+***
+
+### align?
+
+> `optional` **align**: `"left"` \| `"center"`
+
+Defined in: src/components/HeroBanner.tsx:23
+
+Aligns content horizontally.

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/PreviewCardProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/PreviewCardProps.md
@@ -1,0 +1,57 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: PreviewCardProps
+
+Defined in: src/components/PreviewCard.tsx:13
+
+## Properties
+
+### media?
+
+> `optional` **media**: `ReactNode`
+
+Defined in: src/components/PreviewCard.tsx:15
+
+Optional illustration or icon rendered above the title.
+
+***
+
+### title?
+
+> `optional` **title**: `ReactNode`
+
+Defined in: src/components/PreviewCard.tsx:17
+
+Heading text shown in the card.
+
+***
+
+### description?
+
+> `optional` **description**: `ReactNode`
+
+Defined in: src/components/PreviewCard.tsx:19
+
+Supporting description for the card.
+
+***
+
+### primaryCta?
+
+> `optional` **primaryCta**: [`PrimaryCtaButtonProps`](../type-aliases/PrimaryCtaButtonProps.md)
+
+Defined in: src/components/PreviewCard.tsx:21
+
+Primary CTA rendered in the card footer.
+
+***
+
+### secondaryCta?
+
+> `optional` **secondaryCta**: [`OutlineCtaButtonProps`](../type-aliases/OutlineCtaButtonProps.md)
+
+Defined in: src/components/PreviewCard.tsx:23
+
+Secondary CTA rendered next to the primary CTA.

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/SectionHeaderProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/SectionHeaderProps.md
@@ -1,0 +1,51 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: SectionHeaderProps
+
+Defined in: src/components/SectionHeader.tsx:5
+
+## Extended by
+
+- [`SectionProps`](SectionProps.md)
+
+## Properties
+
+### eyebrow?
+
+> `optional` **eyebrow**: `ReactNode`
+
+Defined in: src/components/SectionHeader.tsx:7
+
+Optional label rendered above the title.
+
+***
+
+### title?
+
+> `optional` **title**: `ReactNode`
+
+Defined in: src/components/SectionHeader.tsx:9
+
+Main heading text.
+
+***
+
+### description?
+
+> `optional` **description**: `ReactNode`
+
+Defined in: src/components/SectionHeader.tsx:11
+
+Supporting description under the title.
+
+***
+
+### align?
+
+> `optional` **align**: `"left"` \| `"center"`
+
+Defined in: src/components/SectionHeader.tsx:13
+
+Horizontal alignment for the text stack.

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/SectionProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/SectionProps.md
@@ -1,0 +1,88 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: SectionProps
+
+Defined in: src/components/Section.tsx:9
+
+## Extends
+
+- [`SectionHeaderProps`](SectionHeaderProps.md)
+
+## Properties
+
+### paragraphs?
+
+> `optional` **paragraphs**: `ReactNode`[]
+
+Defined in: src/components/Section.tsx:14
+
+Body copy rendered under the section header. Each entry is wrapped in a
+paragraph-level Typography component.
+
+***
+
+### id?
+
+> `optional` **id**: `string`
+
+Defined in: src/components/Section.tsx:16
+
+Optional custom id applied to the underlying section element.
+
+***
+
+### eyebrow?
+
+> `optional` **eyebrow**: `ReactNode`
+
+Defined in: src/components/SectionHeader.tsx:7
+
+Optional label rendered above the title.
+
+#### Inherited from
+
+[`SectionHeaderProps`](SectionHeaderProps.md).[`eyebrow`](SectionHeaderProps.md#eyebrow)
+
+***
+
+### title?
+
+> `optional` **title**: `ReactNode`
+
+Defined in: src/components/SectionHeader.tsx:9
+
+Main heading text.
+
+#### Inherited from
+
+[`SectionHeaderProps`](SectionHeaderProps.md).[`title`](SectionHeaderProps.md#title)
+
+***
+
+### description?
+
+> `optional` **description**: `ReactNode`
+
+Defined in: src/components/SectionHeader.tsx:11
+
+Supporting description under the title.
+
+#### Inherited from
+
+[`SectionHeaderProps`](SectionHeaderProps.md).[`description`](SectionHeaderProps.md#description)
+
+***
+
+### align?
+
+> `optional` **align**: `"left"` \| `"center"`
+
+Defined in: src/components/SectionHeader.tsx:13
+
+Horizontal alignment for the text stack.
+
+#### Inherited from
+
+[`SectionHeaderProps`](SectionHeaderProps.md).[`align`](SectionHeaderProps.md#align)

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/ViewTrackerProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/ViewTrackerProps.md
@@ -1,0 +1,43 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: ViewTrackerProps
+
+Defined in: src/analytics/EngagementProvider.tsx:559
+
+## Indexable
+
+\[`key`: `string`\]: `unknown`
+
+## Properties
+
+### trackId
+
+> **trackId**: `string`
+
+Defined in: src/analytics/EngagementProvider.tsx:560
+
+***
+
+### meta?
+
+> `optional` **meta**: `Record`\<`string`, `unknown`\>
+
+Defined in: src/analytics/EngagementProvider.tsx:561
+
+***
+
+### as?
+
+> `optional` **as**: `ElementType`
+
+Defined in: src/analytics/EngagementProvider.tsx:562
+
+***
+
+### children?
+
+> `optional` **children**: `ReactNode`
+
+Defined in: src/analytics/EngagementProvider.tsx:563

--- a/app/flashoffer-react/docs/reference/flashoffer-react/type-aliases/OutlineCtaButtonProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/type-aliases/OutlineCtaButtonProps.md
@@ -1,0 +1,17 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Type Alias: OutlineCtaButtonProps
+
+> **OutlineCtaButtonProps** = `ButtonProps` & `Pick`\<`AnchorHTMLAttributes`\<`HTMLAnchorElement`\>, `"target"` \| `"rel"`\> & `object`
+
+Defined in: src/components/OutlineCtaButton.tsx:5
+
+## Type Declaration
+
+### label?
+
+> `optional` **label**: `ReactNode`
+
+Textual label rendered when no custom children are provided.

--- a/app/flashoffer-react/docs/reference/flashoffer-react/type-aliases/PrimaryCtaButtonProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/type-aliases/PrimaryCtaButtonProps.md
@@ -1,0 +1,17 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Type Alias: PrimaryCtaButtonProps
+
+> **PrimaryCtaButtonProps** = `ButtonProps` & `Pick`\<`AnchorHTMLAttributes`\<`HTMLAnchorElement`\>, `"target"` \| `"rel"`\> & `object`
+
+Defined in: src/components/PrimaryCtaButton.tsx:5
+
+## Type Declaration
+
+### label?
+
+> `optional` **label**: `ReactNode`
+
+Textual label rendered when no custom children are provided.

--- a/app/flashoffer-react/package-lock.json
+++ b/app/flashoffer-react/package-lock.json
@@ -28,6 +28,8 @@
         "jest-environment-jsdom": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
+        "typedoc": "^0.28.0",
+        "typedoc-plugin-markdown": "^4.9.0",
         "typescript": "^5.6.3",
         "vite": "^7.0.4",
         "vite-plugin-dts": "^4.5.4"
@@ -1188,6 +1190,20 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.13.0.tgz",
+      "integrity": "sha512-mCrNvZNYNrwKer5PWLF6cOc0OEe2eKzgy976x+IT2tynwJYl+7UpHTSeXQJGijgTcoOf+f359L946unWlYRnsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.13.0",
+        "@shikijs/langs": "^3.13.0",
+        "@shikijs/themes": "^3.13.0",
+        "@shikijs/types": "^3.13.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@isaacs/balanced-match": {
@@ -2468,6 +2484,55 @@
         "string-argv": "~0.3.1"
       }
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.13.0.tgz",
+      "integrity": "sha512-O42rBGr4UDSlhT2ZFMxqM7QzIU+IcpoTMzb3W7AlziI1ZF7R8eS2M0yt5Ry35nnnTX/LTLXFPUjRFCIW+Operg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.13.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.13.0.tgz",
+      "integrity": "sha512-672c3WAETDYHwrRP0yLy3W1QYB89Hbpj+pO4KhxK6FzIrDI2FoEXNiNCut6BQmEApYLfuYfpgOZaqbY+E9b8wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.13.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.13.0.tgz",
+      "integrity": "sha512-Vxw1Nm1/Od8jyA7QuAenaV78BG2nSr3/gCGdBkLpfLscddCkzkL36Q5b67SrLLfvAJTOUzW39x4FHVCFriPVgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.13.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.13.0.tgz",
+      "integrity": "sha512-oM9P+NCFri/mmQ8LoFGVfVyemm5Hi27330zuOBp0annwJdKH1kOLndw3zCtAVDehPLg9fKqoEx3Ht/wNZxolfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -2686,6 +2751,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2832,6 +2907,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5990,6 +6072,16 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
@@ -6056,6 +6148,13 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
@@ -6124,6 +6223,31 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6133,6 +6257,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -6717,6 +6848,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7519,6 +7660,69 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.13.tgz",
+      "integrity": "sha512-dNWY8msnYB2a+7Audha+aTF1Pu3euiE7ySp53w8kEsXoYw7dMouV5A1UsTUY345aB152RHnmRMDiovuBi7BD+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.12.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.9.0.tgz",
+      "integrity": "sha512-9Uu4WR9L7ZBgAl60N/h+jqmPxxvnC9nQAlnnO/OujtG2ubjnKTVUFY1XDhcMY+pCqlX3N2HsQM2QTYZIU9tJuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "typedoc": "0.28.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -7532,6 +7736,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.1",
@@ -7986,8 +8197,6 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/app/flashoffer-react/package.json
+++ b/app/flashoffer-react/package.json
@@ -26,6 +26,7 @@
   "sideEffects": ["*.css"],
   "scripts": {
     "build": "vite build",
+    "docs": "typedoc",
     "test": "jest",
     "test:watch": "jest --watch"
   },
@@ -47,10 +48,12 @@
     "@vitejs/plugin-react": "^4.6.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
+    "ts-node": "^10.9.2",
+    "typedoc": "^0.28.0",
+    "typedoc-plugin-markdown": "^4.9.0",
     "typescript": "^5.6.3",
     "vite": "^7.0.4",
     "vite-plugin-dts": "^4.5.4",
-    "ts-node": "^10.9.2",
     "jest-environment-jsdom": "^29.7.0"
   },
   "peerDependencies": {

--- a/app/flashoffer-react/src/components/OutlineCtaButton.tsx
+++ b/app/flashoffer-react/src/components/OutlineCtaButton.tsx
@@ -2,14 +2,13 @@ import Button from "@mui/material/Button";
 import type { ButtonProps } from "@mui/material/Button";
 import type { AnchorHTMLAttributes, ReactNode } from "react";
 
-export interface OutlineCtaButtonProps
-  extends ButtonProps,
-    Pick<AnchorHTMLAttributes<HTMLAnchorElement>, "target" | "rel"> {
-  /**
-   * Textual label rendered when no custom children are provided.
-   */
-  label?: ReactNode;
-}
+export type OutlineCtaButtonProps = ButtonProps &
+  Pick<AnchorHTMLAttributes<HTMLAnchorElement>, "target" | "rel"> & {
+    /**
+     * Textual label rendered when no custom children are provided.
+     */
+    label?: ReactNode;
+  };
 
 /**
  * Secondary call-to-action button that defaults to an outlined style.

--- a/app/flashoffer-react/src/components/PrimaryCtaButton.tsx
+++ b/app/flashoffer-react/src/components/PrimaryCtaButton.tsx
@@ -2,14 +2,13 @@ import Button from "@mui/material/Button";
 import type { ButtonProps } from "@mui/material/Button";
 import type { AnchorHTMLAttributes, ReactNode } from "react";
 
-export interface PrimaryCtaButtonProps
-  extends ButtonProps,
-    Pick<AnchorHTMLAttributes<HTMLAnchorElement>, "target" | "rel"> {
-  /**
-   * Textual label rendered when no custom children are provided.
-   */
-  label?: ReactNode;
-}
+export type PrimaryCtaButtonProps = ButtonProps &
+  Pick<AnchorHTMLAttributes<HTMLAnchorElement>, "target" | "rel"> & {
+    /**
+     * Textual label rendered when no custom children are provided.
+     */
+    label?: ReactNode;
+  };
 
 /**
  * Primary call-to-action button styled with the Flashoffer theme.

--- a/app/flashoffer-react/tsconfig.docs.json
+++ b/app/flashoffer-react/tsconfig.docs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": [
+    "src/__tests__",
+    "src/**/__tests__",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ]
+}

--- a/app/flashoffer-react/typedoc.json
+++ b/app/flashoffer-react/typedoc.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["./src/index.ts"],
+  "entryPointStrategy": "expand",
+  "tsconfig": "./tsconfig.docs.json",
+  "out": "./docs/reference/flashoffer-react",
+  "plugin": ["typedoc-plugin-markdown"],
+  "readme": "none",
+  "hideBreadcrumbs": true,
+  "categorizeByGroup": false,
+  "excludeExternals": true,
+  "externalPattern": ["**/node_modules/@mui/**", "**/node_modules/@emotion/**"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"],
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "visibilityFilters": {
+    "inherited": false,
+    "external": false
+  },
+  "sort": ["kind", "source-order"]
+}


### PR DESCRIPTION
## Summary
- add TypeDoc configuration, supporting tsconfig, and npm script to generate API docs for flashoffer-react
- generate markdown reference content for components, analytics helpers, and theme utilities using TypeDoc
- expose a make docs rule and tweak CTA button prop definitions so generated docs stay concise

## Testing
- npm test
- npm run docs

------
https://chatgpt.com/codex/tasks/task_e_68dd664039a08321921212b921a8a929