### PR TITLE
Install backend-common package in analytics and quiz services

### DIFF
--- a/app/analytics-backend/Dockerfile
+++ b/app/analytics-backend/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /app
 # Copy dependency manifests and shared PIE utilities first so Docker can
 # reuse the layer when application code changes.
 COPY app/analytics-backend/requirements.txt ./requirements.txt
-COPY app/backend-common/backend_common ./backend_common
+COPY app/backend-common /backend-common
 COPY app/shell/py/pie /tmp/pie
 
 # Install application dependencies, the shared PIE package, and dominate
@@ -33,7 +33,7 @@ COPY app/shell/py/pie /tmp/pie
 # keeping duplicate source trees in the final image.
 RUN pip install --no-cache-dir -r requirements.txt \
     && pip install --no-cache-dir /tmp/pie dominate \
-    && rm -rf /tmp/pie
+    && rm -rf /tmp/pie /backend-common
 
 # Copy the application and tests as the final step so source edits only
 # invalidate the top layer.

--- a/app/analytics-backend/requirements.txt
+++ b/app/analytics-backend/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.3.3
 loguru==0.7.2
 psycopg2-binary==2.9.9
 pytest==7.4.4
+../backend-common

--- a/app/backend-common/setup.py
+++ b/app/backend-common/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="backend-common",
+    version="0.1.0",
+    description="Shared helpers for backend Flask services.",
+    packages=find_packages(),
+    python_requires=">=3.11",
+)

--- a/app/quiz-backend/Dockerfile
+++ b/app/quiz-backend/Dockerfile
@@ -16,12 +16,12 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 COPY app/quiz-backend/requirements.txt ./requirements.txt
-COPY app/backend-common/backend_common ./backend_common
+COPY app/backend-common /backend-common
 COPY app/shell/py/pie /tmp/pie
 
 RUN pip install --no-cache-dir -r requirements.txt \
     && pip install --no-cache-dir /tmp/pie dominate \
-    && rm -rf /tmp/pie
+    && rm -rf /tmp/pie /backend-common
 
 COPY app/quiz-backend/quiz_backend ./quiz_backend
 COPY app/quiz-backend/tests ./tests

--- a/app/quiz-backend/requirements.txt
+++ b/app/quiz-backend/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.3.3
 loguru==0.7.2
 psycopg2-binary==2.9.9
 pytest==7.4.4
+../backend-common


### PR DESCRIPTION
## Summary
- add the shared backend-common package to the analytics and quiz backend requirements
- install backend-common during container builds so both services import the shared helpers at runtime
- package backend-common with a simple setuptools setup to support installation from requirements files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e729bf98a08321b6d766ac90c76931