### PR TITLE
docs: add FlashofferThemeProvider example

### DIFF
--- a/app/flashoffer/flashoffer-react/AGENTS.md
+++ b/app/flashoffer/flashoffer-react/AGENTS.md
@@ -7,3 +7,5 @@
   conventions for detailed parameter and return information.
 - Author documentation with the depth and tone expected between expert
   software engineers.
+- When updating documentation, include a representative code sample whenever
+  possible.

--- a/app/flashoffer/flashoffer-react/docs/reference/flashoffer-react/functions/FlashofferThemeProvider.md
+++ b/app/flashoffer/flashoffer-react/docs/reference/flashoffer-react/functions/FlashofferThemeProvider.md
@@ -10,11 +10,53 @@ Defined in: src/theme/FlashofferThemeProvider.tsx:92
 
 Theme provider exposing CSS-token aware defaults for Flashoffer surfaces.
 
+Wrap this component around your React subtree to inject the Flashoffer theme.
+It constructs an MUI `Theme` from the selected preset, merges any supplied
+`themeOptions`, and exposes the result through `ThemeProvider`. The provider
+also emits a collection of CSS custom properties so non-MUI components can
+consume the same palette tokens.
+
+## Usage example
+
+Mount the provider close to your app shell so all descendants share the same
+design tokens. Extend the preset theme with `themeOptions` when you need to
+override typography or component styles.
+
+```tsx
+import { FlashofferThemeProvider } from "flashoffer-react";
+import { CssBaseline, Typography } from "@mui/material";
+
+export function App() {
+  return (
+    <FlashofferThemeProvider
+      applyCssBaseline
+      preset="spaciousTypography"
+      themeOptions={{
+        typography: {
+          h1: {
+            fontSize: "3rem",
+          },
+        },
+      }}
+    >
+      <CssBaseline />
+      <Typography variant="h1">Deals of the Day</Typography>
+    </FlashofferThemeProvider>
+  );
+}
+```
+
 ## Parameters
 
 ### \_\_namedParameters
 
 [`FlashofferThemeProviderProps`](../interfaces/FlashofferThemeProviderProps.md)
+
+- `themeOptions`: Additional `ThemeOptions` merged with the preset defaults.
+- `applyCssBaseline`: Controls whether MUI's `CssBaseline` is rendered.
+- `preset`: Choose between the `default` palette and `spaciousTypography`.
+- `colorMode`: Palette mode forwarded to presets that support light or dark
+  variants.
 
 ## Returns
 


### PR DESCRIPTION
## Summary
- detail how FlashofferThemeProvider constructs and applies the theme
- document the meaning of the key provider props for easier integration
- add a usage example demonstrating how to customize the provider
- require documentation updates to include a representative code sample via AGENTS guidance

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68e73cfe31f48321b1e2d0628aaa0f94