### PR TITLE
Add quiz backend service and log demo quiz events

### DIFF
--- a/app/flashoffer-demo/src/quizAnalytics.ts
+++ b/app/flashoffer-demo/src/quizAnalytics.ts
@@ -1,0 +1,102 @@
+const QUIZ_EVENTS_ENDPOINT =
+  typeof import.meta.env.VITE_FLASHOFFER_QUIZ_EVENTS_ENDPOINT === "string" &&
+  import.meta.env.VITE_FLASHOFFER_QUIZ_EVENTS_ENDPOINT.trim() !== ""
+    ? import.meta.env.VITE_FLASHOFFER_QUIZ_EVENTS_ENDPOINT
+    : undefined;
+
+const QUIZ_ID = "flashoffer-demo.best-follow-up";
+const USER_STORAGE_KEY = "flashoffer-demo:quiz-user-id";
+
+let cachedUserId: string | null = null;
+
+function generateUserId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  const random = Math.random().toString(16).slice(2, 10);
+  return `${Date.now().toString(16)}-${random}`;
+}
+
+function readStoredUserId(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    const stored = window.sessionStorage.getItem(USER_STORAGE_KEY);
+    return stored && stored.trim() !== "" ? stored : null;
+  } catch (error) {
+    console.warn("Unable to access sessionStorage for quiz analytics", error);
+    return null;
+  }
+}
+
+function writeStoredUserId(userId: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    window.sessionStorage.setItem(USER_STORAGE_KEY, userId);
+  } catch (error) {
+    console.warn("Unable to persist quiz analytics user identifier", error);
+  }
+}
+
+function resolveUserId(): string {
+  if (cachedUserId) {
+    return cachedUserId;
+  }
+  const stored = readStoredUserId();
+  if (stored) {
+    cachedUserId = stored;
+    return cachedUserId;
+  }
+  cachedUserId = generateUserId();
+  writeStoredUserId(cachedUserId);
+  return cachedUserId;
+}
+
+export interface QuizCompletionPayload {
+  selectedOptionId: string;
+  correctOptionId?: string;
+  isCorrect?: boolean;
+  question: string;
+  attempt: number;
+}
+
+export async function logQuizCompletion(
+  payload: QuizCompletionPayload
+): Promise<void> {
+  if (!QUIZ_EVENTS_ENDPOINT) {
+    return;
+  }
+  if (typeof fetch !== "function") {
+    return;
+  }
+
+  const body = {
+    quiz_id: QUIZ_ID,
+    user_id: resolveUserId(),
+    event_type: "complete",
+    passed: Boolean(payload.isCorrect),
+    metadata: {
+      question: payload.question,
+      selected_option_id: payload.selectedOptionId,
+      correct_option_id: payload.correctOptionId,
+      attempt: payload.attempt,
+    },
+    occurred_at: new Date().toISOString(),
+  };
+
+  try {
+    await fetch(QUIZ_EVENTS_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      keepalive: true,
+      credentials: "include",
+    });
+  } catch (error) {
+    console.warn("Failed to log quiz completion", error);
+  }
+}
+

--- a/app/flashoffer-demo/src/sections/QuizShowcaseSection.tsx
+++ b/app/flashoffer-demo/src/sections/QuizShowcaseSection.tsx
@@ -1,7 +1,10 @@
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
+import { useRef } from "react";
 import { MultipleChoiceQuiz, Section } from "flashoffer-react";
+import type { MultipleChoiceAnswer } from "flashoffer-react";
+import { logQuizCompletion } from "../quizAnalytics";
 
 const QUIZ_OPTIONS = [
   {
@@ -30,7 +33,24 @@ const QUIZ_META = JSON.stringify({
   options: QUIZ_OPTIONS.map((option) => option.id)
 });
 
+const QUIZ_QUESTION =
+  "After a prospect explores a Flashoffer landing page, what follow-up drives " +
+  "the highest conversion lift?";
+
 export function QuizShowcaseSection() {
+  const attemptRef = useRef(0);
+
+  const handleAnswer = (answer: MultipleChoiceAnswer) => {
+    attemptRef.current += 1;
+    void logQuizCompletion({
+      attempt: attemptRef.current,
+      question: QUIZ_QUESTION,
+      selectedOptionId: answer.optionId,
+      correctOptionId: "reminder",
+      isCorrect: answer.isCorrect,
+    });
+  };
+
   return (
     <Box
       component="section"
@@ -53,13 +73,14 @@ export function QuizShowcaseSection() {
           </Grid>
           <Grid size={{ xs: 12, md: 7 }}>
             <MultipleChoiceQuiz
-              question="After a prospect explores a Flashoffer landing page, what follow-up drives the highest conversion lift?"
+              question={QUIZ_QUESTION}
               helperText="Consider which option keeps momentum without adding friction."
               options={QUIZ_OPTIONS}
               correctOptionId="reminder"
               explanation="Timely reminders build on existing intent and keep the offer top of mind without introducing blockers."
               successMessage="Exactly. Reinforcing urgency while keeping the path clear sustains conversion lift."
               errorMessage="Think about which follow-up reduces friction instead of adding new steps."
+              onAnswer={handleAnswer}
             />
           </Grid>
         </Grid>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,24 @@ services:
     volumes:
       - ./app/analytics-backend:/app
 
+  quiz-backend:
+    build:
+      context: .
+      dockerfile: ./app/quiz-backend/Dockerfile
+    environment:
+      DATABASE_HOST: analytics-db
+      DATABASE_PORT: 5432
+      DATABASE_USER: analytics
+      DATABASE_PASSWORD: analytics
+      DATABASE_NAME: analytics
+      CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS:-http://localhost:5173,http://localhost:4173}
+    depends_on:
+      - analytics-db
+    ports:
+      - "8002:8000"
+    volumes:
+      - ./app/quiz-backend:/app
+
   flashoffer:
     build:
       context: .
@@ -144,11 +162,15 @@ services:
       PORT: ${FLASHOFFER_PORT:-4173}
       VITE_FLASHOFFER_ANALYTICS_ENDPOINT: ${FLASHOFFER_ANALYTICS_ENDPOINT:-http://localhost:8001/events}
       VITE_FLASHOFFER_ANALYTICS_RECENT_URL: ${FLASHOFFER_ANALYTICS_RECENT_URL:-http://localhost:8001/events/recent}
+      VITE_FLASHOFFER_QUIZ_EVENTS_ENDPOINT: ${FLASHOFFER_QUIZ_EVENTS_ENDPOINT:-http://localhost:8002/api/events/quiz}
     ports:
       - "${FLASHOFFER_PORT:-4173}:4173"
       - "80:80"
     volumes:
       - ./:/workspace
+    depends_on:
+      - analytics-backend
+      - quiz-backend
 
   flashoffer-dev:
     build:
@@ -160,12 +182,14 @@ services:
       CHOKIDAR_USEPOLLING: "true"
       VITE_FLASHOFFER_ANALYTICS_ENDPOINT: ${FLASHOFFER_ANALYTICS_ENDPOINT:-http://localhost:8001/events}
       VITE_FLASHOFFER_ANALYTICS_RECENT_URL: ${FLASHOFFER_ANALYTICS_RECENT_URL:-http://localhost:8001/events/recent}
+      VITE_FLASHOFFER_QUIZ_EVENTS_ENDPOINT: ${FLASHOFFER_QUIZ_EVENTS_ENDPOINT:-http://localhost:8002/api/events/quiz}
     ports:
       - "${FLASHOFFER_DEV_PORT:-5173}:5173"
     volumes:
       - ./:/workspace
     depends_on:
       - analytics-backend
+      - quiz-backend
 
 volumes:
   analytics_data:


### PR DESCRIPTION
## Summary
- add the quiz-backend service to docker-compose and wire flashoffer containers to it
- add a reusable quiz analytics helper that persists a per-session user id
- submit flashoffer demo quiz answers to the quiz backend for completion tracking

## Testing
- npm --prefix app/flashoffer-demo test

------
https://chatgpt.com/codex/tasks/task_e_68e7245392388321988ff180a48cf3dc