### PR TITLE
docs: clarify section component defaults

### DIFF
--- a/app/flashoffer-react/README.md
+++ b/app/flashoffer-react/README.md
@@ -98,12 +98,13 @@ arbitrary attributes to the underlying Material UI primitive.
   an illustration, and override `primaryCta`/`secondaryCta` with button props or
   disable the secondary button by supplying `null`.
 - **`SectionHeader`** – Standalone heading stack with optional `eyebrow` and
-  `title` slots. Defaults render Flashoffer marketing copy, and the `align`
-  prop controls text alignment and flex behavior.
+  `title` slots. Defaults render the `"FLASHOFFER"` eyebrow and the "Launch
+  faster with reusable content blocks." headline. Use `align="center"`
+  (default) or `align="left"` to adjust layout.
 - **`Section`** – High-level wrapper that renders `SectionHeader` plus optional
-  supporting children. Pass any React nodes as `children` to render supporting
-  prose or omit them for a header-only section. Accepts an optional `id` for
-  anchor linking.
+  supporting children. Inherits the same defaults and accepts all
+  `SectionHeader` props alongside an optional `id` for anchor linking.
+  Drop in supporting prose without wiring data first.
 - **`PreviewCard`** – Feature preview card with optional media and CTA row.
   Provide `primaryCta`/`secondaryCta` props to render button controls, or leave
   them undefined for a purely informational card.
@@ -150,8 +151,10 @@ export function LandingWithAnalytics() {
 ```
 
 - **`EngagementProvider`** tracks viewport visibility, scroll depth, and user
-  activity. Adjust thresholds with `viewThresholds` or disable network flushes
-  by setting `flushInterval={null}` when you only need in-memory metrics.
+  activity. Control sampling with `viewThresholds`, `scrollThresholds`, and
+  `heartbeatInterval`, tune inactivity handling with `idleTimeout`, adjust
+  batch sizing through `maxBatch`, or disable network flushes entirely by
+  setting `flushInterval={null}` when you only need in-memory metrics.
 - **`AutoTrack`** watches the DOM for elements marked with `data-track-id`
   attributes. It attaches observers automatically and reads optional
   `data-track-label`/`data-track-meta` attributes for enriched metadata.

--- a/app/flashoffer-react/README.md
+++ b/app/flashoffer-react/README.md
@@ -104,7 +104,15 @@ arbitrary attributes to the underlying Material UI primitive.
 - **`Section`** – High-level wrapper that renders `SectionHeader` plus optional
   supporting children. Inherits the same defaults and accepts all
   `SectionHeader` props alongside an optional `id` for anchor linking.
-  Drop in supporting prose without wiring data first.
+  Render supporting content as natural React children instead of collecting
+  paragraphs in arrays; the component handles spacing itself.
+
+  ```tsx
+  <Section eyebrow="Customers" title="Loved by operators">
+    <p>Flashoffer's automation eliminates manual proposal work.</p>
+    <p>Integrate your CRM to close deals faster.</p>
+  </Section>
+  ```
 - **`PreviewCard`** – Feature preview card with optional media and CTA row.
   Provide `primaryCta`/`secondaryCta` props to render button controls, or leave
   them undefined for a purely informational card.

--- a/app/flashoffer-react/src/components/Section.tsx
+++ b/app/flashoffer-react/src/components/Section.tsx
@@ -15,7 +15,8 @@ export interface SectionProps extends SectionHeaderProps {
  *
  * Mirrors SectionHeader defaults (Flashoffer eyebrow, marketing title,
  * centered alignment) while exposing extra space for arbitrary `children` and
- * an optional section `id`.
+ * an optional section `id`. Pass supporting markup as regular React nodes
+ * rather than assembling arrays; the surrounding Stack handles spacing.
  */
 export function Section({
   align = "center",

--- a/app/flashoffer-react/src/components/Section.tsx
+++ b/app/flashoffer-react/src/components/Section.tsx
@@ -12,6 +12,10 @@ export interface SectionProps extends SectionHeaderProps {
 
 /**
  * High-level section wrapper that combines SectionHeader with supporting copy.
+ *
+ * Mirrors SectionHeader defaults (Flashoffer eyebrow, marketing title,
+ * centered alignment) while exposing extra space for arbitrary `children` and
+ * an optional section `id`.
  */
 export function Section({
   align = "center",

--- a/app/flashoffer-react/src/components/SectionHeader.tsx
+++ b/app/flashoffer-react/src/components/SectionHeader.tsx
@@ -16,6 +16,10 @@ const DEFAULT_TITLE = "Launch faster with reusable content blocks.";
 
 /**
  * Section heading with optional eyebrow and configurable alignment.
+ *
+ * Defaults render the "FLASHOFFER" eyebrow and the "Launch faster with
+ * reusable content blocks." title. Text is centered unless `align="left"` is
+ * provided, and either content slot can be omitted by passing `null`.
  */
 export function SectionHeader({
   eyebrow = DEFAULT_EYEBROW,

--- a/docs/reference/analytics-stack.md
+++ b/docs/reference/analytics-stack.md
@@ -44,7 +44,7 @@ import {
   EngagementProvider,
   AutoTrack,
   useRecordInteraction,
-} from "@press/analytics";
+} from "flashoffer-react";
 
 export function App() {
   return (
@@ -52,6 +52,11 @@ export function App() {
       endpoint="/events"
       site="marketing"
       flushInterval={2500}
+      heartbeatInterval={10000}
+      idleTimeout={60000}
+      scrollThresholds={[0.25, 0.5, 0.75, 1]}
+      viewThresholds={[0.25, 0.5, 0.75, 1]}
+      maxBatch={50}
     >
       <LandingPage />
       <AutoTrack selector="[data-track-id]" />
@@ -75,8 +80,10 @@ function LandingPage() {
 
 `EngagementProvider` handles batching and submission, while AutoTrack discovers
 elements annotated with `data-track-*` attributes and emits view events as they
-enter and leave the viewport. Manual interactions call directly into the
-provider with `useRecordInteraction` to supply richer metadata.
+enter and leave the viewport. Tuning `heartbeatInterval`, `idleTimeout`,
+`scrollThresholds`, `viewThresholds`, or `maxBatch` adjusts how aggressively
+the provider samples and flushes data. Manual interactions call directly into
+the provider with `useRecordInteraction` to supply richer metadata.
 
 ## Demo walkthrough
 Embedding the helpers from `app/flashoffer-react` inside a marketing page


### PR DESCRIPTION
## Summary
- update the flashoffer-react README to spell out Section and SectionHeader defaults
- expand the Section and SectionHeader JSDoc comments so generated docs stay accurate

## Testing
- not run (docs-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68dde119ee688321993c50cca158234f