### PR TITLE
Ensure countdown timer segments remain visible

### DIFF
--- a/app/flashoffer/flashoffer-demo/README.md
+++ b/app/flashoffer/flashoffer-demo/README.md
@@ -44,3 +44,7 @@ the top of the page:
 To try different copy or preview cards, update the arrays declared in
 `src/App.tsx`. Reload the dev server (or rerun the build) after changing the
 sample data to ensure the generated bundle matches your updates.
+
+The countdown showcase highlights how to wire `CountdownTimer` into offer
+pages. Adjust the props in `src/sections/CountdownShowcaseSection.tsx` to try
+alternate headlines, quantities, or end times that match your promotion.

--- a/app/flashoffer/flashoffer-demo/src/App.test.tsx
+++ b/app/flashoffer/flashoffer-demo/src/App.test.tsx
@@ -36,6 +36,19 @@ describe("Flashoffer demo", () => {
     expect(previewCards).toHaveLength(3);
   });
 
+  it("renders the countdown timer showcase", async () => {
+    render(<App />);
+
+    expect(
+      await screen.findByRole("heading", {
+        level: 2,
+        name: /drive urgency with countdowns/i
+      })
+    ).toBeInTheDocument();
+    const timers = await screen.findAllByRole("timer");
+    expect(timers.length).toBeGreaterThan(0);
+  });
+
   it("renders the quiz showcase question", async () => {
     render(<App />);
 

--- a/app/flashoffer/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer/flashoffer-demo/src/App.tsx
@@ -20,6 +20,12 @@ const OverviewSection = lazy(async () => ({
   default: (await import("./sections/OverviewSection")).OverviewSection
 }));
 
+const CountdownShowcaseSection = lazy(async () => ({
+  default: (
+    await import("./sections/CountdownShowcaseSection")
+  ).CountdownShowcaseSection
+}));
+
 const CtaShowcaseSection = lazy(async () => ({
   default: (await import("./sections/CtaShowcaseSection")).CtaShowcaseSection
 }));
@@ -279,6 +285,9 @@ export default function App() {
             </Suspense>
             <Suspense fallback={null}>
               <OverviewSection overviewMeta={overviewMeta} />
+            </Suspense>
+            <Suspense fallback={null}>
+              <CountdownShowcaseSection />
             </Suspense>
             <Suspense fallback={null}>
               <CtaShowcaseSection />

--- a/app/flashoffer/flashoffer-demo/src/sections/CountdownShowcaseSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/CountdownShowcaseSection.tsx
@@ -1,0 +1,61 @@
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { useMemo } from "react";
+import { CountdownTimer, Section } from "flashoffer-react";
+
+export function CountdownShowcaseSection() {
+  const earlyAccessEnd = useMemo(
+    () => new Date(Date.now() + 1000 * 60 * 60 * 45),
+    []
+  );
+  const restockEnd = useMemo(
+    () => new Date(Date.now() + 1000 * 60 * 90),
+    []
+  );
+  const trackMeta = JSON.stringify({ variants: 2 });
+
+  return (
+    <Box
+      component="section"
+      data-track-id="countdown-showcase"
+      data-track-label="Countdown timer showcase"
+      data-track-meta={trackMeta}
+    >
+      <Section
+        align="center"
+        eyebrow="LIMITED-TIME PROMOS"
+        title="Drive urgency with countdowns"
+      >
+        <Typography color="text.secondary">
+          CountdownTimer spotlights dwindling inventory and time-sensitive
+          campaigns with live updates. Combine bold copy with quantity cues to
+          motivate action across flash drops or restock alerts.
+        </Typography>
+        <Stack
+          direction={{ xs: "column", lg: "row" }}
+          spacing={3}
+          alignItems="stretch"
+          justifyContent="center"
+        >
+          <Box sx={{ width: "100%", maxWidth: 420 }}>
+            <CountdownTimer
+              endTime={earlyAccessEnd}
+              timerLabel="Early access ends in"
+              headline="Creator passes are almost gone."
+              quantityRemaining={42}
+              quantityLabel="Passes left"
+            />
+          </Box>
+          <Box sx={{ width: "100%", maxWidth: 420 }}>
+            <CountdownTimer
+              endTime={restockEnd}
+              timerLabel="Restock drops in"
+              headline="Set an alert for the next batch."
+            />
+          </Box>
+        </Stack>
+      </Section>
+    </Box>
+  );
+}

--- a/app/flashoffer/flashoffer-demo/src/sections/index.ts
+++ b/app/flashoffer/flashoffer-demo/src/sections/index.ts
@@ -2,6 +2,7 @@ export * from "./types";
 export * from "./CustomizationControlsSection";
 export * from "./HeroShowcaseSection";
 export * from "./OverviewSection";
+export * from "./CountdownShowcaseSection";
 export * from "./CtaShowcaseSection";
 export * from "./PreviewShowcaseSection";
 export * from "./FigureSpotlightSection";

--- a/app/flashoffer/flashoffer-react/src/components/CountdownTimer.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/CountdownTimer.tsx
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+const SEGMENT_DEFINITIONS = [
+  { key: "days", label: "Days" },
+  { key: "hours", label: "Hours" },
+  { key: "minutes", label: "Minutes" },
+  { key: "seconds", label: "Seconds" }
+] as const;
+
+interface CountdownSegments {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  totalMs: number;
+}
+
+/**
+ * Normalizes end time inputs into a Unix timestamp in milliseconds.
+ *
+ * @param endTime - End time candidate to convert into milliseconds.
+ * @returns Millisecond precision timestamp representing the countdown end.
+ */
+function normalizeEndTime(endTime: Date | string | number): number {
+  const candidate =
+    endTime instanceof Date ? endTime.getTime() : new Date(endTime).getTime();
+
+  if (!Number.isFinite(candidate)) {
+    throw new Error("CountdownTimer received an invalid endTime value.");
+  }
+
+  return candidate;
+}
+
+/**
+ * Derives the remaining time segments from a millisecond timestamp.
+ *
+ * @param targetTimestamp - Future timestamp that represents when the offer
+ *   expires.
+ * @returns Structured segment breakdown describing the time left.
+ */
+function deriveSegments(targetTimestamp: number): CountdownSegments {
+  const now = Date.now();
+  const difference = Math.max(targetTimestamp - now, 0);
+
+  const totalSeconds = Math.floor(difference / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  return {
+    days,
+    hours,
+    minutes,
+    seconds,
+    totalMs: difference
+  };
+}
+
+/**
+ * Creates a spoken announcement summarizing the remaining time segments.
+ *
+ * @param segments - Countdown breakdown that informs the assistive summary.
+ * @returns Readable and accessible message for screen readers.
+ */
+function createAriaAnnouncement(segments: CountdownSegments): string {
+  const parts: string[] = [];
+
+  SEGMENT_DEFINITIONS.forEach(({ key, label }) => {
+    const value = segments[key];
+    const base = label.toLowerCase();
+    const singular = base.endsWith("s") ? base.slice(0, -1) : base;
+
+    if (value > 0 || (key === "seconds" && segments.totalMs === 0)) {
+      const noun = value === 1 ? singular : base;
+      parts.push(`${value} ${noun}`);
+    }
+  });
+
+  if (parts.length === 0) {
+    return "Offer window has concluded.";
+  }
+
+  return `Offer ends in ${parts.join(", ")}.`;
+}
+
+/**
+ * Formats numbers using at least two digits for compact presentation.
+ *
+ * @param value - Segment number to render.
+ * @returns Segment value padded to at least two characters.
+ */
+function formatSegmentValue(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+export interface CountdownTimerProps {
+  /** Target time indicating when the promotion ends. */
+  endTime: Date | string | number;
+  /** Optional number of items remaining for the promotion. */
+  quantityRemaining?: number;
+  /** Headline emphasizing the urgency of the promotion. */
+  headline?: ReactNode;
+  /** Label describing the timer group. */
+  timerLabel?: ReactNode;
+  /** Custom label rendered alongside the remaining quantity. */
+  quantityLabel?: ReactNode;
+  /** Interval, in milliseconds, at which the timer updates. */
+  intervalMs?: number;
+}
+
+const DEFAULT_HEADLINE = "Hurry! This drop is moving fast.";
+const DEFAULT_TIMER_LABEL = "Offer ends in";
+const DEFAULT_QUANTITY_LABEL = "units remaining";
+
+/**
+ * High-contrast countdown module pairing urgency copy with remaining
+ * quantity.
+ *
+ * @param props - Component configuration describing end time and messaging.
+ * @returns A visually urgent countdown surface.
+ */
+export function CountdownTimer({
+  endTime,
+  quantityRemaining,
+  headline = DEFAULT_HEADLINE,
+  timerLabel = DEFAULT_TIMER_LABEL,
+  quantityLabel = DEFAULT_QUANTITY_LABEL,
+  intervalMs = 1000
+}: CountdownTimerProps) {
+  const targetTimestamp = useMemo(() => normalizeEndTime(endTime), [endTime]);
+  const [segments, setSegments] = useState<CountdownSegments>(() =>
+    deriveSegments(targetTimestamp)
+  );
+
+  useEffect(() => {
+    setSegments(deriveSegments(targetTimestamp));
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const id = window.setInterval(() => {
+      setSegments(deriveSegments(targetTimestamp));
+    }, intervalMs);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [targetTimestamp, intervalMs]);
+
+  const ariaAnnouncement = useMemo(
+    () => createAriaAnnouncement(segments),
+    [segments]
+  );
+
+  const formattedQuantity = useMemo(() => {
+    if (typeof quantityRemaining !== "number") {
+      return null;
+    }
+
+    const formatter = new Intl.NumberFormat();
+    return formatter.format(Math.max(quantityRemaining, 0));
+  }, [quantityRemaining]);
+
+  return (
+    <Box
+      component="section"
+      role="timer"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-label={ariaAnnouncement}
+      sx={{
+        background:
+          "linear-gradient(135deg, rgba(255, 238, 239, 0.95) 0%, rgba(255, 226, 233, 0.95) 45%, rgba(255, 255, 255, 0.95) 100%)",
+        borderRadius: 6,
+        border: "1px solid",
+        borderColor: "error.light",
+        boxShadow: "0 24px 40px rgba(229, 57, 53, 0.35)",
+        color: "text.primary",
+        overflow: "visible",
+        p: { xs: 3, md: 4 },
+        position: "relative"
+      }}
+    >
+      <Stack spacing={3} alignItems={{ xs: "stretch", md: "center" }}>
+        <Stack
+          direction={{ xs: "column", md: "row" }}
+          spacing={2}
+          alignItems={{ xs: "flex-start", md: "center" }}
+          justifyContent="space-between"
+        >
+          <Stack spacing={1}>
+            <Typography
+              component="p"
+              variant="overline"
+              sx={{
+                color: "error.dark",
+                fontWeight: 700,
+                letterSpacing: 2,
+                textTransform: "uppercase"
+              }}
+            >
+              {timerLabel}
+            </Typography>
+            <Typography
+              component="h2"
+              variant="h4"
+              sx={{
+                fontWeight: 800,
+                letterSpacing: -0.5,
+                lineHeight: 1.1,
+                maxWidth: 520
+              }}
+            >
+              {headline}
+            </Typography>
+          </Stack>
+          {formattedQuantity ? (
+            <Chip
+              color="error"
+              label={
+                <Stack spacing={0.5} alignItems="center">
+                  <Typography
+                    component="span"
+                    variant="caption"
+                    sx={{ textTransform: "uppercase", fontWeight: 700 }}
+                  >
+                    {quantityLabel}
+                  </Typography>
+                  <Typography
+                    component="span"
+                    variant="h6"
+                    sx={{ fontWeight: 800, lineHeight: 1 }}
+                  >
+                    {formattedQuantity}
+                  </Typography>
+                </Stack>
+              }
+              sx={{
+                background:
+                  "linear-gradient(135deg, #ff1744 0%, #ff4569 50%, #ff8a80 100%)",
+                px: 2.5,
+                py: 2.5,
+                borderRadius: 4,
+                '& .MuiChip-label': {
+                  px: 0,
+                  py: 0
+                }
+              }}
+            />
+          ) : null}
+        </Stack>
+
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "repeat(1, minmax(0, 1fr))",
+              sm: "repeat(2, minmax(0, 1fr))",
+              lg: "repeat(4, minmax(0, 1fr))"
+            }
+          }}
+        >
+          {SEGMENT_DEFINITIONS.map(({ key, label }) => {
+            const value = segments[key];
+            return (
+              <Box
+                key={key}
+                sx={{
+                  background:
+                    "linear-gradient(160deg, rgba(255, 255, 255, 0.9) 0%, rgba(255, 205, 210, 0.6) 60%, rgba(255, 82, 82, 0.6) 100%)",
+                  borderRadius: 4,
+                  border: "1px solid rgba(255, 255, 255, 0.7)",
+                  boxShadow: "0 20px 40px rgba(244, 67, 54, 0.35)",
+                  px: 3,
+                  py: 2,
+                  textAlign: "center"
+                }}
+              >
+                <Typography
+                  component="span"
+                  variant="h3"
+                  aria-label={`${value} ${label.toLowerCase()} remaining`}
+                  sx={{
+                    display: "block",
+                    fontFeatureSettings: '"tnum" on, "ss01" on',
+                    fontWeight: 800,
+                    letterSpacing: -1,
+                    lineHeight: 1,
+                    mb: 1
+                  }}
+                >
+                  {formatSegmentValue(value)}
+                </Typography>
+                <Typography
+                  component="span"
+                  variant="subtitle2"
+                  sx={{
+                    color: "error.dark",
+                    fontWeight: 700,
+                    letterSpacing: 1.5,
+                    textTransform: "uppercase"
+                  }}
+                >
+                  {label}
+                </Typography>
+              </Box>
+            );
+          })}
+        </Box>
+      </Stack>
+    </Box>
+  );
+}

--- a/app/flashoffer/flashoffer-react/src/components/__tests__/CountdownTimer.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/__tests__/CountdownTimer.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
+import { act, render, screen } from "@testing-library/react";
+
+import { FlashofferThemeProvider } from "../../theme/FlashofferThemeProvider";
+import { CountdownTimer } from "../CountdownTimer";
+import type { CountdownTimerProps } from "../CountdownTimer";
+
+const NOW = new Date("2024-01-01T00:00:00Z");
+
+describe("CountdownTimer", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  /** Renders the countdown timer within the Flashoffer theme. */
+  function renderTimer(props: Partial<CountdownTimerProps> = {}) {
+    return render(
+      <FlashofferThemeProvider applyCssBaseline={false}>
+        <CountdownTimer endTime={NOW} {...props} />
+      </FlashofferThemeProvider>
+    );
+  }
+
+  it("renders the remaining time segments", () => {
+    const endTime = new Date("2024-01-03T05:06:07Z");
+    renderTimer({ endTime });
+
+    expect(
+      screen.getByLabelText(/\d+ days remaining/i)
+    ).toHaveTextContent("02");
+    expect(
+      screen.getByLabelText(/\d+ hours remaining/i)
+    ).toHaveTextContent("05");
+    expect(
+      screen.getByLabelText(/\d+ minutes remaining/i)
+    ).toHaveTextContent("06");
+    expect(
+      screen.getByLabelText(/\d+ seconds remaining/i)
+    ).toHaveTextContent("07");
+  });
+
+  it("stops at zero once the deadline passes", () => {
+    renderTimer({ endTime: new Date("2023-12-31T23:59:58Z") });
+    act(() => {
+      jest.advanceTimersByTime(2_000);
+    });
+
+    expect(screen.getByLabelText(/seconds remaining/i)).toHaveTextContent("00");
+    expect(screen.getByLabelText(/minutes remaining/i)).toHaveTextContent("00");
+    expect(screen.getByLabelText(/hours remaining/i)).toHaveTextContent("00");
+    expect(screen.getByLabelText(/days remaining/i)).toHaveTextContent("00");
+  });
+
+  it("highlights the remaining quantity when provided", () => {
+    renderTimer({
+      quantityRemaining: 42,
+      quantityLabel: "kits left"
+    });
+
+    expect(screen.getByText(/kits left/i)).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+});

--- a/app/flashoffer/flashoffer-react/src/index.ts
+++ b/app/flashoffer/flashoffer-react/src/index.ts
@@ -36,6 +36,9 @@ export type {
   MultipleChoiceQuizProps
 } from "./components/MultipleChoiceQuiz";
 
+export { CountdownTimer } from "./components/CountdownTimer";
+export type { CountdownTimerProps } from "./components/CountdownTimer";
+
 export { InstagramEngagementSection } from "./components/InstagramEngagementSection";
 export type { InstagramEngagementSectionProps } from "./components/InstagramEngagementSection";
 


### PR DESCRIPTION
## Summary
- document countdown utilities with Typedoc metadata for clarity
- adjust the countdown container and segment layout so the timer stays fully visible on narrow viewports

## Testing
- npm test -- CountdownTimer
- npm test -- src/App.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e7485100d083218e93c4d202e385f2