### PR TITLE
Document Dockerfiles across services

### DIFF
--- a/app/analytics-backend/Dockerfile
+++ b/app/analytics-backend/Dockerfile
@@ -1,41 +1,78 @@
+######################################################################
+# Analytics API image
+#
+# The analytics backend is a Flask application that serves reporting
+# endpoints consumed by the admin UI. This multi-stage build assembles a
+# reusable base image with Python dependencies and then derives separate
+# development and production targets.
+######################################################################
+
+# Use the slim Python image to keep the base layer small while still
+# providing the tooling required to install Python wheels.
 FROM python:3.11-slim AS base
 
+# Disable bytecode generation to reduce container filesystem churn and set
+# defaults used by both the dev and prod entrypoints.
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     FLASK_APP=analytics_backend.app:create_app \
     CORS_ALLOW_ORIGINS=
 
+# Run the application from /app to match the runtime layout expected by
+# the Flask CLI and unit tests.
 WORKDIR /app
 
+# Copy dependency manifests and shared PIE utilities first so Docker can
+# reuse the layer when application code changes.
 COPY app/analytics-backend/requirements.txt ./requirements.txt
 COPY app/shell/py/pie /tmp/pie
+
+# Install application dependencies, the shared PIE package, and dominate
+# (used to render HTML emails). Cleaning the temporary directory avoids
+# keeping duplicate source trees in the final image.
 RUN pip install --no-cache-dir -r requirements.txt \
     && pip install --no-cache-dir /tmp/pie dominate \
     && rm -rf /tmp/pie
 
+# Copy the application and tests as the final step so source edits only
+# invalidate the top layer.
 COPY app/analytics-backend/analytics_backend ./analytics_backend
 COPY app/analytics-backend/tests ./tests
 
 FROM base AS dev
 
+# The development target exposes Flask's default port for the live reload
+# server.
 EXPOSE 8000
 
+# Run the Flask development server by default to support local workflows.
 CMD ["flask", "--app", "analytics_backend.app:create_app", "run", "--host=0.0.0.0", "--port=8000"]
 
 FROM base AS prod
+
+# Configure Gunicorn defaults; these can be overridden at runtime but the
+# baked-in values match our deployment needs.
 ENV GUNICORN_WORKERS=4 \
     GUNICORN_BIND=unix:/tmp/gunicorn.sock
 
+# Install nginx for reverse proxying and clean up apt metadata to keep the
+# image size in check.
 RUN apt-get update \
     && apt-get install --no-install-recommends -y nginx \
     && rm -rf /var/lib/apt/lists/*
 
+# Gunicorn is only required in the production image, so install it here to
+# avoid bloating the base stage.
 RUN pip install --no-cache-dir gunicorn
 
+# Provide the templated nginx config and startup script used in
+# deployments.
 COPY app/analytics-backend/nginx.conf /etc/nginx/conf.d/default.conf
 COPY app/analytics-backend/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# The production container serves the app via nginx on port 8000.
 EXPOSE 8000
 
+# Launch the entrypoint that supervises both nginx and Gunicorn.
 CMD ["/entrypoint.sh"]

--- a/app/analytics-db/Dockerfile
+++ b/app/analytics-db/Dockerfile
@@ -1,1 +1,11 @@
+######################################################################
+# Analytics database image
+#
+# The analytics service persists metrics inside TimescaleDB. We reuse the
+# upstream image so that database tuning and extension management stay in
+# sync with the official Timescale releases.
+######################################################################
+
+# Pull the latest PostgreSQL 14 TimescaleDB image which includes the
+# extension and recommended configuration out of the box.
 FROM timescale/timescaledb:latest-pg14

--- a/app/flashoffer/Dockerfile
+++ b/app/flashoffer/Dockerfile
@@ -1,17 +1,32 @@
 # syntax=docker/dockerfile:1.6
 
+######################################################################
+# Flashoffer demo build
+#
+# This Dockerfile builds the React-based Flashoffer demo as well as the
+# supporting static assets served by nginx. Multi-stage builds keep Node.js
+# tooling out of the final runtime image while allowing layer reuse across
+# the flashoffer-react and flashoffer-demo packages.
+######################################################################
+
+# Base Node.js layer shared by all build stages. The slim variant provides
+# npm without unnecessary language runtimes.
 FROM node:22-slim AS base
 WORKDIR /workspace
 
+# Install dependencies for the Flashoffer React package so subsequent
+# stages can reuse the layer when only source files change.
 FROM base AS flashoffer-react-deps
 WORKDIR /workspace/app/flashoffer-react
 COPY app/flashoffer-react/package.json app/flashoffer-react/package-lock.json ./
 RUN npm ci
 
+# Build the production Flashoffer React bundle.
 FROM flashoffer-react-deps AS flashoffer-react-build
 COPY app/flashoffer-react ./
 RUN npm run build
 
+# Build the static demo shell that embeds the Flashoffer widget.
 FROM flashoffer-react-build AS flashoffer-demo-build
 WORKDIR /workspace/app/flashoffer-demo
 COPY app/flashoffer-demo/package.json app/flashoffer-demo/package-lock.json ./
@@ -19,6 +34,8 @@ RUN npm ci
 COPY app/flashoffer-demo ./
 RUN npm run build
 
+# Runtime image for running the demo via the Vite preview server. This is
+# primarily used for local development or integration tests.
 FROM node:22-slim AS runner
 ENV NODE_ENV=production
 ENV PORT=4173
@@ -30,6 +47,8 @@ RUN chmod +x /usr/local/bin/flashoffer-entrypoint
 EXPOSE 4173
 ENTRYPOINT ["flashoffer-entrypoint"]
 
+# Production image served by nginx. Only the static assets are copied in,
+# keeping the container small and secure.
 FROM nginx:1.27-alpine AS production
 WORKDIR /usr/share/nginx/html
 COPY app/flashoffer/nginx.conf /etc/nginx/conf.d/default.conf

--- a/app/nginx/Dockerfile
+++ b/app/nginx/Dockerfile
@@ -1,3 +1,13 @@
+######################################################################
+# Static site nginx image
+#
+# This container serves the pre-built Press site. The Docker build embeds
+# a chosen nginx configuration and the static artifact produced by the
+# frontend pipeline so the image can run without external volumes.
+######################################################################
+
+# Use the lightweight Alpine-based nginx image since it already contains an
+# optimized configuration for serving static files.
 FROM nginx:alpine-slim
 
 # Allows specifying which nginx configuration file to include at build time.

--- a/app/pdoc/Dockerfile
+++ b/app/pdoc/Dockerfile
@@ -1,11 +1,24 @@
+######################################################################
+# PIE documentation server image
+#
+# The pdoc container hosts API documentation for the PIE Python package.
+# It installs the same dependencies used in development and exposes the
+# auto-generated site via pdoc's built-in web server.
+######################################################################
+
+# Start from the slim Python base to reduce image size while retaining pip
+# and build tooling.
 FROM python:3.11-slim
 
 WORKDIR /pie
 
-# Install pdoc and dependencies for pie
+# Install pdoc along with the PIE package dependencies to ensure modules
+# import correctly when documentation is generated.
 COPY app/shell/py/pie/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir pdoc \
     && pip install --no-cache-dir -r /tmp/requirements.txt
 
+# Expose the port used by pdoc's HTTP server and configure the entrypoint to
+# render the PIE package docs on demand.
 EXPOSE 8080
 ENTRYPOINT ["pdoc", "-h", "0.0.0.0", "-p", "8080", "pie"]

--- a/app/release/Dockerfile
+++ b/app/release/Dockerfile
@@ -1,3 +1,16 @@
+######################################################################
+# Production site image
+#
+# The release container layers site assets on top of the press-shell base
+# image produced by the development tooling. This keeps the runtime
+# environment consistent between build and deploy steps.
+######################################################################
+
+# Reuse the press-shell image so Python, Node, and other build dependencies
+# are already installed.
 FROM press-shell
+
+# Copy the compiled JavaScript bundle and shared Jinja macro into the
+# locations expected by the running site.
 COPY ./build/static/js/ /press/static/js/
 COPY ./src/templates/macros.jinja /press/templates/macros.jinja

--- a/app/s3/Dockerfile
+++ b/app/s3/Dockerfile
@@ -1,7 +1,24 @@
+######################################################################
+# S3 utility image
+#
+# This container provides the s3cmd CLI and its configuration for running
+# backup and asset-sync tasks from CI. It intentionally remains minimal so
+# jobs start quickly.
+######################################################################
+
+# Use Debian testing to get recent s3cmd releases without building from
+# source.
 FROM debian:testing-slim
+
+# Refresh package metadata and install the S3 tooling plus CA certificates
+# for TLS validation.
 RUN apt update -qq
 RUN apt install -y --no-install-recommends s3cmd
 RUN apt-get install -y ca-certificates
+
+# Remove apt caches to keep the final image size lean.
 RUN rm -rf /var/lib/apt/lists/*
+
+# Provide helper scripts and the default s3cmd configuration.
 COPY ./bin /app/bin
 COPY ./root/.s3cfg /root/.s3cfg

--- a/app/webp/Dockerfile
+++ b/app/webp/Dockerfile
@@ -1,6 +1,27 @@
+######################################################################
+# WebP conversion service image
+#
+# This Dockerfile builds the runtime used by the background worker that
+# converts uploaded images to WebP. Only the utilities required for the
+# conversion pipeline are installed to keep the image small.
+######################################################################
+
+# Start from the slim Debian testing base to access a recent ImageMagick
+# build with WebP support without pulling in unnecessary packages.
 FROM debian:testing-slim
+
+# Refresh package metadata before installing dependencies.
 RUN apt update -qq
+
+# Install ImageMagick for the conversion and jpegoptim to losslessly
+# compress JPEG inputs prior to converting them to WebP. Using
+# --no-install-recommends keeps the layer focused on the essentials.
 RUN apt install -y --no-install-recommends imagemagick
 RUN apt install -y --no-install-recommends jpegoptim
+
+# Remove cached package metadata to keep the final image lean.
 RUN rm -rf /var/lib/apt/lists/*
+
+# Copy the conversion service entrypoint into the container. The script
+# polls the input directory and runs the conversion workflow.
 COPY ./bin/service /app/bin/service


### PR DESCRIPTION
## Summary
- add high-level documentation to each service Dockerfile to explain image roles and key build steps
- clarify the multi-stage Flashoffer build and analytics backend stages so contributors understand how to extend them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dde4fe23408321aefa686951614f8f