### PR TITLE
Prevent revealing correct answer during retries

### DIFF
--- a/app/flashoffer/flashoffer-react/docs/reference/flashoffer-react/functions/MultipleChoiceQuiz.md
+++ b/app/flashoffer/flashoffer-react/docs/reference/flashoffer-react/functions/MultipleChoiceQuiz.md
@@ -50,11 +50,14 @@ through the `onAnswer` callback without rendering evaluation UI.
 ## Submission flow
 
 By default, learners can retry after an incorrect attempt when a correct
-answer is defined. The behaviour can be changed by setting `allowRetry` to
-`false`. The component disables the submit button until an option is
-selected and automatically locks choices after a correct response. Every
-submission triggers `onAnswer` with the selected option identifier and the
-computed correctness flag when available.
+answer is defined. During these retries the component only highlights the
+submitted option, keeping the correct choice hidden until the learner
+either responds accurately or retries are disabled. The behaviour can be
+changed by setting `allowRetry` to `false`. The component disables the
+submit button until an option is selected and automatically locks choices
+after a correct response. Every submission triggers `onAnswer` with the
+selected option identifier and the computed correctness flag when
+available.
 
 ## Accessibility
 

--- a/app/flashoffer/flashoffer-react/docs/reference/flashoffer-react/interfaces/MultipleChoiceQuizProps.md
+++ b/app/flashoffer/flashoffer-react/docs/reference/flashoffer-react/interfaces/MultipleChoiceQuizProps.md
@@ -118,8 +118,10 @@ Label for the retry button. Defaults to "Try again".
 
 Defined in: src/components/MultipleChoiceQuiz.tsx:61
 
-Allows additional attempts when the initial submission is incorrect. Defaults
-to true when a correct answer is configured.
+Allows additional attempts when the initial submission is incorrect. While
+retries remain available, incorrect answers only highlight the submitted
+choice so the correct option stays hidden. Defaults to true when a correct
+answer is configured.
 
 ***
 

--- a/app/flashoffer/flashoffer-react/src/components/MultipleChoiceQuiz.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/MultipleChoiceQuiz.tsx
@@ -140,6 +140,8 @@ export function MultipleChoiceQuiz({
   }, [disabled, evaluation, hasSubmitted, resolvedAllowRetry]);
 
   const showFeedback = Boolean(hasSubmitted && correctOptionId);
+  const revealCorrectAnswer =
+    showFeedback && (evaluation === true || !resolvedAllowRetry);
   const submitDisabled =
     !selectedId ||
     disabled ||
@@ -193,8 +195,16 @@ export function MultipleChoiceQuiz({
                   const isSelected = selectedId === option.id;
                   const isAnswer = correctOptionId === option.id;
                   const isSubmittedSelection = submittedId === option.id;
-                  const highlight =
-                    showFeedback && (isAnswer || isSubmittedSelection);
+                  const highlightSelection = showFeedback && isSubmittedSelection;
+                  const highlightAnswer = revealCorrectAnswer && isAnswer;
+                  const highlight = highlightAnswer || highlightSelection;
+                  const optionState = highlight
+                    ? highlightAnswer
+                      ? "correct"
+                      : "incorrect"
+                    : isSelected
+                    ? "selected"
+                    : "default";
 
                   return (
                     <FormControlLabel
@@ -217,6 +227,7 @@ export function MultipleChoiceQuiz({
                         </Stack>
                       }
                       disabled={disableChoices}
+                      data-option-state={optionState}
                       sx={(theme) => ({
                         alignItems: "flex-start",
                         m: 0,
@@ -226,7 +237,7 @@ export function MultipleChoiceQuiz({
                         borderWidth: 1,
                         borderStyle: "solid",
                         borderColor: highlight
-                          ? isAnswer
+                          ? highlightAnswer
                             ? theme.palette.success.main
                             : theme.palette.error.main
                           : isSelected
@@ -234,7 +245,7 @@ export function MultipleChoiceQuiz({
                           : theme.palette.divider,
                         backgroundColor: highlight
                           ? alpha(
-                              isAnswer
+                              highlightAnswer
                                 ? theme.palette.success.main
                                 : theme.palette.error.main,
                               0.08

--- a/app/flashoffer/flashoffer-react/src/components/__tests__/MultipleChoiceQuiz.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/__tests__/MultipleChoiceQuiz.test.tsx
@@ -81,4 +81,38 @@ describe("MultipleChoiceQuiz", () => {
         .checked
     ).toBe(false);
   });
+
+  it("hides the correct answer highlight when retries are allowed", () => {
+    renderQuiz();
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: /story taps forward/i })
+    );
+    fireEvent.click(screen.getByRole("button", { name: /check answer/i }));
+
+    const incorrectOptionLabel = screen
+      .getByText(/story taps forward/i)
+      .closest("label");
+    const correctOptionLabel = screen
+      .getByText(/saves per reel/i)
+      .closest("label");
+
+    expect(incorrectOptionLabel?.dataset.optionState).toBe("incorrect");
+    expect(correctOptionLabel?.dataset.optionState).toBe("default");
+  });
+
+  it("reveals the correct answer when retries are disabled", () => {
+    renderQuiz({ allowRetry: false });
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: /story taps forward/i })
+    );
+    fireEvent.click(screen.getByRole("button", { name: /check answer/i }));
+
+    const correctOptionLabel = screen
+      .getByText(/saves per reel/i)
+      .closest("label");
+
+    expect(correctOptionLabel?.dataset.optionState).toBe("correct");
+  });
 });


### PR DESCRIPTION
## Summary
- defer revealing the correct choice until retries are exhausted or the learner answers correctly
- expose option state metadata for reliable styling and testing hooks
- document the revised retry behaviour in the reference material

## Testing
- npm test -- MultipleChoiceQuiz

------
https://chatgpt.com/codex/tasks/task_e_68e74ab259cc83219422c01dcdd27ee1