### PR TITLE
Update Flashoffer React documentation guidelines

### DIFF
--- a/app/flashoffer-react/AGENTS.md
+++ b/app/flashoffer-react/AGENTS.md
@@ -1,3 +1,9 @@
 # Flashoffer React Guidelines
 
 - Prioritize responsive layouts that adapt gracefully to mobile viewports.
+- Each source file must begin with a copyright header crediting "Flashoffer
+  Developers" and noting that the library is released under the MIT license.
+- Document every function with a succinct summary of its purpose; use Typedoc
+  conventions for detailed parameter and return information.
+- Author documentation with the depth and tone expected between expert
+  software engineers.


### PR DESCRIPTION
## Summary
- expand the Flashoffer React agent instructions to require MIT copyright headers
- add guidance on function documentation using Typedoc conventions for expert audiences

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00913e3608321a579ca11031d2a86