### PR TITLE
Add multiple choice quiz component

### DIFF
--- a/app/flashoffer-demo/package-lock.json
+++ b/app/flashoffer-demo/package-lock.json
@@ -47,7 +47,10 @@
         "@types/node": "^22.10.1",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@typescript-eslint/eslint-plugin": "^8.15.0",
+        "@typescript-eslint/parser": "^8.15.0",
         "@vitejs/plugin-react": "^4.6.0",
+        "eslint": "^8.57.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "ts-jest": "^29.2.5",
@@ -121,7 +124,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -461,7 +463,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -485,7 +486,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -554,7 +554,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -598,7 +597,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1757,7 +1755,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1817,7 +1816,6 @@
       "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1839,7 +1837,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.15.tgz",
       "integrity": "sha512-+kLxJpaJzXybyDyFXYADyP1cznTO8HSuBpenGlnKOAkH4hyNINiywvXS/tGJhsrGGP/gM185RA3xpjY0Yg4erA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1850,7 +1847,6 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -1987,6 +1983,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1997,6 +1994,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2076,7 +2074,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -2333,7 +2330,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -2836,7 +2834,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -2944,6 +2941,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3136,7 +3134,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3179,6 +3176,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3220,7 +3218,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3230,7 +3227,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -3243,7 +3239,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -3642,7 +3639,6 @@
       "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4754,7 +4750,6 @@
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/app/flashoffer-demo/src/App.test.tsx
+++ b/app/flashoffer-demo/src/App.test.tsx
@@ -36,6 +36,23 @@ describe("Flashoffer demo", () => {
     expect(previewCards).toHaveLength(3);
   });
 
+  it("renders the quiz showcase question", async () => {
+    render(<App />);
+
+    expect(
+      await screen.findByRole("heading", {
+        level: 2,
+        name: /teach best practices with interactive quizzes/i
+      })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /check answer/i })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/multiplechoicequiz mirrors the feel/i)
+    ).toBeInTheDocument();
+  });
+
   it("updates the hero banner gradient tokens for the midnight theme", async () => {
     render(<App />);
 

--- a/app/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer-demo/src/App.tsx
@@ -32,6 +32,10 @@ const FigureSpotlightSection = lazy(async () => ({
   default: (await import("./sections/FigureSpotlightSection")).FigureSpotlightSection
 }));
 
+const QuizShowcaseSection = lazy(async () => ({
+  default: (await import("./sections/QuizShowcaseSection")).QuizShowcaseSection
+}));
+
 const FooterSection = lazy(async () => ({
   default: (await import("./sections/FooterSection")).FooterSection
 }));
@@ -284,6 +288,9 @@ export default function App() {
             </Suspense>
             <Suspense fallback={null}>
               <FigureSpotlightSection />
+            </Suspense>
+            <Suspense fallback={null}>
+              <QuizShowcaseSection />
             </Suspense>
             <Suspense fallback={null}>
               <FooterSection />

--- a/app/flashoffer-demo/src/sections/QuizShowcaseSection.tsx
+++ b/app/flashoffer-demo/src/sections/QuizShowcaseSection.tsx
@@ -1,0 +1,69 @@
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import { MultipleChoiceQuiz, Section } from "flashoffer-react";
+
+const QUIZ_OPTIONS = [
+  {
+    id: "reminder",
+    label: "A personalized reminder with a refreshed CTA",
+    description:
+      "Highlights the offer expiry, reinforces value, and links back to the " +
+      "landing page."
+  },
+  {
+    id: "case-study",
+    label: "A case study download gate",
+    description:
+      "Shares social proof but interrupts momentum with an additional form."
+  },
+  {
+    id: "survey",
+    label: "A follow-up survey",
+    description:
+      "Collects insights yet delays the decision to activate the promotion."
+  }
+];
+
+const QUIZ_META = JSON.stringify({
+  question: "Best follow-up after a Flashoffer engagement",
+  options: QUIZ_OPTIONS.map((option) => option.id)
+});
+
+export function QuizShowcaseSection() {
+  return (
+    <Box
+      component="section"
+      data-track-id="quiz-showcase"
+      data-track-label="Interactive quiz showcase"
+      data-track-meta={QUIZ_META}
+    >
+      <Section
+        eyebrow="INTERACTIVE"
+        title="Teach best practices with interactive quizzes"
+        align="left"
+      >
+        <Grid container spacing={4}>
+          <Grid size={{ xs: 12, md: 5 }}>
+            <Typography color="text.secondary">
+              Embed knowledge checks to reinforce campaign strategy within your
+              onboarding flows. MultipleChoiceQuiz mirrors the feel of
+              Reactor's learning components while remaining dependency light.
+            </Typography>
+          </Grid>
+          <Grid size={{ xs: 12, md: 7 }}>
+            <MultipleChoiceQuiz
+              question="After a prospect explores a Flashoffer landing page, what follow-up drives the highest conversion lift?"
+              helperText="Consider which option keeps momentum without adding friction."
+              options={QUIZ_OPTIONS}
+              correctOptionId="reminder"
+              explanation="Timely reminders build on existing intent and keep the offer top of mind without introducing blockers."
+              successMessage="Exactly. Reinforcing urgency while keeping the path clear sustains conversion lift."
+              errorMessage="Think about which follow-up reduces friction instead of adding new steps."
+            />
+          </Grid>
+        </Grid>
+      </Section>
+    </Box>
+  );
+}

--- a/app/flashoffer-demo/src/sections/index.ts
+++ b/app/flashoffer-demo/src/sections/index.ts
@@ -5,4 +5,5 @@ export * from "./OverviewSection";
 export * from "./CtaShowcaseSection";
 export * from "./PreviewShowcaseSection";
 export * from "./FigureSpotlightSection";
+export * from "./QuizShowcaseSection";
 export * from "./FooterSection";

--- a/app/flashoffer-react/src/components/MultipleChoiceQuiz.tsx
+++ b/app/flashoffer-react/src/components/MultipleChoiceQuiz.tsx
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
+import Alert from "@mui/material/Alert";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormHelperText from "@mui/material/FormHelperText";
+import FormLabel from "@mui/material/FormLabel";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { alpha } from "@mui/material/styles";
+import { useId, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+export interface MultipleChoiceOption {
+  /** Unique identifier used for option selection. */
+  id: string;
+  /** Primary label describing the answer choice. */
+  label: ReactNode;
+  /** Optional supporting copy rendered beneath the label. */
+  description?: ReactNode;
+}
+
+export interface MultipleChoiceAnswer {
+  /** Identifier of the selected option. */
+  optionId: string;
+  /** Whether the option matches the configured correct answer. */
+  isCorrect?: boolean;
+}
+
+export interface MultipleChoiceQuizProps {
+  /** Question or prompt displayed above the answer list. */
+  question: ReactNode;
+  /** Collection of answer choices presented to the learner. */
+  options: MultipleChoiceOption[];
+  /** Helper text that expands on the question prompt. */
+  helperText?: ReactNode;
+  /** Identifier representing the correct answer choice. */
+  correctOptionId?: string;
+  /** Additional explanation surfaced once the learner submits. */
+  explanation?: ReactNode;
+  /** Custom message rendered for successful submissions. */
+  successMessage?: ReactNode;
+  /** Custom message rendered when the submission is incorrect. */
+  errorMessage?: ReactNode;
+  /** Invoked each time the learner submits an answer. */
+  onAnswer?: (answer: MultipleChoiceAnswer) => void;
+  /** Label for the submit button. */
+  submitLabel?: string;
+  /** Label for the retry button. */
+  tryAgainLabel?: string;
+  /**
+   * Allows additional attempts when the initial submission is incorrect.
+   * Defaults to true when a correct answer is configured.
+   */
+  allowRetry?: boolean;
+  /** Disables interactions with the quiz component. */
+  disabled?: boolean;
+}
+
+const DEFAULT_SUCCESS = "Great job! That answer is correct.";
+const DEFAULT_ERROR = "Not quite. Give it another look.";
+const DEFAULT_SUBMIT_LABEL = "Check answer";
+const DEFAULT_TRY_AGAIN_LABEL = "Try again";
+
+/**
+ * Accessible multiple choice quiz with inline evaluation feedback.
+ */
+export function MultipleChoiceQuiz({
+  question,
+  options,
+  helperText,
+  correctOptionId,
+  explanation,
+  successMessage = DEFAULT_SUCCESS,
+  errorMessage = DEFAULT_ERROR,
+  onAnswer,
+  submitLabel = DEFAULT_SUBMIT_LABEL,
+  tryAgainLabel = DEFAULT_TRY_AGAIN_LABEL,
+  allowRetry,
+  disabled = false
+}: MultipleChoiceQuizProps) {
+  const resolvedAllowRetry = useMemo(() => {
+    if (typeof allowRetry === "boolean") {
+      return allowRetry;
+    }
+    return Boolean(correctOptionId);
+  }, [allowRetry, correctOptionId]);
+
+  const questionId = useId();
+  const groupId = useId();
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [submittedId, setSubmittedId] = useState<string | null>(null);
+
+  const hasSubmitted = submittedId !== null;
+  const evaluation = useMemo(() => {
+    if (!correctOptionId || !hasSubmitted || !submittedId) {
+      return undefined;
+    }
+    return submittedId === correctOptionId;
+  }, [correctOptionId, hasSubmitted, submittedId]);
+
+  const handleSubmit = () => {
+    if (!selectedId) {
+      return;
+    }
+    setSubmittedId(selectedId);
+    onAnswer?.({
+      optionId: selectedId,
+      isCorrect: correctOptionId
+        ? selectedId === correctOptionId
+        : undefined
+    });
+  };
+
+  const handleRetry = () => {
+    setSelectedId(null);
+    setSubmittedId(null);
+  };
+
+  const disableChoices = useMemo(() => {
+    if (disabled) {
+      return true;
+    }
+    if (!hasSubmitted) {
+      return false;
+    }
+    if (!resolvedAllowRetry) {
+      return true;
+    }
+    return evaluation === true;
+  }, [disabled, evaluation, hasSubmitted, resolvedAllowRetry]);
+
+  const showFeedback = Boolean(hasSubmitted && correctOptionId);
+  const submitDisabled =
+    !selectedId ||
+    disabled ||
+    (hasSubmitted && !resolvedAllowRetry) ||
+    evaluation === true;
+  const showRetryButton =
+    resolvedAllowRetry && hasSubmitted && evaluation !== true;
+
+  return (
+    <Card component="section" elevation={3} sx={{ borderRadius: 3 }}>
+      <CardContent>
+        <Stack spacing={3}>
+          <Stack spacing={1}>
+            <Typography
+              component="h2"
+              variant="h6"
+              id={questionId}
+              sx={{ fontWeight: 600 }}
+            >
+              {question}
+            </Typography>
+            {helperText ? (
+              <Typography variant="body2" color="text.secondary">
+                {helperText}
+              </Typography>
+            ) : null}
+          </Stack>
+          <FormControl component="fieldset" disabled={disableChoices}>
+            <FormLabel
+              htmlFor={groupId}
+              sx={{
+                position: "absolute",
+                height: 0,
+                width: 0,
+                overflow: "hidden"
+              }}
+            >
+              Multiple choice question
+            </FormLabel>
+            <RadioGroup
+              aria-labelledby={questionId}
+              id={groupId}
+              name={groupId}
+              value={selectedId ?? ""}
+              onChange={(event) => {
+                setSelectedId(event.target.value);
+              }}
+            >
+              <Stack spacing={1.5}>
+                {options.map((option) => {
+                  const isSelected = selectedId === option.id;
+                  const isAnswer = correctOptionId === option.id;
+                  const isSubmittedSelection = submittedId === option.id;
+                  const highlight =
+                    showFeedback && (isAnswer || isSubmittedSelection);
+
+                  return (
+                    <FormControlLabel
+                      key={option.id}
+                      value={option.id}
+                      control={<Radio />}
+                      label={
+                        <Stack spacing={option.description ? 0.5 : 0}>
+                          <Typography variant="body1" fontWeight={600}>
+                            {option.label}
+                          </Typography>
+                          {option.description ? (
+                            <Typography
+                              variant="body2"
+                              color="text.secondary"
+                            >
+                              {option.description}
+                            </Typography>
+                          ) : null}
+                        </Stack>
+                      }
+                      disabled={disableChoices}
+                      sx={(theme) => ({
+                        alignItems: "flex-start",
+                        m: 0,
+                        px: 2,
+                        py: 1.5,
+                        borderRadius: 2,
+                        borderWidth: 1,
+                        borderStyle: "solid",
+                        borderColor: highlight
+                          ? isAnswer
+                            ? theme.palette.success.main
+                            : theme.palette.error.main
+                          : isSelected
+                          ? theme.palette.primary.main
+                          : theme.palette.divider,
+                        backgroundColor: highlight
+                          ? alpha(
+                              isAnswer
+                                ? theme.palette.success.main
+                                : theme.palette.error.main,
+                              0.08
+                            )
+                          : theme.palette.background.paper,
+                        transition: theme.transitions.create([
+                          "background-color",
+                          "border-color"
+                        ]),
+                        ".MuiRadio-root": {
+                          mt: 0.25
+                        }
+                      })}
+                    />
+                  );
+                })}
+              </Stack>
+            </RadioGroup>
+            {helperText ? null : (
+              <FormHelperText sx={{ mt: 2 }}>
+                Select the response that best answers the question.
+              </FormHelperText>
+            )}
+          </FormControl>
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={1.5}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleSubmit}
+              disabled={submitDisabled}
+            >
+              {submitLabel}
+            </Button>
+            {showRetryButton ? (
+              <Button variant="outlined" onClick={handleRetry}>
+                {tryAgainLabel}
+              </Button>
+            ) : null}
+          </Stack>
+          {showFeedback ? (
+            <Alert severity={evaluation ? "success" : "error"}>
+              <Stack spacing={1}>
+                <Typography variant="body2">
+                  {evaluation ? successMessage : errorMessage}
+                </Typography>
+                {explanation ? (
+                  <Typography variant="body2" color="text.secondary">
+                    {explanation}
+                  </Typography>
+                ) : null}
+              </Stack>
+            </Alert>
+          ) : null}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/flashoffer-react/src/components/__tests__/MultipleChoiceQuiz.test.tsx
+++ b/app/flashoffer-react/src/components/__tests__/MultipleChoiceQuiz.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { FlashofferThemeProvider } from "../../theme/FlashofferThemeProvider";
+import { MultipleChoiceQuiz } from "../MultipleChoiceQuiz";
+import type { MultipleChoiceQuizProps } from "../MultipleChoiceQuiz";
+
+describe("MultipleChoiceQuiz", () => {
+  function renderQuiz(props: Partial<MultipleChoiceQuizProps> = {}) {
+    return render(
+      <FlashofferThemeProvider applyCssBaseline={false}>
+        <MultipleChoiceQuiz
+          question="Which metric indicates the strongest engagement lift?"
+          helperText="Select the option that best demonstrates sustained performance."
+          options={[
+            {
+              id: "story",
+              label: "Story taps forward",
+              description: "Viewers who tap forward without exiting."
+            },
+            {
+              id: "save",
+              label: "Saves per reel",
+              description: "Average number of saves across promoted reels."
+            },
+            {
+              id: "session",
+              label: "Average session duration",
+              description: "Time spent engaging with bundled offers."
+            }
+          ]}
+          correctOptionId="save"
+          {...props}
+        />
+      </FlashofferThemeProvider>
+    );
+  }
+
+  it("submits the selected answer and surfaces success feedback", () => {
+    const handleAnswer = jest.fn();
+    renderQuiz({ onAnswer: handleAnswer });
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: /saves per reel/i })
+    );
+    fireEvent.click(screen.getByRole("button", { name: /check answer/i }));
+
+    expect(handleAnswer).toHaveBeenCalledWith({
+      optionId: "save",
+      isCorrect: true
+    });
+    expect(
+      screen.getByText(/great job! that answer is correct\./i)
+    ).toBeInTheDocument();
+  });
+
+  it("allows retrying incorrect responses", () => {
+    renderQuiz();
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: /story taps forward/i })
+    );
+    fireEvent.click(screen.getByRole("button", { name: /check answer/i }));
+
+    expect(
+      screen.getByText(/not quite. give it another look\./i)
+    ).toBeInTheDocument();
+
+    const tryAgainButton = screen.getByRole("button", { name: /try again/i });
+    fireEvent.click(tryAgainButton);
+
+    expect(
+      screen.queryByText(/not quite. give it another look\./i)
+    ).not.toBeInTheDocument();
+    expect(
+      (screen.getByRole("radio", { name: /story taps forward/i }) as HTMLInputElement)
+        .checked
+    ).toBe(false);
+  });
+});

--- a/app/flashoffer-react/src/index.ts
+++ b/app/flashoffer-react/src/index.ts
@@ -29,6 +29,13 @@ export type { SectionProps } from "./components/Section";
 export { PreviewCard } from "./components/PreviewCard";
 export type { PreviewCardProps } from "./components/PreviewCard";
 
+export { MultipleChoiceQuiz } from "./components/MultipleChoiceQuiz";
+export type {
+  MultipleChoiceAnswer,
+  MultipleChoiceOption,
+  MultipleChoiceQuizProps
+} from "./components/MultipleChoiceQuiz";
+
 export { InstagramEngagementSection } from "./components/InstagramEngagementSection";
 export type { InstagramEngagementSectionProps } from "./components/InstagramEngagementSection";
 


### PR DESCRIPTION
## Summary
- add a reusable MultipleChoiceQuiz component with configurable feedback and retry behaviour
- cover the quiz interactions with unit tests and export it from the flashoffer-react package
- showcase the component in the flashoffer demo via a new interactive quiz section

## Testing
- npm test -- --runInBand (app/flashoffer-react)
- npm test (app/flashoffer-demo)


------
https://chatgpt.com/codex/tasks/task_e_68e3e80955308321b304f3d2712e0bb4