### PR TITLE
Render Section copy via children in flashoffer demo

### DIFF
--- a/app/flashoffer-demo/src/sections/CtaShowcaseSection.tsx
+++ b/app/flashoffer-demo/src/sections/CtaShowcaseSection.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
 import { OutlineCtaButton, PrimaryCtaButton, Section } from "flashoffer-react";
 
 export function CtaShowcaseSection() {
@@ -16,33 +17,35 @@ export function CtaShowcaseSection() {
         align="center"
         eyebrow="CALL TO ACTION"
         title="Pre-built CTA variations"
-        description="Mix and match primary and secondary button styles to suit product launches, onboarding nudges, or seasonal promotions."
-        paragraphs={[]}
-      />
-      <Stack
-        direction={{ xs: "column", sm: "row" }}
-        spacing={2}
-        sx={{ mt: 3 }}
-        alignItems="center"
-        justifyContent="center"
       >
-        <PrimaryCtaButton
-          href="https://example.com/flashoffer"
-          data-track-id="cta-primary"
-          data-track-label="Primary CTA"
-          data-track-meta={JSON.stringify({ location: "cta-showcase" })}
+        <Typography color="text.secondary">
+          Mix and match primary and secondary button styles to suit product
+          launches, onboarding nudges, or seasonal promotions.
+        </Typography>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2}
+          alignItems="center"
+          justifyContent="center"
         >
-          Explore Flashoffer components
-        </PrimaryCtaButton>
-        <OutlineCtaButton
-          href="mailto:support@example.com"
-          data-track-id="cta-secondary"
-          data-track-label="Secondary CTA"
-          data-track-meta={JSON.stringify({ location: "cta-showcase" })}
-        >
-          Contact support
-        </OutlineCtaButton>
-      </Stack>
+          <PrimaryCtaButton
+            href="https://example.com/flashoffer"
+            data-track-id="cta-primary"
+            data-track-label="Primary CTA"
+            data-track-meta={JSON.stringify({ location: "cta-showcase" })}
+          >
+            Explore Flashoffer components
+          </PrimaryCtaButton>
+          <OutlineCtaButton
+            href="mailto:support@example.com"
+            data-track-id="cta-secondary"
+            data-track-label="Secondary CTA"
+            data-track-meta={JSON.stringify({ location: "cta-showcase" })}
+          >
+            Contact support
+          </OutlineCtaButton>
+        </Stack>
+      </Section>
     </Box>
   );
 }

--- a/app/flashoffer-demo/src/sections/CustomizationControlsSection.tsx
+++ b/app/flashoffer-demo/src/sections/CustomizationControlsSection.tsx
@@ -34,9 +34,12 @@ export function CustomizationControlsSection({
           align="left"
           eyebrow="CUSTOMIZE"
           title="Customize the showcase"
-          description="Switch palettes or tweak hero alignment to preview how Flashoffer primitives adapt."
-          paragraphs={[]}
-        />
+        >
+          <Typography color="text.secondary">
+            Switch palettes or tweak hero alignment to preview how Flashoffer
+            primitives adapt.
+          </Typography>
+        </Section>
         <Divider flexItem sx={{ borderColor: "divider" }} />
         <Stack
           direction={{ xs: "column", sm: "row" }}

--- a/app/flashoffer-demo/src/sections/FigureSpotlightSection.tsx
+++ b/app/flashoffer-demo/src/sections/FigureSpotlightSection.tsx
@@ -1,4 +1,5 @@
 import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import { Figure, Section } from "flashoffer-react";
 
 const FIGURE_META = JSON.stringify({ orientation: "landscape" });
@@ -14,25 +15,28 @@ export function FigureSpotlightSection() {
       <Section
         eyebrow="MEDIA"
         title="Pair imagery with supporting context"
-        description="Use Figure to keep visuals responsive across breakpoints while pairing them with captions or attributions."
-        paragraphs={[]}
-      />
-      <Box
-        sx={{
-          mt: 3,
-          display: "flex",
-          justifyContent: "center"
-        }}
       >
-        <Figure
-          src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=960&q=80"
-          alt="Product marketer reviewing launch campaign timelines"
-          caption="Launch dashboards stay legible on any device thanks to responsive scaling."
+        <Typography color="text.secondary">
+          Use Figure to keep visuals responsive across breakpoints while pairing
+          them with captions or attributions.
+        </Typography>
+        <Box
           sx={{
-            maxWidth: 560
+            display: "flex",
+            justifyContent: "center",
+            width: "100%"
           }}
-        />
-      </Box>
+        >
+          <Figure
+            src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=960&q=80"
+            alt="Product marketer reviewing launch campaign timelines"
+            caption="Launch dashboards stay legible on any device thanks to responsive scaling."
+            sx={{
+              maxWidth: 560
+            }}
+          />
+        </Box>
+      </Section>
     </Box>
   );
 }

--- a/app/flashoffer-demo/src/sections/OverviewSection.tsx
+++ b/app/flashoffer-demo/src/sections/OverviewSection.tsx
@@ -1,4 +1,5 @@
 import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import { Section } from "flashoffer-react";
 import { OVERVIEW_PARAGRAPHS } from "./content";
 
@@ -17,9 +18,17 @@ export function OverviewSection({ overviewMeta }: OverviewSectionProps) {
         align="center"
         eyebrow="OVERVIEW"
         title="Narrate launches with reusable sections"
-        description="Combine headlines and supporting copy without rebuilding layouts from scratch."
-        paragraphs={OVERVIEW_PARAGRAPHS}
-      />
+      >
+        <Typography color="text.secondary">
+          Combine headlines and supporting copy without rebuilding layouts from
+          scratch.
+        </Typography>
+        {OVERVIEW_PARAGRAPHS.map((paragraph) => (
+          <Typography key={paragraph} color="text.secondary">
+            {paragraph}
+          </Typography>
+        ))}
+      </Section>
     </Box>
   );
 }

--- a/app/flashoffer-demo/src/sections/PreviewShowcaseSection.tsx
+++ b/app/flashoffer-demo/src/sections/PreviewShowcaseSection.tsx
@@ -1,5 +1,6 @@
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import { PreviewCard, Section } from "flashoffer-react";
 import { PREVIEW_CARDS } from "./content";
 
@@ -26,27 +27,30 @@ export function PreviewShowcaseSection({ previewMeta }: PreviewShowcaseSectionPr
       <Section
         eyebrow="SHOWCASE"
         title="Modular previews for any campaign"
-        description="Drop PreviewCard components into grid layouts to tease content, share regional updates, or pair with testimonials."
         align="left"
-        paragraphs={[]}
-      />
-      <Grid container spacing={3} sx={{ mt: 3 }}>
-        {PREVIEW_CARDS.map((card, index) => {
-          const label = String(card.title);
-          const cardTrackId = `preview-card-${toTrackId(label) || index + 1}`;
-          return (
-            <Grid
-              key={card.title}
-              size={{ xs: 12, md: 4 }}
-              data-track-id={cardTrackId}
-              data-track-label={label}
-              data-track-meta={JSON.stringify({ index, title: label })}
-            >
-              <PreviewCard {...card} />
-            </Grid>
-          );
-        })}
-      </Grid>
+      >
+        <Typography color="text.secondary">
+          Drop PreviewCard components into grid layouts to tease content, share
+          regional updates, or pair with testimonials.
+        </Typography>
+        <Grid container spacing={3} sx={{ width: "100%" }}>
+          {PREVIEW_CARDS.map((card, index) => {
+            const label = String(card.title);
+            const cardTrackId = `preview-card-${toTrackId(label) || index + 1}`;
+            return (
+              <Grid
+                key={card.title}
+                size={{ xs: 12, md: 4 }}
+                data-track-id={cardTrackId}
+                data-track-label={label}
+                data-track-meta={JSON.stringify({ index, title: label })}
+              >
+                <PreviewCard {...card} />
+              </Grid>
+            );
+          })}
+        </Grid>
+      </Section>
     </Box>
   );
 }

--- a/app/flashoffer-react/README.md
+++ b/app/flashoffer-react/README.md
@@ -97,13 +97,13 @@ arbitrary attributes to the underlying Material UI primitive.
   and CTA buttons. Set `align="left"` to left-align copy, pass `media` to render
   an illustration, and override `primaryCta`/`secondaryCta` with button props or
   disable the secondary button by supplying `null`.
-- **`SectionHeader`** – Standalone heading stack with `eyebrow`, `title`, and
-  `description` slots. The `align` prop controls text alignment and flex
-  behavior.
-- **`Section`** – High-level wrapper that renders `SectionHeader` plus body copy
-  paragraphs. Supply `paragraphs` as an array of React nodes to populate the
-  prose region or omit it for a header-only section. Accepts an optional `id`
-  for anchor linking.
+- **`SectionHeader`** – Standalone heading stack with optional `eyebrow` and
+  `title` slots. Defaults render Flashoffer marketing copy, and the `align`
+  prop controls text alignment and flex behavior.
+- **`Section`** – High-level wrapper that renders `SectionHeader` plus optional
+  supporting children. Pass any React nodes as `children` to render supporting
+  prose or omit them for a header-only section. Accepts an optional `id` for
+  anchor linking.
 - **`PreviewCard`** – Feature preview card with optional media and CTA row.
   Provide `primaryCta`/`secondaryCta` props to render button controls, or leave
   them undefined for a purely informational card.

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/Section.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/Section.md
@@ -6,7 +6,7 @@
 
 > **Section**(`__namedParameters`): `Element`
 
-Defined in: src/components/Section.tsx:29
+Defined in: src/components/Section.tsx:16
 
 High-level section wrapper that combines SectionHeader with supporting copy.
 

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/SectionHeader.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/SectionHeader.md
@@ -8,7 +8,7 @@
 
 Defined in: src/components/SectionHeader.tsx:25
 
-Section heading with optional eyebrow and description.
+Section heading with optional eyebrow and configurable alignment.
 
 ## Parameters
 

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/SectionHeaderProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/SectionHeaderProps.md
@@ -18,7 +18,7 @@ Defined in: src/components/SectionHeader.tsx:5
 
 Defined in: src/components/SectionHeader.tsx:7
 
-Optional label rendered above the title.
+Optional label rendered above the title. Defaults to "FLASHOFFER".
 
 ***
 
@@ -28,17 +28,7 @@ Optional label rendered above the title.
 
 Defined in: src/components/SectionHeader.tsx:9
 
-Main heading text.
-
-***
-
-### description?
-
-> `optional` **description**: `ReactNode`
-
-Defined in: src/components/SectionHeader.tsx:11
-
-Supporting description under the title.
+Main heading text. Defaults to Flashoffer marketing copy.
 
 ***
 
@@ -46,6 +36,6 @@ Supporting description under the title.
 
 > `optional` **align**: `"left"` \| `"center"`
 
-Defined in: src/components/SectionHeader.tsx:13
+Defined in: src/components/SectionHeader.tsx:11
 
-Horizontal alignment for the text stack.
+Horizontal alignment for the text stack. Defaults to "center".

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/SectionProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/SectionProps.md
@@ -4,7 +4,7 @@
 
 # Interface: SectionProps
 
-Defined in: src/components/Section.tsx:9
+Defined in: src/components/Section.tsx:6
 
 ## Extends
 
@@ -12,24 +12,23 @@ Defined in: src/components/Section.tsx:9
 
 ## Properties
 
-### paragraphs?
-
-> `optional` **paragraphs**: `ReactNode`[]
-
-Defined in: src/components/Section.tsx:14
-
-Body copy rendered under the section header. Each entry is wrapped in a
-paragraph-level Typography component.
-
-***
-
 ### id?
 
 > `optional` **id**: `string`
 
-Defined in: src/components/Section.tsx:16
+Defined in: src/components/Section.tsx:10
 
 Optional custom id applied to the underlying section element.
+
+***
+
+### children?
+
+> `optional` **children**: `ReactNode`
+
+Defined in: src/components/Section.tsx:8
+
+Supporting content rendered under the section header.
 
 ***
 
@@ -58,20 +57,6 @@ Main heading text.
 #### Inherited from
 
 [`SectionHeaderProps`](SectionHeaderProps.md).[`title`](SectionHeaderProps.md#title)
-
-***
-
-### description?
-
-> `optional` **description**: `ReactNode`
-
-Defined in: src/components/SectionHeader.tsx:11
-
-Supporting description under the title.
-
-#### Inherited from
-
-[`SectionHeaderProps`](SectionHeaderProps.md).[`description`](SectionHeaderProps.md#description)
 
 ***
 

--- a/app/flashoffer-react/src/__tests__/components.test.tsx
+++ b/app/flashoffer-react/src/__tests__/components.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import Typography from "@mui/material/Typography";
 import { FlashofferThemeProvider, createFlashofferTheme } from "../index";
 import { Footer } from "../components/Footer";
 import { HeroBanner } from "../components/HeroBanner";
@@ -95,13 +96,36 @@ describe("Flashoffer React primitives", () => {
     expect(screen.getAllByRole("link").length).toBeGreaterThanOrEqual(1);
   });
 
-  it("renders supplied paragraphs inside section", () => {
+  it("renders SectionHeader defaults when props are omitted", () => {
+    renderWithTheme(<SectionHeader />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /reusable content blocks/i
+      })
+    ).toBeVisible();
+    expect(screen.getByText("FLASHOFFER")).toBeVisible();
+  });
+
+  it("aligns SectionHeader content when left-aligned", () => {
     renderWithTheme(
-      <Section
-        align="left"
-        title="Release highlights"
-        paragraphs={["First paragraph", "Second paragraph"]}
-      />
+      <SectionHeader align="left" eyebrow="Highlights" title="Aligned" />
+    );
+
+    const heading = screen.getByRole("heading", { level: 2, name: "Aligned" });
+    const header = heading.closest("header");
+    expect(header).not.toBeNull();
+    expect(header).toHaveStyle({ textAlign: "left" });
+    expect(header).toHaveStyle({ alignItems: "flex-start" });
+  });
+
+  it("renders supplied children inside section", () => {
+    renderWithTheme(
+      <Section align="left" title="Release highlights">
+        <Typography>First paragraph</Typography>
+        <Typography>Second paragraph</Typography>
+      </Section>
     );
 
     expect(
@@ -109,25 +133,19 @@ describe("Flashoffer React primitives", () => {
     ).toBeVisible();
     const paragraphs = screen.getAllByText(/paragraph$/);
     expect(paragraphs).toHaveLength(2);
-    paragraphs.forEach((paragraph) => {
-      expect(paragraph.tagName.toLowerCase()).toBe("p");
-    });
   });
 
-  it("applies themed palette colors to section copy", () => {
-    render(
-      <FlashofferThemeProvider
-        applyCssBaseline={false}
-        themeOptions={{
-          palette: { text: { primary: "#111827", secondary: "#0ea5e9" } }
-        }}
-      >
-        <Section title="Themed section" paragraphs={["Custom paragraph"]} />
-      </FlashofferThemeProvider>
+  it("applies alignment styles to section copy", () => {
+    renderWithTheme(
+      <Section align="left" title="Aligned section">
+        <Typography>Aligned content</Typography>
+      </Section>
     );
 
-    const paragraph = screen.getByText("Custom paragraph");
-    expect(window.getComputedStyle(paragraph).color).toBe("rgb(14, 165, 233)");
+    const heading = screen.getByRole("heading", { level: 2, name: "Aligned section" });
+    const section = heading.closest("section");
+    expect(section).not.toBeNull();
+    expect(section).toHaveStyle({ textAlign: "left" });
   });
 
   it("supports Outline CTA default label", () => {

--- a/app/flashoffer-react/src/components/Section.tsx
+++ b/app/flashoffer-react/src/components/Section.tsx
@@ -1,17 +1,11 @@
-import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
-import Typography from "@mui/material/Typography";
-import { useTheme } from "@mui/material/styles";
 import type { ReactNode } from "react";
 import { SectionHeader } from "./SectionHeader";
 import type { SectionHeaderProps } from "./SectionHeader";
 
-export interface SectionProps {
-  /**
-   * Body copy rendered under the section header. Each entry is wrapped in a
-   * paragraph-level Typography component.
-   */
-  children?: ReactNode[];
+export interface SectionProps extends SectionHeaderProps {
+  /** Supporting content rendered under the section header. */
+  children?: ReactNode;
   /** Optional custom id applied to the underlying section element. */
   id?: string;
 }
@@ -25,15 +19,16 @@ export function Section({
   children,
   ...headerProps
 }: SectionProps) {
-  const theme = useTheme();
-  const textAlign = align;
   const alignItems = align === "center" ? "center" : "flex-start";
-  const paragraphColor = theme.palette.text.secondary;
-  const sectionTextColor = theme.palette.text.primary;
-  const paragraphMarginTop = theme.spacing(3);
 
   return (
-    <Stack component="section" id={id} sx={{ color: sectionTextColor }} spacing={3}>
+    <Stack
+      component="section"
+      id={id}
+      spacing={3}
+      alignItems={alignItems}
+      textAlign={align}
+    >
       <SectionHeader align={align} {...headerProps} />
       {children}
     </Stack>

--- a/app/flashoffer-react/src/components/SectionHeader.tsx
+++ b/app/flashoffer-react/src/components/SectionHeader.tsx
@@ -3,11 +3,11 @@ import Typography from "@mui/material/Typography";
 import type { ReactNode } from "react";
 
 export interface SectionHeaderProps {
-  /** Optional label rendered above the title. */
+  /** Optional label rendered above the title. Defaults to "FLASHOFFER". */
   eyebrow?: ReactNode;
-  /** Main heading text. */
+  /** Main heading text. Defaults to Flashoffer marketing copy. */
   title?: ReactNode;
-  /** Horizontal alignment for the text stack. */
+  /** Horizontal alignment for the text stack. Defaults to "center". */
   align?: "left" | "center";
 }
 
@@ -15,7 +15,7 @@ const DEFAULT_EYEBROW = "FLASHOFFER";
 const DEFAULT_TITLE = "Launch faster with reusable content blocks.";
 
 /**
- * Section heading with optional eyebrow.
+ * Section heading with optional eyebrow and configurable alignment.
  */
 export function SectionHeader({
   eyebrow = DEFAULT_EYEBROW,


### PR DESCRIPTION
## Summary
- update the flashoffer demo sections to provide Section descriptions as Typography children that follow the header defaults
- keep supporting layouts inside each Section so CTA stacks, preview grids, and figure spotlights inherit the component spacing

## Testing
- npm test -- --runTestsByPath src/__tests__/components.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd9e8ecd34832198ec88087221274f