### PR TITLE
Align spacious hero banner with spacious presets

### DIFF
--- a/app/flashoffer-demo/package-lock.json
+++ b/app/flashoffer-demo/package-lock.json
@@ -52,6 +52,8 @@
         "jest-environment-jsdom": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
+        "typedoc": "^0.28.0",
+        "typedoc-plugin-markdown": "^4.9.0",
         "typescript": "^5.6.3",
         "vite": "^7.0.4",
         "vite-plugin-dts": "^4.5.4"

--- a/app/flashoffer-demo/src/App.test.tsx
+++ b/app/flashoffer-demo/src/App.test.tsx
@@ -65,4 +65,34 @@ describe("Flashoffer demo", () => {
       ).toBe("#0f172a");
     });
   });
+
+  it.each([
+    ["spaciousLight", "rgba(29, 78, 216, 0.14)", "rgba(219, 39, 119, 0.18)"],
+    ["spaciousDark", "rgba(96, 165, 250, 0.28)", "rgba(15, 23, 42, 0.85)"]
+  ])(
+    "updates the hero banner gradient tokens for the %s theme",
+    async (preset, gradientStart, gradientStop) => {
+      render(<App />);
+
+      const paletteSelect = await screen.findByLabelText(
+        /select theme palette/i
+      );
+      fireEvent.change(paletteSelect, { target: { value: preset } });
+
+      const heroWrapper = (await screen.findByTestId("hero-banner-wrapper")) as HTMLElement;
+
+      await waitFor(() => {
+        expect(
+          getComputedStyle(heroWrapper).getPropertyValue(
+            "--flashoffer-hero-gradient-start"
+          ).trim()
+        ).toBe(gradientStart);
+        expect(
+          getComputedStyle(heroWrapper).getPropertyValue(
+            "--flashoffer-hero-gradient-stop"
+          ).trim()
+        ).toBe(gradientStop);
+      });
+    }
+  );
 });

--- a/app/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer-demo/src/App.tsx
@@ -1,11 +1,13 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Stack from "@mui/material/Stack";
-import type { ThemeOptions } from "@mui/material/styles";
+import type { PaletteMode, ThemeOptions } from "@mui/material/styles";
 import { Suspense, lazy, startTransition, useMemo, useState } from "react";
 import { FlashofferThemeProvider } from "flashoffer-react";
+import type { FlashofferThemePreset } from "flashoffer-react";
 import type { HeroAlignment, ThemePreset } from "./sections/types";
 import { OVERVIEW_PARAGRAPHS, PREVIEW_CARDS } from "./sections/content";
+import { THEME_PRESET_LABELS } from "./sections/types";
 
 const CustomizationControlsSection = lazy(async () => ({
   default: (await import("./sections/CustomizationControlsSection")).CustomizationControlsSection
@@ -35,31 +37,49 @@ const FooterSection = lazy(async () => ({
   default: (await import("./sections/FooterSection")).FooterSection
 }));
 
-const themePresets: Record<ThemePreset, ThemeOptions | undefined> = {
-  ocean: undefined,
+interface ThemePresetConfig {
+  preset?: FlashofferThemePreset;
+  colorMode?: PaletteMode;
+  themeOptions?: ThemeOptions;
+}
+
+const themePresets: Record<ThemePreset, ThemePresetConfig> = {
+  ocean: {},
   sunset: {
-    palette: {
-      primary: { main: "#f97316", contrastText: "#1f2937" },
-      secondary: { main: "#facc15", contrastText: "#0f172a" }
+    themeOptions: {
+      palette: {
+        primary: { main: "#f97316", contrastText: "#1f2937" },
+        secondary: { main: "#facc15", contrastText: "#0f172a" }
+      }
     }
   },
   midnight: {
-    palette: {
-      primary: { main: "#6366f1", contrastText: "#f8fafc" },
-      secondary: { main: "#38bdf8", contrastText: "#0f172a" },
-      background: { default: "#0f172a", paper: "#111827" },
-      text: { primary: "#f8fafc", secondary: "#cbd5f5" }
-    },
-    components: {
-      MuiCard: {
-        styleOverrides: {
-          root: {
-            backgroundColor: "rgba(15, 23, 42, 0.75)",
-            border: "1px solid rgba(148, 163, 184, 0.2)"
+    themeOptions: {
+      palette: {
+        primary: { main: "#6366f1", contrastText: "#f8fafc" },
+        secondary: { main: "#38bdf8", contrastText: "#0f172a" },
+        background: { default: "#0f172a", paper: "#111827" },
+        text: { primary: "#f8fafc", secondary: "#cbd5f5" }
+      },
+      components: {
+        MuiCard: {
+          styleOverrides: {
+            root: {
+              backgroundColor: "rgba(15, 23, 42, 0.75)",
+              border: "1px solid rgba(148, 163, 184, 0.2)"
+            }
           }
         }
       }
     }
+  },
+  spaciousLight: {
+    preset: "spaciousTypography",
+    colorMode: "light"
+  },
+  spaciousDark: {
+    preset: "spaciousTypography",
+    colorMode: "dark"
   }
 };
 
@@ -164,18 +184,28 @@ export default function App() {
   const [palettePreset, setPalettePreset] = useState<ThemePreset>("ocean");
   const [heroAlignment, setHeroAlignment] = useState<HeroAlignment>("center");
 
-  const themeOptions = useMemo(
+  const themeConfig = useMemo(
     () => themePresets[palettePreset],
     [palettePreset]
   );
 
   const controlsMeta = useMemo(
-    () => JSON.stringify({ palette: palettePreset, heroAlignment }),
+    () =>
+      JSON.stringify({
+        palette: palettePreset,
+        presetLabel: THEME_PRESET_LABELS[palettePreset],
+        heroAlignment
+      }),
     [heroAlignment, palettePreset]
   );
 
   const heroMeta = useMemo(
-    () => JSON.stringify({ alignment: heroAlignment, palette: palettePreset }),
+    () =>
+      JSON.stringify({
+        alignment: heroAlignment,
+        palette: palettePreset,
+        presetLabel: THEME_PRESET_LABELS[palettePreset]
+      }),
     [heroAlignment, palettePreset]
   );
 
@@ -190,12 +220,20 @@ export default function App() {
   );
 
   const pageMeta = useMemo(
-    () => JSON.stringify({ palette: palettePreset }),
+    () =>
+      JSON.stringify({
+        palette: palettePreset,
+        presetLabel: THEME_PRESET_LABELS[palettePreset]
+      }),
     [palettePreset]
   );
 
   return (
-    <FlashofferThemeProvider themeOptions={themeOptions}>
+    <FlashofferThemeProvider
+      themeOptions={themeConfig.themeOptions}
+      preset={themeConfig.preset}
+      colorMode={themeConfig.colorMode}
+    >
       <Box
         sx={{
           backgroundColor: "var(--flashoffer-color-background)",

--- a/app/flashoffer-demo/src/sections/CustomizationControlsSection.tsx
+++ b/app/flashoffer-demo/src/sections/CustomizationControlsSection.tsx
@@ -5,6 +5,7 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { Section } from "flashoffer-react";
 import type { HeroAlignment, ThemePreset } from "./types";
+import { THEME_PRESET_LABELS, THEME_PRESET_ORDER } from "./types";
 
 export interface CustomizationControlsSectionProps {
   palettePreset: ThemePreset;
@@ -71,9 +72,11 @@ export function CustomizationControlsSection({
               data-track-label="Palette selector"
               data-track-meta={JSON.stringify({ palette: palettePreset })}
             >
-              <option value="ocean">Ocean (default)</option>
-              <option value="sunset">Sunset</option>
-              <option value="midnight">Midnight</option>
+              {THEME_PRESET_ORDER.map((value) => (
+                <option key={value} value={value}>
+                  {THEME_PRESET_LABELS[value]}
+                </option>
+              ))}
             </select>
           </Box>
           <Box>

--- a/app/flashoffer-demo/src/sections/HeroShowcaseSection.tsx
+++ b/app/flashoffer-demo/src/sections/HeroShowcaseSection.tsx
@@ -22,6 +22,14 @@ const HERO_GRADIENT_OVERRIDES: Record<
   midnight: {
     "--flashoffer-hero-gradient-start": "#1e293b",
     "--flashoffer-hero-gradient-stop": "#0f172a"
+  },
+  spaciousLight: {
+    "--flashoffer-hero-gradient-start": "rgba(29, 78, 216, 0.14)",
+    "--flashoffer-hero-gradient-stop": "rgba(219, 39, 119, 0.18)"
+  },
+  spaciousDark: {
+    "--flashoffer-hero-gradient-start": "rgba(96, 165, 250, 0.28)",
+    "--flashoffer-hero-gradient-stop": "rgba(15, 23, 42, 0.85)"
   }
 };
 
@@ -45,6 +53,7 @@ export function HeroShowcaseSection({
       data-track-id="hero-banner"
       data-track-label="Hero banner"
       data-track-meta={heroMeta}
+      data-testid="hero-banner-wrapper"
       sx={heroGradientOverrides}
     >
       <HeroBanner

--- a/app/flashoffer-demo/src/sections/types.ts
+++ b/app/flashoffer-demo/src/sections/types.ts
@@ -1,2 +1,23 @@
-export type ThemePreset = "ocean" | "sunset" | "midnight";
+export type ThemePreset =
+  | "ocean"
+  | "sunset"
+  | "midnight"
+  | "spaciousLight"
+  | "spaciousDark";
 export type HeroAlignment = "left" | "center";
+
+export const THEME_PRESET_ORDER: readonly ThemePreset[] = [
+  "ocean",
+  "sunset",
+  "midnight",
+  "spaciousLight",
+  "spaciousDark"
+];
+
+export const THEME_PRESET_LABELS: Record<ThemePreset, string> = {
+  ocean: "Ocean (default)",
+  sunset: "Sunset",
+  midnight: "Midnight",
+  spaciousLight: "Spacious typography (light)",
+  spaciousDark: "Spacious typography (dark)"
+};

--- a/app/flashoffer-react/AGENTS.md
+++ b/app/flashoffer-react/AGENTS.md
@@ -1,0 +1,3 @@
+# Flashoffer React Guidelines
+
+- Prioritize responsive layouts that adapt gracefully to mobile viewports.

--- a/app/flashoffer-react/README.md
+++ b/app/flashoffer-react/README.md
@@ -62,10 +62,13 @@ export function LandingPage() {
 ### Theme customization
 
 `FlashofferThemeProvider` merges any supplied Material UI `ThemeOptions` with
-the baseline palette. For more granular control, call `createFlashofferTheme`
-and pass the resulting theme to your own `ThemeProvider` instance. The component
-primitives respect CSS tokens such as `--flashoffer-color-primary` and
-`--flashoffer-font-family`, enabling runtime theming through global styles.
+the baseline palette. Use the `preset` prop to activate opinionated design
+systems that ship with the library. The `colorMode` prop toggles between light
+and dark variants when a preset exposes them. For more granular control, call
+`createFlashofferTheme` and pass the resulting theme to your own
+`ThemeProvider` instance. The component primitives respect CSS tokens such as
+`--flashoffer-color-primary` and `--flashoffer-font-family`, enabling runtime
+theming through global styles.
 
 ```tsx
 import { ThemeProvider } from "@mui/material/styles";
@@ -78,6 +81,41 @@ const theme = createFlashofferTheme({
 });
 
 export function App({ children }: { children: React.ReactNode }) {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}
+```
+
+To start from the spacious typography preset rather than the default palette,
+pass the preset into the provider or derive a standalone theme with
+`createSpaciousTypographyTheme`.
+
+```tsx
+import { ThemeProvider } from "@mui/material/styles";
+import {
+  FlashofferThemeProvider,
+  createSpaciousTypographyTheme
+} from "flashoffer-react";
+
+export function SpaciousLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <FlashofferThemeProvider
+      preset="spaciousTypography"
+      colorMode="dark"
+      themeOptions={{ typography: { fontSize: 18 } }}
+    >
+      {children}
+    </FlashofferThemeProvider>
+  );
+}
+
+export function SpaciousThemeProvider({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  const theme = createSpaciousTypographyTheme("dark", {
+    typography: { fontSize: 18 }
+  });
   return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
 }
 ```

--- a/app/flashoffer-react/docs/reference/flashoffer-react/README.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/README.md
@@ -23,6 +23,7 @@
 
 ## Type Aliases
 
+- [FlashofferThemePreset](type-aliases/FlashofferThemePreset.md)
 - [OutlineCtaButtonProps](type-aliases/OutlineCtaButtonProps.md)
 - [PrimaryCtaButtonProps](type-aliases/PrimaryCtaButtonProps.md)
 
@@ -44,4 +45,5 @@
 - [Section](functions/Section.md)
 - [SectionHeader](functions/SectionHeader.md)
 - [createFlashofferTheme](functions/createFlashofferTheme.md)
+- [createSpaciousTypographyTheme](functions/createSpaciousTypographyTheme.md)
 - [FlashofferThemeProvider](functions/FlashofferThemeProvider.md)

--- a/app/flashoffer-react/docs/reference/flashoffer-react/functions/createSpaciousTypographyTheme.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/functions/createSpaciousTypographyTheme.md
@@ -1,0 +1,25 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Function: createSpaciousTypographyTheme()
+
+> **createSpaciousTypographyTheme**(`mode?`, `overrides?`): `Theme`
+
+Defined in: src/theme/FlashofferThemeProvider.tsx:105
+
+Create the spacious typography preset with optional overrides.
+
+## Parameters
+
+### mode?
+
+`PaletteMode`
+
+### overrides?
+
+`ThemeOptions`
+
+## Returns
+
+`Theme`

--- a/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/FlashofferThemeProviderProps.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/interfaces/FlashofferThemeProviderProps.md
@@ -41,3 +41,23 @@ Optional theme overrides merged with the default Flashoffer palette.
 Defined in: src/theme/FlashofferThemeProvider.tsx:86
 
 Whether to include MUI's CssBaseline.
+
+***
+
+### preset?
+
+> `optional` **preset**: [`FlashofferThemePreset`](../type-aliases/FlashofferThemePreset.md)
+
+Defined in: src/theme/FlashofferThemeProvider.tsx:95
+
+Select a preset to use as the base Flashoffer theme before applying overrides.
+
+***
+
+### colorMode?
+
+> `optional` **colorMode**: `PaletteMode`
+
+Defined in: src/theme/FlashofferThemeProvider.tsx:97
+
+Controls the palette mode for presets that support a light and dark variant.

--- a/app/flashoffer-react/docs/reference/flashoffer-react/type-aliases/FlashofferThemePreset.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/type-aliases/FlashofferThemePreset.md
@@ -1,0 +1,11 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Type Alias: FlashofferThemePreset
+
+> **FlashofferThemePreset** = "default" | "spaciousTypography"
+
+Defined in: src/theme/FlashofferThemeProvider.tsx:73
+
+Named preset options supported by `FlashofferThemeProvider`.

--- a/app/flashoffer-react/src/__tests__/components.test.tsx
+++ b/app/flashoffer-react/src/__tests__/components.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import Typography from "@mui/material/Typography";
-import { FlashofferThemeProvider, createFlashofferTheme } from "../index";
+import {
+  FlashofferThemeProvider,
+  createFlashofferTheme,
+  createSpaciousTypographyTheme
+} from "../index";
 import { Footer } from "../components/Footer";
 import { HeroBanner } from "../components/HeroBanner";
 import { OutlineCtaButton } from "../components/OutlineCtaButton";
@@ -193,6 +197,16 @@ describe("Flashoffer React primitives", () => {
     expect(theme.palette.primary.main).toBe("#123456");
   });
 
+  it("offers spacious typography theme variants", () => {
+    const lightTheme = createSpaciousTypographyTheme("light");
+    const darkTheme = createSpaciousTypographyTheme("dark");
+
+    expect(lightTheme.palette.mode).toBe("light");
+    expect(lightTheme.typography.body1?.lineHeight).toBe(1.75);
+    expect(darkTheme.palette.mode).toBe("dark");
+    expect(darkTheme.palette.background.default).toBe("#0b1120");
+  });
+
   it("propagates custom theme options through provider", () => {
     function ThemeProbe() {
       const theme = useTheme();
@@ -217,5 +231,32 @@ describe("Flashoffer React primitives", () => {
       "data-color",
       "#ff00aa"
     );
+  });
+
+  it("allows selecting the spacious typography preset", () => {
+    function ThemeProbe() {
+      const theme = useTheme();
+      return (
+        <span
+          data-testid="spacious-typography"
+          data-line-height={theme.typography.body1?.lineHeight}
+          data-background={theme.palette.background.default}
+        />
+      );
+    }
+
+    render(
+      <FlashofferThemeProvider
+        applyCssBaseline={false}
+        preset="spaciousTypography"
+        colorMode="dark"
+      >
+        <ThemeProbe />
+      </FlashofferThemeProvider>
+    );
+
+    const probe = screen.getByTestId("spacious-typography");
+    expect(probe).toHaveAttribute("data-line-height", "1.75");
+    expect(probe).toHaveAttribute("data-background", "#0b1120");
   });
 });

--- a/app/flashoffer-react/src/index.ts
+++ b/app/flashoffer-react/src/index.ts
@@ -1,4 +1,9 @@
-export { FlashofferThemeProvider, createFlashofferTheme } from "./theme/FlashofferThemeProvider";
+export {
+  FlashofferThemeProvider,
+  createFlashofferTheme,
+  createSpaciousTypographyTheme
+} from "./theme/FlashofferThemeProvider";
+export type { FlashofferThemePreset } from "./theme/FlashofferThemeProvider";
 export type { FlashofferThemeProviderProps } from "./theme/FlashofferThemeProvider";
 
 export { PrimaryCtaButton } from "./components/PrimaryCtaButton";

--- a/app/flashoffer-react/src/theme/FlashofferThemeProvider.tsx
+++ b/app/flashoffer-react/src/theme/FlashofferThemeProvider.tsx
@@ -2,13 +2,14 @@ import CssBaseline from "@mui/material/CssBaseline";
 import GlobalStyles from "@mui/material/GlobalStyles";
 import { StyledEngineProvider } from "@mui/material/styles";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
-import type { Theme, ThemeOptions } from "@mui/material/styles";
+import type { PaletteMode, Theme, ThemeOptions } from "@mui/material/styles";
 import { deepmerge } from "@mui/utils";
 import type { PropsWithChildren } from "react";
 import { useMemo } from "react";
 
 const baseThemeOptions: ThemeOptions = {
   palette: {
+    mode: "light",
     primary: {
       main: "#2563eb",
       contrastText: "#ffffff"
@@ -54,6 +55,141 @@ const baseThemeOptions: ThemeOptions = {
   }
 };
 
+const spaciousTypographyBaseOptions: ThemeOptions = {
+  typography: {
+    fontFamily:
+      '"Source Sans 3", "Inter", "Helvetica", "Arial", sans-serif',
+    fontSize: 16,
+    h1: {
+      fontWeight: 600,
+      fontSize: "clamp(2.75rem, 6vw, 3.5rem)",
+      lineHeight: 1.2,
+      letterSpacing: "-0.015em"
+    },
+    h2: {
+      fontWeight: 600,
+      fontSize: "clamp(2.25rem, 5vw, 3rem)",
+      lineHeight: 1.25,
+      letterSpacing: "-0.012em"
+    },
+    h3: {
+      fontWeight: 600,
+      fontSize: "clamp(1.75rem, 3.5vw, 2.25rem)",
+      lineHeight: 1.3,
+      letterSpacing: "-0.01em"
+    },
+    h4: {
+      fontWeight: 600,
+      fontSize: "clamp(1.5rem, 3vw, 1.875rem)",
+      lineHeight: 1.35,
+      letterSpacing: "-0.008em"
+    },
+    body1: {
+      fontSize: "1.125rem",
+      lineHeight: 1.75
+    },
+    body2: {
+      fontSize: "1.05rem",
+      lineHeight: 1.7
+    },
+    subtitle1: {
+      fontSize: "1rem",
+      lineHeight: 1.65
+    },
+    subtitle2: {
+      fontSize: "0.95rem",
+      lineHeight: 1.6
+    },
+    caption: {
+      letterSpacing: "0.08em",
+      textTransform: "uppercase"
+    },
+    button: {
+      textTransform: "none",
+      fontWeight: 600,
+      letterSpacing: "0.02em"
+    }
+  },
+  spacing: 10,
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        body: {
+          fontFeatureSettings: '"liga" 1, "kern" 1'
+        }
+      }
+    },
+    MuiContainer: {
+      styleOverrides: {
+        root: {
+          paddingInline: "clamp(1.25rem, 4vw, 2.5rem)"
+        }
+      }
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: "var(--flashoffer-radius-button, 999px)",
+          paddingInline: "clamp(2rem, 5vw, 2.75rem)",
+          paddingBlock: "0.875rem"
+        }
+      }
+    }
+  }
+};
+
+const spaciousTypographyPalette: Record<PaletteMode, ThemeOptions> = {
+  light: {
+    palette: {
+      mode: "light",
+      primary: {
+        main: "#1d4ed8",
+        contrastText: "#ffffff"
+      },
+      secondary: {
+        main: "#db2777",
+        contrastText: "#ffffff"
+      },
+      background: {
+        default: "#f1f5f9",
+        paper: "#ffffff"
+      },
+      text: {
+        primary: "#0f172a",
+        secondary: "#334155"
+      }
+    }
+  },
+  dark: {
+    palette: {
+      mode: "dark",
+      primary: {
+        main: "#60a5fa",
+        contrastText: "#0b1120"
+      },
+      secondary: {
+        main: "#f9a8d4",
+        contrastText: "#111827"
+      },
+      background: {
+        default: "#0b1120",
+        paper: "#111827"
+      },
+      text: {
+        primary: "#e2e8f0",
+        secondary: "#cbd5f5"
+      }
+    }
+  }
+};
+
+function buildSpaciousTypographyThemeOptions(mode: PaletteMode): ThemeOptions {
+  return deepmerge(
+    spaciousTypographyBaseOptions,
+    spaciousTypographyPalette[mode]
+  );
+}
+
 /**
  * Create a Flashoffer design system theme with optional overrides.
  */
@@ -63,6 +199,19 @@ export function createFlashofferTheme(overrides?: ThemeOptions): Theme {
   }
   return createTheme(deepmerge(baseThemeOptions, overrides));
 }
+
+export function createSpaciousTypographyTheme(
+  mode: PaletteMode = "light",
+  overrides?: ThemeOptions
+): Theme {
+  const baseOptions = buildSpaciousTypographyThemeOptions(mode);
+  if (!overrides) {
+    return createTheme(baseOptions);
+  }
+  return createTheme(deepmerge(baseOptions, overrides));
+}
+
+export type FlashofferThemePreset = "default" | "spaciousTypography";
 
 const cssVariableStyles = (theme: Theme) => ({
   ":root": {
@@ -84,6 +233,13 @@ export interface FlashofferThemeProviderProps extends PropsWithChildren {
   themeOptions?: ThemeOptions;
   /** Whether to include MUI's CssBaseline. */
   applyCssBaseline?: boolean;
+  /**
+   * Select a preset to use as the base Flashoffer theme before applying
+   * overrides.
+   */
+  preset?: FlashofferThemePreset;
+  /** Controls the palette mode for presets that support it. */
+  colorMode?: PaletteMode;
 }
 
 /**
@@ -92,11 +248,18 @@ export interface FlashofferThemeProviderProps extends PropsWithChildren {
 export function FlashofferThemeProvider({
   children,
   themeOptions,
-  applyCssBaseline = true
+  applyCssBaseline = true,
+  preset = "default",
+  colorMode = "light"
 }: FlashofferThemeProviderProps) {
   const theme = useMemo(
-    () => createFlashofferTheme(themeOptions),
-    [themeOptions]
+    () => {
+      if (preset === "spaciousTypography") {
+        return createSpaciousTypographyTheme(colorMode, themeOptions);
+      }
+      return createFlashofferTheme(themeOptions);
+    },
+    [colorMode, preset, themeOptions]
   );
 
   return (


### PR DESCRIPTION
## Summary
- add hero gradient overrides for the spacious typography light and dark presets and expose a test id for the banner wrapper
- extend the Flashoffer demo tests to verify the spacious presets set the expected hero gradient tokens

## Testing
- npm test -- src/App.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de9b06340c8321b5a5daae3a225e1f