### PR TITLE
Add rationale for flashoffer-react in demo copy

### DIFF
--- a/app/flashoffer-demo/src/sections/HeroShowcaseSection.tsx
+++ b/app/flashoffer-demo/src/sections/HeroShowcaseSection.tsx
@@ -59,7 +59,10 @@ export function HeroShowcaseSection({
       <HeroBanner
         align={heroAlignment}
         title="Launch coordinated offers in minutes."
-        subtitle="Flashoffer ships reusable hero, CTA, and preview components so teams can publish landing experiments without bespoke design cycles."
+        subtitle={
+          "Flashoffer-react helps artists publish campaigns without bending to " +
+          "inconsistent moderation while respecting civic safeguards."
+        }
         primaryCta={{
           label: "Explore Flashoffer components",
           href: "https://example.com/flashoffer",

--- a/app/flashoffer-demo/src/sections/OverviewSection.tsx
+++ b/app/flashoffer-demo/src/sections/OverviewSection.tsx
@@ -20,8 +20,8 @@ export function OverviewSection({ overviewMeta }: OverviewSectionProps) {
         title="Narrate launches with reusable sections"
       >
         <Typography color="text.secondary">
-          Combine headlines and supporting copy without rebuilding layouts from
-          scratch.
+          Combine headlines and supporting copy while staying independent from
+          opaque review cycles.
         </Typography>
         {OVERVIEW_PARAGRAPHS.map((paragraph) => (
           <Typography key={paragraph} color="text.secondary">

--- a/app/flashoffer-demo/src/sections/content.tsx
+++ b/app/flashoffer-demo/src/sections/content.tsx
@@ -66,8 +66,22 @@ const previewMedia = (
 );
 
 export const OVERVIEW_PARAGRAPHS = [
-  "Use the Section component to pair launch announcements, feature guides, or changelog summaries with consistent typography.",
-  "Each paragraph is wrapped in semantic markup and inherits spacing from the Flashoffer design tokens, so marketing teams can focus on messaging."
+  [
+    "Flashoffer-react emerged after repeated takedowns of fine art on ",
+    "mainstream networks. We respect law and order, yet opaque filters ",
+    "squeeze the livelihoods of artists."
+  ].join(""),
+  [
+    "We understand the tension between shielding minors from explicit ",
+    "material and giving artists room to breathe. The framework offers ",
+    "reusable, policy-free layouts so you can advertise art on your own ",
+    "terms."
+  ].join(""),
+  [
+    "Compose campaigns and deploy them to any Docker-ready cloud in ",
+    "minutes. While any tool can be misused, we trust creators to stand by ",
+    "one another more often than not."
+  ].join("")
 ];
 
 export const PREVIEW_CARDS = [


### PR DESCRIPTION
## Summary
- explain the purpose of flashoffer-react in the hero banner copy
- highlight independence from opaque moderation in the overview intro
- describe the framework’s censorship rationale and deployment flexibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e053e797988321bf68ba6dd4bd22b3