### PR TITLE
Add build cache mounts to backend Dockerfiles

### DIFF
--- a/app/analytics-backend/Dockerfile
+++ b/app/analytics-backend/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.6
 ######################################################################
 # Analytics API image
 #
@@ -31,7 +32,8 @@ COPY app/shell/py/pie /tmp/pie
 # Install application dependencies, the shared PIE package, and dominate
 # (used to render HTML emails). Cleaning the temporary directory avoids
 # keeping duplicate source trees in the final image.
-RUN pip install --no-cache-dir -r requirements.txt \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir -r requirements.txt \
     && pip install --no-cache-dir /tmp/pie dominate \
     && rm -rf /tmp/pie
 
@@ -57,14 +59,18 @@ ENV GUNICORN_WORKERS=4 \
     GUNICORN_BIND=unix:/tmp/gunicorn.sock
 
 # Install nginx for reverse proxying and clean up apt metadata to keep the
-# image size in check.
-RUN apt-get update \
+# image size in check. Caching apt metadata dramatically speeds up rebuilds
+# while still ensuring the runtime layer stays slim.
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update \
     && apt-get install --no-install-recommends -y nginx \
     && rm -rf /var/lib/apt/lists/*
 
 # Gunicorn is only required in the production image, so install it here to
 # avoid bloating the base stage.
-RUN pip install --no-cache-dir gunicorn
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir gunicorn
 
 # Provide the templated nginx config and startup script used in
 # deployments.

--- a/app/quiz-backend/Dockerfile
+++ b/app/quiz-backend/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.6
 ######################################################################
 # Quiz API image
 #
@@ -19,7 +20,8 @@ COPY app/quiz-backend/requirements.txt ./requirements.txt
 COPY app/backend-common/backend_common ./backend_common
 COPY app/shell/py/pie /tmp/pie
 
-RUN pip install --no-cache-dir -r requirements.txt \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir -r requirements.txt \
     && pip install --no-cache-dir /tmp/pie dominate \
     && rm -rf /tmp/pie
 
@@ -37,11 +39,16 @@ FROM base AS prod
 ENV GUNICORN_WORKERS=4 \
     GUNICORN_BIND=unix:/tmp/gunicorn.sock
 
-RUN apt-get update \
+# Install nginx for reverse proxying and keep apt metadata cached during
+# builds to speed up rebuilds without bloating the runtime image.
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update \
     && apt-get install --no-install-recommends -y nginx \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir gunicorn
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir gunicorn
 
 COPY app/quiz-backend/nginx.conf /etc/nginx/conf.d/default.conf
 COPY app/quiz-backend/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## Summary
- enable BuildKit syntax for the analytics and quiz backend images
- add cache mounts for pip and apt layers to reuse dependencies across builds

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e72833b7f48321a244e6301cfe0990