### PR TITLE
Expose Flashoffer presets in demo theme selector

### DIFF
--- a/app/flashoffer/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer/flashoffer-demo/src/App.tsx
@@ -76,6 +76,22 @@ const themePresets: Record<ThemePreset, ThemePresetConfig> = {
       }
     }
   },
+  sunriseGlow: {
+    preset: "sunriseGlow"
+  },
+  midnightPulse: {
+    preset: "midnightPulse",
+    colorMode: "dark"
+  },
+  oceanBreeze: {
+    preset: "oceanBreeze"
+  },
+  forestCanopy: {
+    preset: "forestCanopy"
+  },
+  monochromeFocus: {
+    preset: "monochromeFocus"
+  },
   spaciousLight: {
     preset: "spaciousTypography",
     colorMode: "light"

--- a/app/flashoffer/flashoffer-demo/src/sections/HeroShowcaseSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/HeroShowcaseSection.tsx
@@ -23,6 +23,26 @@ const HERO_GRADIENT_OVERRIDES: Record<
     "--flashoffer-hero-gradient-start": "#1e293b",
     "--flashoffer-hero-gradient-stop": "#0f172a"
   },
+  sunriseGlow: {
+    "--flashoffer-hero-gradient-start": "rgba(249, 115, 22, 0.22)",
+    "--flashoffer-hero-gradient-stop": "rgba(234, 179, 8, 0.28)"
+  },
+  midnightPulse: {
+    "--flashoffer-hero-gradient-start": "rgba(99, 102, 241, 0.35)",
+    "--flashoffer-hero-gradient-stop": "rgba(15, 23, 42, 0.92)"
+  },
+  oceanBreeze: {
+    "--flashoffer-hero-gradient-start": "rgba(14, 165, 233, 0.18)",
+    "--flashoffer-hero-gradient-stop": "rgba(20, 184, 166, 0.24)"
+  },
+  forestCanopy: {
+    "--flashoffer-hero-gradient-start": "rgba(34, 197, 94, 0.18)",
+    "--flashoffer-hero-gradient-stop": "rgba(15, 118, 110, 0.28)"
+  },
+  monochromeFocus: {
+    "--flashoffer-hero-gradient-start": "rgba(15, 23, 42, 0.12)",
+    "--flashoffer-hero-gradient-stop": "rgba(15, 23, 42, 0.32)"
+  },
   spaciousLight: {
     "--flashoffer-hero-gradient-start": "rgba(29, 78, 216, 0.14)",
     "--flashoffer-hero-gradient-stop": "rgba(219, 39, 119, 0.18)"

--- a/app/flashoffer/flashoffer-demo/src/sections/types.ts
+++ b/app/flashoffer/flashoffer-demo/src/sections/types.ts
@@ -2,6 +2,11 @@ export type ThemePreset =
   | "ocean"
   | "sunset"
   | "midnight"
+  | "sunriseGlow"
+  | "midnightPulse"
+  | "oceanBreeze"
+  | "forestCanopy"
+  | "monochromeFocus"
   | "spaciousLight"
   | "spaciousDark";
 export type HeroAlignment = "left" | "center";
@@ -10,6 +15,11 @@ export const THEME_PRESET_ORDER: readonly ThemePreset[] = [
   "ocean",
   "sunset",
   "midnight",
+  "sunriseGlow",
+  "midnightPulse",
+  "oceanBreeze",
+  "forestCanopy",
+  "monochromeFocus",
   "spaciousLight",
   "spaciousDark"
 ];
@@ -18,6 +28,11 @@ export const THEME_PRESET_LABELS: Record<ThemePreset, string> = {
   ocean: "Ocean (default)",
   sunset: "Sunset",
   midnight: "Midnight",
+  sunriseGlow: "Sunrise glow",
+  midnightPulse: "Midnight pulse",
+  oceanBreeze: "Ocean breeze",
+  forestCanopy: "Forest canopy",
+  monochromeFocus: "Monochrome focus",
   spaciousLight: "Spacious typography (light)",
   spaciousDark: "Spacious typography (dark)"
 };


### PR DESCRIPTION
## Summary
- add the remaining Flashoffer theme presets to the demo switcher with labels and ordering updates
- provide hero gradient overrides so each preset renders cohesive backgrounds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e74a2736b08321808b98e24fe5fdeb