### PR TITLE
Inline flashoffer demo illustrations

### DIFF
--- a/app/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer-demo/src/App.tsx
@@ -64,11 +64,100 @@ const themePresets: Record<ThemePreset, ThemeOptions | undefined> = {
 };
 
 const heroMedia = (
-  <img
-    src="https://images.unsplash.com/photo-1553877522-43269d4ea984?auto=format&fit=crop&w=720&q=80"
-    alt="Marketing dashboard showing campaign metrics"
-    style={{ width: "100%", borderRadius: "24px", boxShadow: "0 24px 60px rgba(15, 23, 42, 0.12)" }}
-  />
+  <svg
+    viewBox="0 0 720 480"
+    role="img"
+    aria-labelledby="hero-illustration-title hero-illustration-desc"
+    style={{
+      width: "100%",
+      borderRadius: "24px",
+      boxShadow: "0 24px 60px rgba(15, 23, 42, 0.12)"
+    }}
+  >
+    <title id="hero-illustration-title">
+      Marketing dashboard illustration
+    </title>
+    <desc id="hero-illustration-desc">
+      A stylized dashboard with charts representing campaign performance.
+    </desc>
+    <defs>
+      <linearGradient id="heroGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stopColor="#1d4ed8" stopOpacity="0.16" />
+        <stop offset="100%" stopColor="#60a5fa" stopOpacity="0.32" />
+      </linearGradient>
+      <linearGradient id="heroBar" x1="0%" y1="100%" x2="0%" y2="0%">
+        <stop offset="0%" stopColor="#2563eb" />
+        <stop offset="100%" stopColor="#a855f7" />
+      </linearGradient>
+    </defs>
+    <rect fill="#f8fafc" x="0" y="0" width="720" height="480" rx="32" />
+    <rect
+      x="36"
+      y="48"
+      width="648"
+      height="384"
+      rx="24"
+      fill="url(#heroGradient)"
+    />
+    <g transform="translate(96 120)">
+      <rect
+        x="0"
+        y="0"
+        width="528"
+        height="72"
+        rx="12"
+        fill="#0f172a"
+        opacity="0.92"
+      />
+      <circle cx="48" cy="36" r="18" fill="#38bdf8" opacity="0.85" />
+      <rect x="90" y="24" width="96" height="12" rx="6" fill="#cbd5f5" />
+      <rect x="90" y="48" width="168" height="8" rx="4" fill="#a5b4fc" />
+      <rect x="282" y="24" width="72" height="12" rx="6" fill="#cbd5f5" />
+      <rect x="282" y="48" width="102" height="8" rx="4" fill="#a5b4fc" />
+      <rect x="402" y="24" width="66" height="12" rx="6" fill="#cbd5f5" />
+      <rect x="402" y="48" width="84" height="8" rx="4" fill="#a5b4fc" />
+    </g>
+    <g transform="translate(126 228)">
+      <rect
+        x="0"
+        y="0"
+        width="468"
+        height="180"
+        rx="20"
+        fill="#0f172a"
+        opacity="0.88"
+      />
+      <polyline
+        points="48,132 126,72 204,108 282,60 360,96 420,24"
+        fill="none"
+        stroke="#facc15"
+        strokeWidth="8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity="0.9"
+      />
+      <rect x="60" y="36" width="48" height="84" rx="8" fill="url(#heroBar)" />
+      <rect x="144" y="60" width="48" height="60" rx="8" fill="url(#heroBar)" />
+      <rect x="228" y="36" width="48" height="84" rx="8" fill="url(#heroBar)" />
+      <rect x="312" y="24" width="48" height="96" rx="8" fill="url(#heroBar)" />
+      <rect x="396" y="48" width="48" height="72" rx="8" fill="url(#heroBar)" />
+      <rect x="36" y="144" width="96" height="12" rx="6" fill="#38bdf8" />
+      <rect x="150" y="144" width="96" height="12" rx="6" fill="#38bdf8" />
+      <rect x="264" y="144" width="96" height="12" rx="6" fill="#38bdf8" />
+    </g>
+    <rect
+      x="96"
+      y="348"
+      width="528"
+      height="66"
+      rx="18"
+      fill="#0f172a"
+      opacity="0.92"
+    />
+    <rect x="132" y="372" width="162" height="18" rx="9" fill="#38bdf8" />
+    <rect x="318" y="372" width="108" height="18" rx="9" fill="#6366f1" />
+    <rect x="450" y="372" width="102" height="18" rx="9" fill="#a855f7" />
+  </svg>
 );
 
 export default function App() {

--- a/app/flashoffer-demo/src/sections/FigureSpotlightSection.tsx
+++ b/app/flashoffer-demo/src/sections/FigureSpotlightSection.tsx
@@ -4,6 +4,37 @@ import { Figure, Section } from "flashoffer-react";
 
 const FIGURE_META = JSON.stringify({ orientation: "landscape" });
 
+const FIGURE_IMAGE_SRC = `data:image/svg+xml;utf8,${encodeURIComponent(
+  `<svg viewBox="0 0 960 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+    <defs>
+      <linearGradient id="figureGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#1d4ed8" stop-opacity="0.18" />
+        <stop offset="100%" stop-color="#a855f7" stop-opacity="0.28" />
+      </linearGradient>
+    </defs>
+    <rect x="0" y="0" width="960" height="640" rx="48" fill="#0f172a" />
+    <rect x="48" y="60" width="864" height="520" rx="40" fill="url(#figureGradient)" />
+    <g transform="translate(120 140)" fill="#0f172a" fill-opacity="0.9">
+      <rect x="0" y="0" width="720" height="80" rx="20" />
+      <rect x="60" y="24" width="200" height="16" rx="8" fill="#cbd5f5" />
+      <rect x="60" y="52" width="320" height="12" rx="6" fill="#94a3b8" />
+      <circle cx="36" cy="40" r="14" fill="#38bdf8" />
+    </g>
+    <g transform="translate(174 260)">
+      <rect x="0" y="0" width="612" height="300" rx="32" fill="#0f172a" fill-opacity="0.92" />
+      <polyline points="72,220 168,168 264,196 360,140 456,176 528,104" fill="none" stroke="#facc15" stroke-width="16" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.9" />
+      <rect x="90" y="72" width="48" height="168" rx="16" fill="#38bdf8" />
+      <rect x="198" y="116" width="48" height="124" rx="16" fill="#6366f1" />
+      <rect x="306" y="96" width="48" height="144" rx="16" fill="#a855f7" />
+      <rect x="414" y="52" width="48" height="188" rx="16" fill="#22d3ee" />
+      <rect x="522" y="132" width="48" height="108" rx="16" fill="#38bdf8" />
+      <rect x="120" y="244" width="168" height="18" rx="9" fill="#38bdf8" fill-opacity="0.85" />
+      <rect x="318" y="244" width="168" height="18" rx="9" fill="#6366f1" fill-opacity="0.75" />
+    </g>
+  </svg>`
+)}
+`;
+
 export function FigureSpotlightSection() {
   return (
     <Box
@@ -28,7 +59,7 @@ export function FigureSpotlightSection() {
           }}
         >
           <Figure
-            src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=960&q=80"
+            src={FIGURE_IMAGE_SRC}
             alt="Product marketer reviewing launch campaign timelines"
             caption="Launch dashboards stay legible on any device thanks to responsive scaling."
             sx={{

--- a/app/flashoffer-demo/src/sections/content.tsx
+++ b/app/flashoffer-demo/src/sections/content.tsx
@@ -1,3 +1,70 @@
+const previewMedia = (
+  gradientId: string,
+  accentColor: string,
+  secondaryAccent: string
+) => (
+  <svg
+    viewBox="0 0 320 240"
+    role="img"
+    aria-hidden="true"
+    style={{ width: "100%", borderRadius: "16px" }}
+  >
+    <defs>
+      <linearGradient id={`${gradientId}-background`} x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stopColor={accentColor} stopOpacity="0.12" />
+        <stop offset="100%" stopColor={secondaryAccent} stopOpacity="0.24" />
+      </linearGradient>
+    </defs>
+    <rect
+      x="0"
+      y="0"
+      width="320"
+      height="240"
+      rx="18"
+      fill={`url(#${gradientId}-background)`}
+    />
+    <g transform="translate(36 42)" fill="#0f172a" opacity="0.85">
+      <rect x="0" y="0" width="248" height="30" rx="8" />
+      <rect x="0" y="48" width="208" height="18" rx="9" opacity="0.9" />
+      <rect x="0" y="78" width="168" height="18" rx="9" opacity="0.8" />
+      <rect x="0" y="108" width="192" height="18" rx="9" opacity="0.7" />
+    </g>
+    <g transform="translate(36 150)">
+      <rect x="0" y="0" width="36" height="60" rx="12" fill={accentColor} />
+      <rect
+        x="60"
+        y="12"
+        width="36"
+        height="48"
+        rx="12"
+        fill={secondaryAccent}
+        opacity="0.85"
+      />
+      <rect
+        x="120"
+        y="6"
+        width="36"
+        height="54"
+        rx="12"
+        fill={accentColor}
+        opacity="0.8"
+      />
+      <rect
+        x="180"
+        y="18"
+        width="36"
+        height="42"
+        rx="12"
+        fill={secondaryAccent}
+        opacity="0.75"
+      />
+    </g>
+    <circle cx="252" cy="72" r="18" fill={accentColor} opacity="0.9" />
+    <circle cx="280" cy="96" r="12" fill={secondaryAccent} opacity="0.8" />
+    <circle cx="258" cy="116" r="8" fill="#0f172a" opacity="0.75" />
+  </svg>
+);
+
 export const OVERVIEW_PARAGRAPHS = [
   "Use the Section component to pair launch announcements, feature guides, or changelog summaries with consistent typography.",
   "Each paragraph is wrapped in semantic markup and inherits spacing from the Flashoffer design tokens, so marketing teams can focus on messaging."
@@ -8,25 +75,13 @@ export const PREVIEW_CARDS = [
     title: "Personalized launch offers",
     description:
       "Highlight tailored bundles that can be activated in a few clicks. Swap copy and imagery to match your latest campaign without rebuilding layouts.",
-    media: (
-      <img
-        src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=480&q=80"
-        alt="Two teammates collaborating over a laptop"
-        style={{ width: "100%", borderRadius: "16px" }}
-      />
-    )
+    media: previewMedia("preview-offers", "#22d3ee", "#6366f1")
   },
   {
     title: "Lifecycle automation",
     description:
       "Pair Flashoffer pages with your automation stack to trigger discounts or add-ons in response to usage signals.",
-    media: (
-      <img
-        src="https://images.unsplash.com/photo-1527430253228-e93688616381?auto=format&fit=crop&w=480&q=80"
-        alt="Abstract dashboard charts"
-        style={{ width: "100%", borderRadius: "16px" }}
-      />
-    ),
+    media: previewMedia("preview-automation", "#f97316", "#facc15"),
     secondaryCta: {
       label: "View playbook",
       href: "https://example.com/playbook"
@@ -36,13 +91,7 @@ export const PREVIEW_CARDS = [
     title: "Localized experiences",
     description:
       "Clone the same structure across regions while tuning content, pricing, and compliance disclosures in minutes.",
-    media: (
-      <img
-        src="https://images.unsplash.com/photo-1527430253228-e93688616381?auto=format&fit=crop&w=480&q=80"
-        alt="Abstract dashboard charts"
-        style={{ width: "100%", borderRadius: "16px" }}
-      />
-    ),
+    media: previewMedia("preview-localized", "#34d399", "#60a5fa"),
     primaryCta: {
       label: "See localization tips",
       href: "https://example.com/localization"


### PR DESCRIPTION
## Summary
- replace external hero banner image with inline SVG illustration
- inline preview card artwork and figure media to remove remote image requests

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dde44266688321acd6cf86157f8d78