### PR TITLE
Add multiple choice demo page using react-multiple-choice

### DIFF
--- a/app/flashoffer-demo/package-lock.json
+++ b/app/flashoffer-demo/package-lock.json
@@ -14,9 +14,11 @@
         "@mui/utils": "^7.3.1",
         "flashoffer-react": "file:../flashoffer-react",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-multiple-choice": "^2.0.2"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@types/node": "^22.10.1",
@@ -47,7 +49,10 @@
         "@types/node": "^22.10.1",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@typescript-eslint/eslint-plugin": "^8.15.0",
+        "@typescript-eslint/parser": "^8.15.0",
         "@vitejs/plugin-react": "^4.6.0",
+        "eslint": "^8.57.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "ts-jest": "^29.2.5",
@@ -121,7 +126,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -461,7 +465,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -485,7 +488,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -554,7 +556,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -598,7 +599,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1131,6 +1131,133 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@material-ui/core": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.4.tgz",
+      "integrity": "sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==",
+      "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.2.0",
+        "@material-ui/system": "^3.0.0-alpha.0",
+        "@material-ui/utils": "^3.0.0-alpha.2",
+        "@types/jss": "^9.5.6",
+        "@types/react-transition-group": "^2.0.8",
+        "brcast": "^3.0.1",
+        "classnames": "^2.2.5",
+        "csstype": "^2.5.2",
+        "debounce": "^1.1.0",
+        "deepmerge": "^3.0.0",
+        "dom-helpers": "^3.2.1",
+        "hoist-non-react-statics": "^3.2.1",
+        "is-plain-object": "^2.0.4",
+        "jss": "^9.8.7",
+        "jss-camel-case": "^6.0.0",
+        "jss-default-unit": "^8.0.2",
+        "jss-global": "^3.0.0",
+        "jss-nested": "^6.0.1",
+        "jss-props-sort": "^6.0.0",
+        "jss-vendor-prefixer": "^7.0.0",
+        "normalize-scroll-left": "^0.1.2",
+        "popper.js": "^1.14.1",
+        "prop-types": "^15.6.0",
+        "react-event-listener": "^0.6.2",
+        "react-transition-group": "^2.2.1",
+        "recompose": "0.28.0 - 0.30.0",
+        "warning": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0",
+        "react-dom": "^16.3.0"
+      }
+    },
+    "node_modules/@material-ui/core/node_modules/@types/react-transition-group": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.9.2.tgz",
+      "integrity": "sha512-5Fv2DQNO+GpdPZcxp2x/OQG/H19A01WlmpjVD9cKvVFmoVLOZ9LvBgSWG6pSXIU4og5fgbvGPaCV5+VGkWAEHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@material-ui/core/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "license": "MIT"
+    },
+    "node_modules/@material-ui/core/node_modules/dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
+    "node_modules/@material-ui/core/node_modules/react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0",
+        "react-dom": ">=15.0.0"
+      }
+    },
+    "node_modules/@material-ui/system": {
+      "version": "3.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-3.0.0-alpha.2.tgz",
+      "integrity": "sha512-odmxQ0peKpP7RQBQ8koly06YhsPzcoVib1vByVPBH4QhwqBXuYoqlCjt02846fYspAqkrWzjxnWUD311EBbxOA==",
+      "deprecated": "You can now upgrade to @mui/system. See the guide: https://mui.com/guides/migration-v4/",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.2.0",
+        "deepmerge": "^3.0.0",
+        "prop-types": "^15.6.0",
+        "warning": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0",
+        "react-dom": "^16.3.0"
+      }
+    },
+    "node_modules/@material-ui/utils": {
+      "version": "3.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-3.0.0-alpha.3.tgz",
+      "integrity": "sha512-rwMdMZptX0DivkqBuC+Jdq7BYTXwqKai5G5ejPpuEDKpWzi1Oxp+LygGw329FrKpuKeiqpcymlqJTjmy+quWng==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.2.0",
+        "prop-types": "^15.6.0",
+        "react-is": "^16.6.3"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0",
+        "react-dom": "^16.3.0"
+      }
+    },
+    "node_modules/@material-ui/utils/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "7.3.2",
@@ -1682,7 +1809,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1811,13 +1937,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jss": {
+      "version": "9.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.8.tgz",
+      "integrity": "sha512-bBbHvjhm42UKki+wZpR89j73ykSXg99/bhuKuYYePtpma3ZAnmeGnl0WxXiZhPGsIfzKwCUkpPC0jlrVMBfRxA==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^2.0.0",
+        "indefinite-observable": "^1.0.1"
+      }
+    },
+    "node_modules/@types/jss/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
       "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1839,7 +1980,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.15.tgz",
       "integrity": "sha512-+kLxJpaJzXybyDyFXYADyP1cznTO8HSuBpenGlnKOAkH4hyNINiywvXS/tGJhsrGGP/gM185RA3xpjY0Yg4erA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1850,7 +1990,6 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2014,6 +2153,12 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2056,6 +2201,12 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/brcast": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.2.tgz",
+      "integrity": "sha512-f5XwwFCCuvgqP2nMH/hJ74FqnGmb4X3D+NC//HphxJzzhsZvSZa+Hk/syB7j3ZHpPDLMoYU8oBgviRWfNvEfKA==",
+      "license": "MIT"
+    },
     "node_modules/browserslist": {
       "version": "4.26.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
@@ -2076,7 +2227,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -2162,6 +2312,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha512-YXzt1cQ4a2jqazhcuSWEOc1K2q8g9H6eWNsyZgi640LDzRWVQ2eDe+Y/kVdftH+vYdPF2rgDb3dLdpxE1jvAxw==",
+      "license": "MIT"
+    },
     "node_modules/check-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -2171,6 +2327,12 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -2201,6 +2363,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "license": "MIT"
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -2224,6 +2393,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/css-vendor": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-0.3.8.tgz",
+      "integrity": "sha512-Vx/Vl3zsHj32Z+WTNzGjd2iSbSIJTYHMmyGUT2nzCjj0Xk4qLfwpQ8nF6TQ5oo3Cf0s/An3DTc7LclH1BkAXbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-in-browser": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -2274,6 +2452,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2306,6 +2490,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -2366,6 +2559,15 @@
       "integrity": "sha512-ITxuoPfJu3lsNWUi2lBM2PaBPYgH3uqmxut5vmBxgYvyI4AlJ6P3Cai1O76mOrkJCBzq0IxWg/NtqOrpu/0gKA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -2527,6 +2729,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fbjs": {
+      "version": "0.8.18",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
+      "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.30"
       }
     },
     "node_modules/fdir": {
@@ -2757,11 +2974,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2784,6 +3006,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/indefinite-observable": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-1.0.2.tgz",
+      "integrity": "sha512-Mps0898zEduHyPhb7UCgNmfzlqNZknVmaFz5qzr0mm04YQ5FGLhAyK/dJ+NaRxGyR6juQXIxh5Ev0xx+qq0nYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "symbol-observable": "1.2.0"
       }
     },
     "node_modules/indent-string": {
@@ -2817,12 +3048,58 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g==",
+      "license": "MIT"
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2836,7 +3113,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -2901,6 +3177,102 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jss": {
+      "version": "9.8.7",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-9.8.7.tgz",
+      "integrity": "sha512-awj3XRZYxbrmmrx9LUSj5pXSUfm12m8xzi/VKeqI1ZwWBtQ0kVPTs3vYs32t4rFw83CgFDukA8wKzOE9sMQnoQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-in-browser": "^1.1.3",
+        "symbol-observable": "^1.1.0",
+        "warning": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jss-camel-case": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-6.1.0.tgz",
+      "integrity": "sha512-HPF2Q7wmNW1t79mCqSeU2vdd/vFFGpkazwvfHMOhPlMgXrJDzdj9viA2SaHk9ZbD5pfL63a8ylp4++irYbbzMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.2"
+      },
+      "peerDependencies": {
+        "jss": "^9.7.0"
+      }
+    },
+    "node_modules/jss-default-unit": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jss": "^9.4.0"
+      }
+    },
+    "node_modules/jss-global": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jss": "^9.0.0"
+      }
+    },
+    "node_modules/jss-nested": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-6.0.1.tgz",
+      "integrity": "sha512-rn964TralHOZxoyEgeq3hXY8hyuCElnvQoVrQwKHVmu55VRDd6IqExAx9be5HgK0yN/+hQdgAXQl/GUrBbbSTA==",
+      "license": "MIT",
+      "dependencies": {
+        "warning": "^3.0.0"
+      },
+      "peerDependencies": {
+        "jss": "^9.0.0"
+      }
+    },
+    "node_modules/jss-nested/node_modules/warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/jss-props-sort": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jss": "^9.0.0"
+      }
+    },
+    "node_modules/jss-vendor-prefixer": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz",
+      "integrity": "sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-vendor": "^0.3.8"
+      },
+      "peerDependencies": {
+        "jss": "^9.0.0"
+      }
+    },
+    "node_modules/jss/node_modules/warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3026,11 +3398,27 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
       "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-scroll-left": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz",
+      "integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg==",
       "license": "MIT"
     },
     "node_modules/nwsapi": {
@@ -3136,12 +3524,22 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/postcss": {
@@ -3188,6 +3586,15 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3220,7 +3627,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3230,12 +3636,25 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-event-listener": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.7.tgz",
+      "integrity": "sha512-DLxxUSjZT5Qg8u+51V0KPKW7FI4zCkbP7fjKNGpaRItjaYgO4WycwoqJDumw+UGGQ0DmmPbQ3RUH8LsqQgHWpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.2.0",
+        "prop-types": "^15.6.0",
+        "warning": "^4.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0"
       }
     },
     "node_modules/react-is": {
@@ -3244,6 +3663,26 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-multiple-choice": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-multiple-choice/-/react-multiple-choice-2.0.2.tgz",
+      "integrity": "sha512-47jo9fyQ/v9yD0qLmtj7Y/l6K2tuoGxfGdDa8Nym7GZtJhud+tZm39AJLUdRBlxw+rTyoc5oDnkJ5W4xTgZUyA==",
+      "license": "ISC",
+      "dependencies": {
+        "@material-ui/core": "^3.2.2",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0",
+        "react-dom": "^16.3.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -3270,6 +3709,29 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/recompose": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
+      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "change-emitter": "^0.1.2",
+        "fbjs": "^0.8.1",
+        "hoist-non-react-statics": "^2.3.1",
+        "react-lifecycles-compat": "^3.0.2",
+        "symbol-observable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/recompose/node_modules/hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -3367,7 +3829,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -3398,6 +3859,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -3468,6 +3935,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -3598,6 +4074,32 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ua-parser-js": {
+      "version": "0.7.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
+      "integrity": "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -3642,7 +4144,6 @@
       "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4754,7 +5255,6 @@
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4822,6 +5322,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -4844,6 +5353,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",

--- a/app/flashoffer-demo/package.json
+++ b/app/flashoffer-demo/package.json
@@ -18,9 +18,11 @@
     "@mui/utils": "^7.3.1",
     "flashoffer-react": "file:../flashoffer-react",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-multiple-choice": "^2.0.2"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@types/node": "^22.10.1",

--- a/app/flashoffer-demo/src/App.test.tsx
+++ b/app/flashoffer-demo/src/App.test.tsx
@@ -36,6 +36,16 @@ describe("Flashoffer demo", () => {
     expect(previewCards).toHaveLength(3);
   });
 
+  it("links to the multiple choice demo", async () => {
+    render(<App />);
+
+    const demoLink = await screen.findByRole("link", {
+      name: /try the multiple choice demo/i
+    });
+
+    expect(demoLink).toHaveAttribute("href", "/multiple-choice");
+  });
+
   it("updates the hero banner gradient tokens for the midnight theme", async () => {
     render(<App />);
 

--- a/app/flashoffer-demo/src/compat/material-ui/Radio.tsx
+++ b/app/flashoffer-demo/src/compat/material-ui/Radio.tsx
@@ -1,0 +1,3 @@
+import Radio from "@mui/material/Radio";
+
+export default Radio;

--- a/app/flashoffer-demo/src/compat/reactMultipleChoice.tsx
+++ b/app/flashoffer-demo/src/compat/reactMultipleChoice.tsx
@@ -1,0 +1,94 @@
+import Radio from "@mui/material/Radio";
+import type { CSSProperties, ReactNode } from "react";
+import LegacyOption from "react-multiple-choice/dist/Option";
+import {
+  Question as LegacyQuestion,
+  QuestionGroup as LegacyQuestionGroup,
+  Test as LegacyTest
+} from "react-multiple-choice";
+
+interface OptionStyleOverrides {
+  icon?: CSSProperties;
+  option?: CSSProperties;
+}
+
+interface PatchedOptionProps {
+  value: string;
+  children?: ReactNode;
+  style?: OptionStyleOverrides;
+  selectedStyle?: Pick<OptionStyleOverrides, "option">;
+  _isSelected?: boolean;
+  _onSelect?: (value: string) => void;
+}
+
+interface PatchedOptionInstance {
+  props: PatchedOptionProps;
+  _patchedInputId?: string;
+}
+
+const BASE_OPTION_STYLE: CSSProperties = {
+  alignItems: "center",
+  borderRadius: 12,
+  cursor: "pointer",
+  display: "flex",
+  gap: 12,
+  margin: "5px 0",
+  padding: "8px 12px",
+  transition: "border-color 0.2s ease, box-shadow 0.2s ease"
+};
+
+let optionIdCounter = 0;
+
+const optionPrototype = LegacyOption.prototype as PatchedOptionInstance & {
+  render?: () => ReactNode;
+  __patched?: boolean;
+};
+
+if (!optionPrototype.__patched) {
+  optionPrototype.render = function renderOption() {
+    const { value, children, style, selectedStyle, _isSelected, _onSelect } =
+      this.props;
+
+    if (!this._patchedInputId) {
+      optionIdCounter += 1;
+      this._patchedInputId = `react-multiple-choice-option-${optionIdCounter}`;
+    }
+
+    const computedStyle: CSSProperties = {
+      ...BASE_OPTION_STYLE,
+      ...(style?.option ?? {})
+    };
+
+    if (_isSelected) {
+      Object.assign(computedStyle, selectedStyle?.option ?? {});
+    }
+
+    const ariaLabel =
+      typeof children === "string" || typeof children === "number"
+        ? String(children)
+        : undefined;
+
+    return (
+      <label htmlFor={this._patchedInputId} style={computedStyle}>
+        <Radio
+          id={this._patchedInputId}
+          checked={Boolean(_isSelected)}
+          onChange={() => {
+            _onSelect?.(value);
+          }}
+          value={value}
+          style={style?.icon}
+          inputProps={{ "aria-label": ariaLabel }}
+        />
+        <span>{children}</span>
+      </label>
+    );
+  };
+
+  optionPrototype.__patched = true;
+}
+
+export const Option = LegacyOption;
+export const Test = LegacyTest;
+export const QuestionGroup = LegacyQuestionGroup;
+export const Question = LegacyQuestion;

--- a/app/flashoffer-demo/src/main.tsx
+++ b/app/flashoffer-demo/src/main.tsx
@@ -2,7 +2,31 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { AutoTrack, EngagementProvider } from "flashoffer-react";
 import App from "./App";
+import { MultipleChoiceDemoPage } from "./pages/MultipleChoiceDemoPage";
 import "./index.css";
+
+const normalizePath = (pathname: string, baseUrl: string) => {
+  const trimmedBase = baseUrl === "/" ? "" : baseUrl.replace(/\/$/, "");
+  let routePath = pathname;
+
+  if (trimmedBase && routePath.startsWith(trimmedBase)) {
+    routePath = routePath.slice(trimmedBase.length);
+  }
+
+  if (routePath === "") {
+    routePath = "/";
+  }
+
+  if (!routePath.startsWith("/")) {
+    routePath = `/${routePath}`;
+  }
+
+  if (routePath.length > 1 && routePath.endsWith("/")) {
+    routePath = routePath.slice(0, -1);
+  }
+
+  return routePath;
+};
 
 const analyticsEndpoint =
   typeof import.meta.env.VITE_FLASHOFFER_ANALYTICS_ENDPOINT === "string" &&
@@ -16,10 +40,13 @@ if (!rootElement) {
   throw new Error("Missing root element");
 }
 
+const routePath = normalizePath(window.location.pathname, import.meta.env.BASE_URL);
+const isMultipleChoiceRoute = routePath === "/multiple-choice";
+
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <EngagementProvider site="flashoffer-demo" endpoint={analyticsEndpoint}>
-      <App />
+      {isMultipleChoiceRoute ? <MultipleChoiceDemoPage /> : <App />}
       <AutoTrack />
     </EngagementProvider>
   </React.StrictMode>

--- a/app/flashoffer-demo/src/pages/MultipleChoiceDemoPage.test.tsx
+++ b/app/flashoffer-demo/src/pages/MultipleChoiceDemoPage.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MultipleChoiceDemoPage } from "./MultipleChoiceDemoPage";
+
+describe("MultipleChoiceDemoPage", () => {
+  it("renders the quiz question and options", () => {
+    render(<MultipleChoiceDemoPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /test your flashoffer instincts/i
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: /which flashoffer-react capability keeps campaign visuals aligned/i
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/theme presets and typography utilities/i)
+    ).toBeInTheDocument();
+  });
+
+  it("updates the feedback copy when the correct answer is selected", () => {
+    render(<MultipleChoiceDemoPage />);
+
+    fireEvent.click(
+      screen.getByLabelText(/theme presets and typography utilities/i)
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        level: 4,
+        name: /correct — consistent theming drives alignment/i
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/app/flashoffer-demo/src/pages/MultipleChoiceDemoPage.tsx
+++ b/app/flashoffer-demo/src/pages/MultipleChoiceDemoPage.tsx
@@ -1,0 +1,208 @@
+import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import Divider from "@mui/material/Divider";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { alpha, useTheme } from "@mui/material/styles";
+import { useCallback, useMemo, useState } from "react";
+import "../polyfills/reactLegacyFactory";
+import {
+  FlashofferThemeProvider,
+  OutlineCtaButton,
+  SectionHeader
+} from "flashoffer-react";
+import { Option, Question, QuestionGroup, Test } from "../compat/reactMultipleChoice";
+
+const QUESTION_NUMBER = 0;
+
+const ANSWER_DETAILS: Record<
+  string,
+  {
+    heading: string;
+    description: string;
+  }
+> = {
+  theming: {
+    heading: "Correct — consistent theming drives alignment",
+    description:
+      "Theme presets, typography spacing, and palette controls make campaigns feel cohesive while still flexible."
+  },
+  assetHosting: {
+    heading: "Not quite — hosting lives elsewhere",
+    description:
+      "Flashoffer-react focuses on rendering surfaces. Media assets remain under your control and can be sourced from any CDN."
+  },
+  moderation: {
+    heading: "Close — policy guidance is adjacent",
+    description:
+      "The library documents moderation workflows, but consistency comes from the reusable layout primitives themselves."
+  },
+  analytics: {
+    heading: "Insight helps, but design system comes first",
+    description:
+      "Engagement analytics quantify performance; they do not replace the structured UI toolkit that keeps offers recognizable."
+  }
+};
+
+function MultipleChoiceDemoContent() {
+  const theme = useTheme();
+  const [selections, setSelections] = useState<Record<number, string>>({});
+
+  const handleOptionSelect = useCallback((nextSelections: Record<number, string>) => {
+    setSelections(nextSelections);
+  }, []);
+
+  const activeSelection = selections[QUESTION_NUMBER];
+
+  const optionStyle = useMemo(
+    () => ({
+      icon: {
+        color: theme.palette.primary.main
+      },
+      option: {
+        border: `1px solid ${theme.palette.divider}`,
+        borderRadius: theme.spacing(3),
+        display: "flex",
+        alignItems: "center",
+        gap: theme.spacing(1.5),
+        padding: theme.spacing(2),
+        backgroundColor: theme.palette.background.paper,
+        cursor: "pointer",
+        transition: "border-color 0.2s ease, box-shadow 0.2s ease"
+      }
+    }),
+    [theme]
+  );
+
+  const selectedOptionStyle = useMemo(
+    () => ({
+      option: {
+        borderColor: theme.palette.primary.main,
+        backgroundColor: alpha(theme.palette.primary.main, 0.08),
+        boxShadow: `0 0 0 4px ${alpha(theme.palette.primary.main, 0.15)}`
+      }
+    }),
+    [theme]
+  );
+
+  const feedback = useMemo(() => {
+    const selectionDetails =
+      activeSelection !== undefined ? ANSWER_DETAILS[activeSelection] : undefined;
+
+    if (!selectionDetails) {
+      return {
+        heading: "Choose an option to view guidance",
+        description:
+          "Select the answer that best matches how Flashoffer-react supports consistent go-to-market storytelling."
+      };
+    }
+
+    return selectionDetails;
+  }, [activeSelection]);
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: "var(--flashoffer-color-background)",
+        color: "var(--flashoffer-color-text-primary)",
+        minHeight: "100vh"
+      }}
+    >
+      <Container component="main" maxWidth="md" sx={{ py: { xs: 6, md: 10 } }}>
+        <Stack spacing={{ xs: 6, md: 8 }}>
+          <SectionHeader
+            align="center"
+            eyebrow="LEARNING LAB"
+            title="Test your Flashoffer instincts"
+            description="Walk through a single-question quiz to see how the multiple choice components capture structured feedback."
+          />
+          <Paper
+            elevation={0}
+            sx={{
+              p: { xs: 3, md: 4 },
+              borderRadius: 4,
+              border: `1px solid ${theme.palette.divider}`,
+              backgroundColor: alpha(theme.palette.background.paper, 0.9)
+            }}
+          >
+            <Test
+              onOptionSelect={handleOptionSelect}
+              style={{
+                width: "100%",
+                display: "flex",
+                flexDirection: "column",
+                gap: theme.spacing(3)
+              }}
+            >
+              <QuestionGroup
+                questionNumber={QUESTION_NUMBER}
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: theme.spacing(2)
+                }}
+              >
+                <Question style={{ marginBottom: theme.spacing(1) }}>
+                  <Typography component="h3" variant="h5">
+                    Which Flashoffer-react capability keeps campaign visuals aligned across every launch?
+                  </Typography>
+                </Question>
+                <Option
+                  value="theming"
+                  style={optionStyle}
+                  selectedStyle={selectedOptionStyle}
+                >
+                  Theme presets and typography utilities that adapt to palette decisions.
+                </Option>
+                <Option
+                  value="assetHosting"
+                  style={optionStyle}
+                  selectedStyle={selectedOptionStyle}
+                >
+                  Built-in asset hosting that stores 8K product footage for each release.
+                </Option>
+                <Option
+                  value="moderation"
+                  style={optionStyle}
+                  selectedStyle={selectedOptionStyle}
+                >
+                  Embedded moderation playbooks that mirror partner platform policy updates.
+                </Option>
+                <Option
+                  value="analytics"
+                  style={optionStyle}
+                  selectedStyle={selectedOptionStyle}
+                >
+                  Real-time engagement analytics that chart how audiences respond to each CTA.
+                </Option>
+              </QuestionGroup>
+            </Test>
+            <Divider sx={{ my: { xs: 3, md: 4 } }} />
+            <Stack spacing={1.5}>
+              <Typography variant="h6" component="h4">
+                {feedback.heading}
+              </Typography>
+              <Typography color="text.secondary">{feedback.description}</Typography>
+            </Stack>
+          </Paper>
+          <Stack alignItems="center">
+            <OutlineCtaButton
+              component="a"
+              href="/"
+              label="Return to the Flashoffer demo"
+            />
+          </Stack>
+        </Stack>
+      </Container>
+    </Box>
+  );
+}
+
+export function MultipleChoiceDemoPage() {
+  return (
+    <FlashofferThemeProvider applyCssBaseline>
+      <MultipleChoiceDemoContent />
+    </FlashofferThemeProvider>
+  );
+}

--- a/app/flashoffer-demo/src/polyfills/reactLegacyFactory.ts
+++ b/app/flashoffer-demo/src/polyfills/reactLegacyFactory.ts
@@ -1,0 +1,46 @@
+import * as React from "react";
+
+type LegacyFactory = <T extends React.ElementType>(
+  type: T
+) => (
+  props?: React.ComponentPropsWithoutRef<T>,
+  ...children: React.ReactNode[]
+) => React.ReactElement | null;
+
+type ReactWithLegacyFactory = typeof React & {
+  createFactory?: LegacyFactory;
+};
+
+const reactNamespace = React as ReactWithLegacyFactory & {
+  default?: ReactWithLegacyFactory;
+};
+
+const legacyFactory: LegacyFactory = ((type: React.ElementType) => {
+  const factory = (
+    props?: Record<string, unknown> | null,
+    ...children: React.ReactNode[]
+  ) => React.createElement(type, props, ...children);
+
+  (factory as { type?: React.ElementType }).type = type;
+
+  return factory;
+}) as LegacyFactory;
+
+const targets = [reactNamespace, reactNamespace.default].filter(
+  (candidate): candidate is ReactWithLegacyFactory =>
+    Boolean(candidate) && typeof candidate === "object"
+);
+
+for (const target of targets) {
+  if (typeof target.createFactory !== "function") {
+    try {
+      Object.defineProperty(target, "createFactory", {
+        configurable: true,
+        writable: true,
+        value: legacyFactory
+      });
+    } catch {
+      // Ignore attempts to define the property on non-extensible namespace objects.
+    }
+  }
+}

--- a/app/flashoffer-demo/src/sections/OverviewSection.tsx
+++ b/app/flashoffer-demo/src/sections/OverviewSection.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import { Section } from "flashoffer-react";
+import { PrimaryCtaButton, Section } from "flashoffer-react";
 
 export interface OverviewSectionProps {
   overviewMeta: string;
@@ -38,6 +39,22 @@ export function OverviewSection({ overviewMeta }: OverviewSectionProps) {
           minutes. While any tool can be misused, we trust creators to stand by
           one another more often than not.
         </Typography>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          justifyContent="center"
+          alignItems="center"
+          spacing={2}
+          sx={{ pt: { xs: 3, md: 4 } }}
+        >
+          <PrimaryCtaButton
+            component="a"
+            href="/multiple-choice"
+            label="Try the multiple choice demo"
+            data-track-id="overview-multiple-choice-link"
+            data-track-label="Multiple choice demo link"
+            data-track-meta={overviewMeta}
+          />
+        </Stack>
       </Section>
     </Box>
   );

--- a/app/flashoffer-demo/vite.config.ts
+++ b/app/flashoffer-demo/vite.config.ts
@@ -10,6 +10,9 @@ const flashofferSource = fileURLToPath(
   new URL("../flashoffer-react/src/index.ts", import.meta.url)
 );
 const nodeModulesDir = resolvePath(projectRoot, "node_modules");
+const compatLegacyRadio = toPosixPath(
+  resolvePath(projectRoot, "src/compat/material-ui/Radio.tsx")
+);
 const materialBase = toPosixPath(
   resolvePath(nodeModulesDir, "@mui/material")
 );
@@ -22,6 +25,18 @@ export default defineConfig({
       {
         find: "flashoffer-react",
         replacement: flashofferSource
+      },
+      {
+        find: "@material-ui/core/Radio",
+        replacement: compatLegacyRadio
+      },
+      {
+        find: "@material-ui/core/Radio/Radio",
+        replacement: compatLegacyRadio
+      },
+      {
+        find: "@material-ui/core/Radio/index",
+        replacement: compatLegacyRadio
       },
       {
         find: /^@mui\/material$/i,


### PR DESCRIPTION
## Summary
- add the react-multiple-choice dependency and testing utilities needed for Vitest
- introduce a multiple choice demo page that showcases the quiz component under the Flashoffer theme and links back to the homepage
- patch the legacy option widget to use modern MUI radios and route /multiple-choice from the existing single-page entry point

## Testing
- npm test -- --reporter verbose

------
https://chatgpt.com/codex/tasks/task_e_68e3db4f22bc8321b5f67d1ebbcb6862