### PR TITLE
Limit engagement tracking duration

### DIFF
--- a/app/flashoffer-react/src/analytics/EngagementProvider.tsx
+++ b/app/flashoffer-react/src/analytics/EngagementProvider.tsx
@@ -10,6 +10,7 @@ import {
 import type { ElementType, ReactNode } from "react";
 
 const MAX_CONSECUTIVE_FAILURES = 10;
+const MAX_COLLECTION_DURATION_MS = 60_000;
 
 export interface EngagementEvent {
   type: string;
@@ -217,6 +218,19 @@ export function EngagementProvider({
   useEffect(() => {
     flushRef.current = flush;
   }, [flush]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+    const timeout = window.setTimeout(() => {
+      void flushRef.current?.("lifetime");
+      disableTracking();
+    }, MAX_COLLECTION_DURATION_MS);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [disableTracking]);
 
   useEffect(() => {
     thresholdsRef.current = viewThresholds;

--- a/app/flashoffer-react/src/analytics/__tests__/EngagementProvider.test.tsx
+++ b/app/flashoffer-react/src/analytics/__tests__/EngagementProvider.test.tsx
@@ -93,3 +93,75 @@ describe("EngagementProvider connection failure handling", () => {
     view.unmount();
   });
 });
+
+describe("EngagementProvider lifetime", () => {
+  const globalScope = globalThis as GlobalWithOptionalFetch;
+  const originalFetch = globalScope.fetch;
+  let fetchMock: jest.MockedFunction<typeof fetch>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    fetchMock = jest
+      .fn(async () => ({ ok: true } as Response))
+      .mockName("fetch") as jest.MockedFunction<typeof fetch>;
+    globalScope.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    globalScope.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("halts event recording after one minute", async () => {
+    const recordRef = {
+      current: (() => undefined) as RecordFn,
+    } as MutableRefObject<RecordFn>;
+
+    const view = render(
+      <EngagementProvider
+        endpoint="/engagement"
+        site="test"
+        maxBatch={1}
+        flushInterval={null}
+        heartbeatInterval={60_000}
+        idleTimeout={-1}
+        scrollThresholds={[]}
+        viewThresholds={[]}
+      >
+        <Recorder recordRef={recordRef} />
+      </EngagementProvider>
+    );
+
+    await act(async () => {
+      recordRef.current("before-timeout");
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(59_000);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      recordRef.current("still-active");
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1_000);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      recordRef.current("post-timeout");
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    view.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- stop EngagementProvider after one minute by scheduling a shutdown timer that flushes queued events and disables tracking
- add a regression test that verifies events stop flowing after the one-minute lifetime expires

## Testing
- npm test -- --runTestsByPath src/analytics/__tests__/EngagementProvider.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ddcab5126c8321abe520161c5bb578