### PR TITLE
Add docker-compose maintenance guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,13 @@
 - Node.js projects: modify `package.json` and `package-lock.json` only when
   the dependency list changes.
 
+## `docker-compose.yml`
+
+- Always document services with comments that explain ongoing maintenance and
+  operational expectations.
+- Group related services together and sort them alphabetically within their
+  groupings.
+
 ## Checker Scripts
 
 - When generating Codex checker scripts, always include ExcludeList support.


### PR DESCRIPTION
## Summary
- document maintenance expectations for docker-compose services
- require related services to be grouped and alphabetized

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e724aefc7c8321ae8461ea9f3960a7