### PR TITLE
Optimize analytics-db Dockerfile caching

### DIFF
--- a/app/analytics-db/Dockerfile
+++ b/app/analytics-db/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.6
 ######################################################################
 # Analytics database image
 #
@@ -9,8 +10,11 @@
 # Pull the latest PostgreSQL 14 TimescaleDB image which includes the
 # extension and recommended configuration out of the box.
 FROM timescale/timescaledb:latest-pg14
-RUN apk add s3cmd
-RUN apk add --no-cache python3 py3-pip postgresql-client
-RUN pip install --no-cache-dir --break-system-packages psycopg[binary] pandas
+
+RUN --mount=type=cache,target=/var/cache/apk \
+  apk add --no-cache s3cmd python3 py3-pip postgresql-client
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+  pip install --break-system-packages psycopg[binary] pandas
 COPY ./app/analytics-db/s3cfg /root/.s3cfg
 COPY ./app/analytics-db/bin/ /root/bin/


### PR DESCRIPTION
## Summary
- enable Dockerfile BuildKit syntax to support cache mounts
- reuse cached layers for apk and pip to reduce redundant downloads when building analytics-db

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea6de0468832182a19007ab07ff8f