### PR TITLE
Enforce alphabetical ordering in Flashoffer docs

### DIFF
--- a/app/flashoffer-react/AGENTS.md
+++ b/app/flashoffer-react/AGENTS.md
@@ -7,3 +7,5 @@
   conventions for detailed parameter and return information.
 - Author documentation with the depth and tone expected between expert
   software engineers.
+- When curating documentation indexes (for example, lists of child page links),
+  sort entries alphabetically.

--- a/app/flashoffer-react/docs/reference/flashoffer-react/README.md
+++ b/app/flashoffer-react/docs/reference/flashoffer-react/README.md
@@ -7,19 +7,19 @@
 ## Interfaces
 
 - [AutoTrackProps](interfaces/AutoTrackProps.md)
+- [EngagementContextValue](interfaces/EngagementContextValue.md)
 - [EngagementEvent](interfaces/EngagementEvent.md)
 - [EngagementProviderProps](interfaces/EngagementProviderProps.md)
-- [EngagementContextValue](interfaces/EngagementContextValue.md)
-- [ViewTrackerProps](interfaces/ViewTrackerProps.md)
 - [EventConsoleProps](interfaces/EventConsoleProps.md)
 - [FigureProps](interfaces/FigureProps.md)
+- [FlashofferThemeProviderProps](interfaces/FlashofferThemeProviderProps.md)
 - [FooterLink](interfaces/FooterLink.md)
 - [FooterProps](interfaces/FooterProps.md)
 - [HeroBannerProps](interfaces/HeroBannerProps.md)
 - [PreviewCardProps](interfaces/PreviewCardProps.md)
-- [SectionProps](interfaces/SectionProps.md)
 - [SectionHeaderProps](interfaces/SectionHeaderProps.md)
-- [FlashofferThemeProviderProps](interfaces/FlashofferThemeProviderProps.md)
+- [SectionProps](interfaces/SectionProps.md)
+- [ViewTrackerProps](interfaces/ViewTrackerProps.md)
 
 ## Type Aliases
 
@@ -30,13 +30,12 @@
 ## Functions
 
 - [AutoTrack](functions/AutoTrack.md)
+- [createFlashofferTheme](functions/createFlashofferTheme.md)
+- [createSpaciousTypographyTheme](functions/createSpaciousTypographyTheme.md)
 - [EngagementProvider](functions/EngagementProvider.md)
-- [useEngagement](functions/useEngagement.md)
-- [useViewTracker](functions/useViewTracker.md)
-- [ViewTracker](functions/ViewTracker.md)
-- [useRecordInteraction](functions/useRecordInteraction.md)
 - [EventConsole](functions/EventConsole.md)
 - [Figure](functions/Figure.md)
+- [FlashofferThemeProvider](functions/FlashofferThemeProvider.md)
 - [Footer](functions/Footer.md)
 - [HeroBanner](functions/HeroBanner.md)
 - [OutlineCtaButton](functions/OutlineCtaButton.md)
@@ -44,9 +43,10 @@
 - [PrimaryCtaButton](functions/PrimaryCtaButton.md)
 - [Section](functions/Section.md)
 - [SectionHeader](functions/SectionHeader.md)
-- [createFlashofferTheme](functions/createFlashofferTheme.md)
-- [createSpaciousTypographyTheme](functions/createSpaciousTypographyTheme.md)
-- [FlashofferThemeProvider](functions/FlashofferThemeProvider.md)
+- [useEngagement](functions/useEngagement.md)
+- [useRecordInteraction](functions/useRecordInteraction.md)
+- [useViewTracker](functions/useViewTracker.md)
+- [ViewTracker](functions/ViewTracker.md)
 
 ## Guides
 


### PR DESCRIPTION
## Summary
- add a documentation guideline that index lists must be alphabetical
- reorder the Flashoffer React reference README index entries accordingly

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e6a8845dbc8321b7fca81d3fcd9c40