### PR TITLE
feat: add campaign countdown support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 .Python
 build/
 app/flashoffer/build/
+node_modules/
 develop-eggs/
 dist/
 downloads/

--- a/app/flashoffer/campaign-backend/Dockerfile
+++ b/app/flashoffer/campaign-backend/Dockerfile
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1.6
+######################################################################
+# Campaign API image
+#
+# The campaign backend exposes countdown metadata for Flashoffer timers.
+# This multi-stage build mirrors the analytics and quiz services so the
+# development workflow remains consistent across backend components.
+######################################################################
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    FLASK_APP=campaign_backend.app:create_app \
+    CORS_ALLOW_ORIGINS=
+
+WORKDIR /app
+
+COPY app/flashoffer/campaign-backend/requirements.txt ./requirements.txt
+COPY app/flashoffer/backend-common /backend-common
+COPY app/shell/py/pie /tmp/pie
+
+RUN --mount=type=cache,target=/root/.cache/pip,id=campaign-backend-pip \
+    pip install -r requirements.txt \
+    && pip install /tmp/pie dominate \
+    && rm -rf /tmp/pie /backend-common
+
+COPY app/flashoffer/campaign-backend/campaign_backend ./campaign_backend
+COPY app/flashoffer/campaign-backend/tests ./tests
+
+FROM base AS dev
+
+EXPOSE 8000
+
+CMD ["flask", "--app", "campaign_backend.app:create_app", "run", "--host=0.0.0.0", "--port=8000"]
+
+FROM base AS prod
+
+ENV GUNICORN_WORKERS=4 \
+    GUNICORN_BIND=unix:/tmp/gunicorn.sock
+
+RUN --mount=type=cache,target=/var/cache/apt,id=campaign-backend \
+    --mount=type=cache,target=/var/lib/apt/lists,id=campaign-backend \
+    apt-get update \
+    && apt-get install --no-install-recommends -y nginx \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/root/.cache/pip,id=campaign-backend-pip \
+    pip install gunicorn
+
+COPY app/flashoffer/campaign-backend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY app/flashoffer/campaign-backend/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8000
+
+CMD ["/entrypoint.sh"]

--- a/app/flashoffer/campaign-backend/campaign_backend/__init__.py
+++ b/app/flashoffer/campaign-backend/campaign_backend/__init__.py
@@ -1,0 +1,5 @@
+"""Campaign service package exposing countdown utilities."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/app/flashoffer/campaign-backend/campaign_backend/app.py
+++ b/app/flashoffer/campaign-backend/campaign_backend/app.py
@@ -1,0 +1,138 @@
+"""Flask application serving campaign countdown metadata."""
+
+from __future__ import annotations
+
+import atexit
+import json
+import time
+from datetime import datetime, timezone
+
+from flask import Flask, Response, jsonify, request
+
+from pie.logging import logger
+
+from backend_common import DatabaseConfig, configure_cors
+
+from .db import CampaignStore
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+
+    app = Flask(__name__)
+
+    config = DatabaseConfig.from_env()
+    storage = _initialise_storage(app, config)
+    atexit.register(storage.close)
+    app.config["DB_POOL"] = storage
+
+    apply_cors = configure_cors(app, component="campaign-backend")
+
+    @app.route("/health", methods=["GET"])
+    def healthcheck() -> Response:
+        with storage.connection() as conn:  # type: ignore[assignment]
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+                cur.fetchone()
+        return apply_cors(jsonify({"status": "ok"}))
+
+    @app.route("/api/campaign/<campaign_id>/time_remaining", methods=["OPTIONS"])
+    def time_remaining_options(campaign_id: str) -> Response:  # noqa: D401 - CORS helper
+        return apply_cors(Response(status=204))
+
+    @app.route("/api/campaign/<campaign_id>/time_remaining", methods=["GET"])
+    def time_remaining(campaign_id: str) -> Response:
+        record = storage.fetch_time_remaining(campaign_id)
+        requested_campaign = request.args.get("cid", campaign_id)
+        source = request.args.get("ct", "countdown-timer")
+
+        if record is None:
+            payload = {
+                "campaign_id": requested_campaign,
+                "time_remaining_ms": 0,
+                "quantity_remaining": None,
+                "source": source,
+            }
+            response = jsonify(payload)
+            response.status_code = 404
+            return apply_cors(response)
+
+        payload = {
+            "campaign_id": requested_campaign,
+            "time_remaining_ms": record["time_remaining_ms"],
+            "quantity_remaining": record["quantity_remaining"],
+            "source": source,
+            "fetched_at": datetime.now(tz=timezone.utc).isoformat(),
+        }
+        return apply_cors(jsonify(payload))
+
+    @app.route("/config", methods=["GET"])
+    def config_dump() -> Response:
+        details = {
+            "database": {
+                "host": config.host,
+                "port": config.port,
+                "name": config.database,
+            }
+        }
+        return apply_cors(Response(json.dumps(details), mimetype="application/json"))
+
+    return app
+
+
+def _initialise_storage(app: Flask, config: DatabaseConfig) -> CampaignStore:
+    """Initialise the campaign store with retry semantics."""
+
+    retry_interval = 5.0
+    timeout = 300.0
+    start_time = time.monotonic()
+    deadline = start_time + timeout
+    attempt = 1
+
+    storage_logger = logger.bind(
+        component="campaign-backend",
+        operation="database-initialisation",
+        flask_app=app.name,
+    )
+
+    while True:
+        storage: CampaignStore | None = None
+        try:
+            storage = CampaignStore(config)
+            storage.initialize()
+            storage.ensure_demo_campaign()
+        except Exception as exc:  # noqa: BLE001 - preserve original context
+            if storage is not None:
+                try:
+                    storage.close()
+                except Exception:  # noqa: BLE001 - suppress during cleanup
+                    pass
+
+            now = time.monotonic()
+            if now >= deadline:
+                storage_logger.opt(exception=exc).error(
+                    "Failed to connect to the database",
+                    attempts=attempt,
+                    timeout_seconds=timeout,
+                    elapsed_seconds=now - start_time,
+                )
+                raise
+
+            storage_logger.opt(exception=exc).warning(
+                "Database connection attempt failed",
+                attempt=attempt,
+                retry_interval_seconds=retry_interval,
+                seconds_until_timeout=max(0.0, deadline - now),
+            )
+            attempt += 1
+            time.sleep(retry_interval)
+        else:
+            storage_logger.info(
+                "Connected to the database",
+                attempts=attempt,
+                elapsed_seconds=time.monotonic() - start_time,
+            )
+            return storage
+
+
+__all__ = ["create_app"]

--- a/app/flashoffer/campaign-backend/campaign_backend/db.py
+++ b/app/flashoffer/campaign-backend/campaign_backend/db.py
@@ -1,0 +1,113 @@
+"""Database utilities for campaign countdown metadata."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from backend_common import DatabaseConfig, PostgresPool
+
+
+class CampaignStore(PostgresPool):
+    """Store providing access to campaign countdown information."""
+
+    def initialize(self) -> None:
+        """Create the campaign table if it is missing."""
+
+        with self.connection() as conn:  # type: ignore[assignment]
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS campaign (
+                        id TEXT PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        ends_at TIMESTAMPTZ NOT NULL,
+                        quantity_remaining INTEGER,
+                        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                    )
+                    """
+                )
+            conn.commit()
+
+    def fetch_time_remaining(self, campaign_id: str) -> Optional[Dict[str, Any]]:
+        """Return the remaining time details for a campaign."""
+
+        with self.connection() as conn:  # type: ignore[assignment]
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT ends_at, quantity_remaining
+                    FROM campaign
+                    WHERE id = %s
+                    """,
+                    (campaign_id,),
+                )
+                row = cur.fetchone()
+
+        if row is None:
+            return None
+
+        ends_at = _normalise_timestamp(row[0])
+        remaining = max(
+            int((ends_at - datetime.now(tz=timezone.utc)).total_seconds() * 1000),
+            0,
+        )
+        quantity = row[1] if row[1] is not None else None
+
+        return {
+            "campaign_id": campaign_id,
+            "time_remaining_ms": remaining,
+            "quantity_remaining": quantity,
+            "ends_at": ends_at,
+        }
+
+    def ensure_demo_campaign(self) -> None:
+        """Seed the demo campaign when no record exists."""
+
+        with self.connection() as conn:  # type: ignore[assignment]
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM campaign WHERE id = %s",
+                    ("flashoffer-demo",),
+                )
+                exists = cur.fetchone() is not None
+                if not exists:
+                    cur.execute(
+                        """
+                        INSERT INTO campaign (id, name, ends_at, quantity_remaining)
+                        VALUES (%s, %s, %s, %s)
+                        ON CONFLICT (id) DO NOTHING
+                        """,
+                        (
+                            "flashoffer-demo",
+                            "Flashoffer Demo",
+                            datetime.now(tz=timezone.utc) + timedelta(hours=46),
+                            128,
+                        ),
+                    )
+            conn.commit()
+
+    def truncate(self) -> None:
+        """Remove campaign records, useful for tests."""
+
+        with self.connection() as conn:  # type: ignore[assignment]
+            with conn.cursor() as cur:
+                cur.execute("TRUNCATE campaign")
+            conn.commit()
+
+
+def _normalise_timestamp(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if isinstance(value, str):
+        cleaned = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(cleaned)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    return datetime.now(tz=timezone.utc)
+
+
+__all__ = ["CampaignStore", "DatabaseConfig"]

--- a/app/flashoffer/campaign-backend/entrypoint.sh
+++ b/app/flashoffer/campaign-backend/entrypoint.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+GUNICORN_BIND="${GUNICORN_BIND:-unix:/tmp/gunicorn.sock}"
+GUNICORN_WORKERS="${GUNICORN_WORKERS:-4}"
+SOCKET_PATH="$GUNICORN_BIND"
+case "$GUNICORN_BIND" in
+  unix:*)
+    SOCKET_PATH="${GUNICORN_BIND#unix:}"
+    ;;
+  *)
+    SOCKET_PATH=""
+    ;;
+ esac
+
+cleanup() {
+  if [ -n "${GUNICORN_PID:-}" ] && kill -0 "$GUNICORN_PID" 2>/dev/null; then
+    kill "$GUNICORN_PID" 2>/dev/null || true
+    wait "$GUNICORN_PID" 2>/dev/null || true
+  fi
+  if [ -n "${NGINX_PID:-}" ] && kill -0 "$NGINX_PID" 2>/dev/null; then
+    kill "$NGINX_PID" 2>/dev/null || true
+    wait "$NGINX_PID" 2>/dev/null || true
+  fi
+  if [ -n "$SOCKET_PATH" ] && [ -S "$SOCKET_PATH" ]; then
+    rm -f "$SOCKET_PATH"
+  fi
+}
+
+trap cleanup INT TERM EXIT
+
+if [ -n "$SOCKET_PATH" ]; then
+  SOCKET_DIR=$(dirname "$SOCKET_PATH")
+  mkdir -p "$SOCKET_DIR"
+  rm -f "$SOCKET_PATH"
+fi
+
+gunicorn \
+  --bind "$GUNICORN_BIND" \
+  --workers "$GUNICORN_WORKERS" \
+  --access-logfile - \
+  --error-logfile - \
+  "campaign_backend.app:create_app()" &
+GUNICORN_PID=$!
+
+nginx -g 'daemon off;' &
+NGINX_PID=$!
+
+while :; do
+  if ! kill -0 "$GUNICORN_PID" 2>/dev/null; then
+    wait "$GUNICORN_PID"
+    STATUS=$?
+    kill "$NGINX_PID" 2>/dev/null || true
+    wait "$NGINX_PID" 2>/dev/null || true
+    exit $STATUS
+  fi
+
+  if ! kill -0 "$NGINX_PID" 2>/dev/null; then
+    wait "$NGINX_PID"
+    STATUS=$?
+    kill "$GUNICORN_PID" 2>/dev/null || true
+    wait "$GUNICORN_PID" 2>/dev/null || true
+    exit $STATUS
+  fi
+
+  sleep 1
+ done

--- a/app/flashoffer/campaign-backend/nginx.conf
+++ b/app/flashoffer/campaign-backend/nginx.conf
@@ -1,0 +1,17 @@
+upstream campaign_backend {
+    server unix:/tmp/gunicorn.sock;
+}
+
+server {
+    listen 8000;
+    listen [::]:8000;
+
+    location / {
+        proxy_pass http://campaign_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+}

--- a/app/flashoffer/campaign-backend/requirements.txt
+++ b/app/flashoffer/campaign-backend/requirements.txt
@@ -1,0 +1,5 @@
+Flask==2.3.3
+loguru==0.7.2
+psycopg2-binary==2.9.9
+pytest==7.4.4
+../backend-common

--- a/app/flashoffer/campaign-backend/tests/conftest.py
+++ b/app/flashoffer/campaign-backend/tests/conftest.py
@@ -1,0 +1,34 @@
+import os
+from typing import Iterator
+
+import pytest
+
+from campaign_backend.app import create_app
+from campaign_backend.db import CampaignStore
+
+
+@pytest.fixture(scope="session")
+def flask_app() -> Iterator:
+    required_vars = [
+        "DATABASE_HOST",
+        "DATABASE_USER",
+        "DATABASE_PASSWORD",
+        "DATABASE_NAME",
+    ]
+    missing = [var for var in required_vars if not os.getenv(var)]
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise RuntimeError(
+            "Tests require the database containers to be running. Missing "
+            f"variables: {missing_list}"
+        )
+
+    app = create_app()
+    yield app
+    pool: CampaignStore = app.config["DB_POOL"]
+    pool.truncate()
+
+
+@pytest.fixture()
+def client(flask_app):
+    return flask_app.test_client()

--- a/app/flashoffer/campaign-backend/tests/test_app.py
+++ b/app/flashoffer/campaign-backend/tests/test_app.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timedelta, timezone
+
+from campaign_backend.db import CampaignStore
+
+
+def test_healthcheck(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "ok"}
+
+
+def test_time_remaining_returns_payload(client, flask_app):
+    pool: CampaignStore = flask_app.config["DB_POOL"]
+    ends_at = datetime.now(tz=timezone.utc) + timedelta(minutes=90)
+
+    with pool.connection() as conn:  # type: ignore[assignment]
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO campaign (id, name, ends_at, quantity_remaining)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (id) DO UPDATE
+                SET ends_at = EXCLUDED.ends_at,
+                    quantity_remaining = EXCLUDED.quantity_remaining
+                """,
+                ("launch", "Launch Countdown", ends_at, 25),
+            )
+        conn.commit()
+
+    response = client.get(
+        "/api/campaign/launch/time_remaining?ct=countdown-timer&cid=launch"
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["campaign_id"] == "launch"
+    assert data["source"] == "countdown-timer"
+    assert data["quantity_remaining"] == 25
+    assert data["time_remaining_ms"] > 0
+
+
+def test_missing_campaign_returns_zero(client):
+    response = client.get("/api/campaign/unknown/time_remaining")
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data["campaign_id"] == "unknown"
+    assert data["time_remaining_ms"] == 0
+    assert data["quantity_remaining"] is None

--- a/app/flashoffer/flashoffer-demo/nginx.conf
+++ b/app/flashoffer/flashoffer-demo/nginx.conf
@@ -24,6 +24,15 @@ server {
         application/json
         image/svg+xml;
 
+    location /api/campaign/ {
+        proxy_pass http://campaign-backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/app/flashoffer/flashoffer-demo/src/sections/CountdownShowcaseSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/CountdownShowcaseSection.tsx
@@ -5,14 +5,7 @@ import { useMemo } from "react";
 import { CountdownTimer, Section } from "flashoffer-react";
 
 export function CountdownShowcaseSection() {
-  const earlyAccessEnd = useMemo(
-    () => new Date(Date.now() + 1000 * 60 * 60 * 45),
-    []
-  );
-  const restockEnd = useMemo(
-    () => new Date(Date.now() + 1000 * 60 * 90),
-    []
-  );
+  const restockDurationMs = useMemo(() => 1000 * 60 * 90, []);
   const trackMeta = JSON.stringify({ variants: 2 });
 
   return (
@@ -40,7 +33,7 @@ export function CountdownShowcaseSection() {
         >
           <Box sx={{ width: "100%", maxWidth: 420 }}>
             <CountdownTimer
-              endTime={earlyAccessEnd}
+              campaignId="flashoffer-demo"
               timerLabel="Early access ends in"
               headline="Creator passes are almost gone."
               quantityRemaining={42}
@@ -49,7 +42,7 @@ export function CountdownShowcaseSection() {
           </Box>
           <Box sx={{ width: "100%", maxWidth: 420 }}>
             <CountdownTimer
-              endTime={restockEnd}
+              timeRemainingMs={restockDurationMs}
               timerLabel="Restock drops in"
               headline="Set an alert for the next batch."
             />

--- a/app/flashoffer/flashoffer-demo/vite.config.ts
+++ b/app/flashoffer/flashoffer-demo/vite.config.ts
@@ -15,6 +15,18 @@ const materialBase = toPosixPath(
 );
 const muiUtilsBase = toPosixPath(resolvePath(nodeModulesDir, "@mui/utils"));
 
+const campaignProxyTarget =
+  process.env.FLASHOFFER_CAMPAIGN_API?.trim() || "http://localhost:8003";
+const campaignProxy =
+  campaignProxyTarget !== ""
+    ? {
+        "/api/campaign": {
+          target: campaignProxyTarget,
+          changeOrigin: true
+        }
+      }
+    : undefined;
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -40,6 +52,12 @@ export default defineConfig({
         replacement: `${muiUtilsBase}/$1`
       }
     ]
+  },
+  server: {
+    proxy: campaignProxy
+  },
+  preview: {
+    proxy: campaignProxy
   },
   build: {
     outDir: "../build/static/js",

--- a/app/flashoffer/flashoffer-react/src/components/CountdownTimer.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/CountdownTimer.tsx
@@ -44,6 +44,16 @@ function normalizeEndTime(endTime: Date | string | number): number {
 }
 
 /**
+ * Converts a duration into an absolute countdown deadline.
+ *
+ * @param remainingMs - Milliseconds remaining for the countdown.
+ * @returns Unix timestamp representing when the countdown ends.
+ */
+function deriveTargetFromDuration(remainingMs: number): number {
+  return Date.now() + Math.max(0, remainingMs);
+}
+
+/**
  * Derives the remaining time segments from a millisecond timestamp.
  *
  * @param targetTimestamp - Future timestamp that represents when the offer
@@ -106,9 +116,81 @@ function formatSegmentValue(value: number): string {
   return value.toString().padStart(2, "0");
 }
 
+/**
+ * Requests the remaining time for a campaign from the backend API.
+ *
+ * @param campaign - Identifier of the campaign to query.
+ * @param signal - Optional abort controller signal.
+ * @returns Remaining milliseconds or {@code null} when unavailable.
+ */
+async function fetchCampaignTimeRemaining(
+  campaign: string,
+  signal?: AbortSignal | null
+): Promise<number | null> {
+  if (typeof fetch !== "function") {
+    return null;
+  }
+
+  const encodedId = encodeURIComponent(campaign);
+  const url = `/api/campaign/${encodedId}/time_remaining?ct=countdown-timer&cid=${encodedId}`;
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: signal ?? undefined
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = await response.json();
+    if (typeof payload !== "object" || payload === null) {
+      return null;
+    }
+
+    const candidate =
+      (payload as { time_remaining_ms?: unknown }).time_remaining_ms ??
+      (payload as { timeRemainingMs?: unknown }).timeRemainingMs ??
+      (payload as { time_remaining?: unknown }).time_remaining ??
+      (payload as { timeRemaining?: unknown }).timeRemaining;
+
+    if (typeof candidate === "number" && Number.isFinite(candidate)) {
+      return candidate;
+    }
+
+    if (typeof candidate === "string") {
+      const parsed = Number(candidate);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+
+    return null;
+  } catch (error) {
+    if (
+      (typeof DOMException !== "undefined" &&
+        error instanceof DOMException &&
+        error.name === "AbortError") ||
+      (typeof error === "object" &&
+        error !== null &&
+        (error as { name?: string }).name === "AbortError")
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
 export interface CountdownTimerProps {
+  /** Identifier for a campaign whose remaining time should be fetched. */
+  campaignId?: string;
   /** Target time indicating when the promotion ends. */
-  endTime: Date | string | number;
+  endTime?: Date | string | number;
+  /** Remaining time, in milliseconds, when no campaign is provided. */
+  timeRemainingMs?: number;
   /** Optional number of items remaining for the promotion. */
   quantityRemaining?: number;
   /** Headline emphasizing the urgency of the promotion. */
@@ -129,21 +211,120 @@ const DEFAULT_QUANTITY_LABEL = "units remaining";
  * High-contrast countdown module pairing urgency copy with remaining
  * quantity.
  *
+ * When provided a `campaignId`, the component retrieves countdown data from
+ * the campaign API. Without a campaign identifier the caller must supply
+ * either `timeRemainingMs` or `endTime` to determine the countdown target.
+ *
  * @param props - Component configuration describing end time and messaging.
  * @returns A visually urgent countdown surface.
  */
 export function CountdownTimer({
+  campaignId,
   endTime,
+  timeRemainingMs,
   quantityRemaining,
   headline = DEFAULT_HEADLINE,
   timerLabel = DEFAULT_TIMER_LABEL,
   quantityLabel = DEFAULT_QUANTITY_LABEL,
   intervalMs = 1000
 }: CountdownTimerProps) {
-  const targetTimestamp = useMemo(() => normalizeEndTime(endTime), [endTime]);
+  const normalizedCampaignId =
+    typeof campaignId === "string" ? campaignId.trim() : "";
+  const hasCampaign = normalizedCampaignId !== "";
+  const hasDurationInput = typeof timeRemainingMs === "number";
+  if (hasDurationInput && !Number.isFinite(timeRemainingMs)) {
+    throw new Error(
+      "CountdownTimer received an invalid timeRemainingMs value."
+    );
+  }
+
+  const hasExplicitDuration = hasDurationInput;
+  const hasEndTime = endTime !== undefined;
+
+  if (!hasCampaign && !hasExplicitDuration && !hasEndTime) {
+    throw new Error(
+      "CountdownTimer requires either a campaignId, timeRemainingMs, or endTime."
+    );
+  }
+
+  const [targetTimestamp, setTargetTimestamp] = useState<number>(() => {
+    if (hasExplicitDuration && typeof timeRemainingMs === "number") {
+      return deriveTargetFromDuration(timeRemainingMs);
+    }
+
+    if (hasEndTime && endTime !== undefined) {
+      return normalizeEndTime(endTime);
+    }
+
+    return Date.now();
+  });
   const [segments, setSegments] = useState<CountdownSegments>(() =>
     deriveSegments(targetTimestamp)
   );
+
+  useEffect(() => {
+    if (hasCampaign) {
+      let cancelled = false;
+      const controller =
+        typeof AbortController !== "undefined" ? new AbortController() : null;
+
+      async function loadCampaignRemaining() {
+        try {
+          const remainingMs = await fetchCampaignTimeRemaining(
+            normalizedCampaignId,
+            controller?.signal
+          );
+
+          if (cancelled) {
+            return;
+          }
+
+          const safeRemaining = Math.max(0, remainingMs ?? 0);
+          setTargetTimestamp(deriveTargetFromDuration(safeRemaining));
+        } catch (error) {
+          if (cancelled) {
+            return;
+          }
+
+          if (
+            (typeof DOMException !== "undefined" &&
+              error instanceof DOMException &&
+              error.name === "AbortError") ||
+            (typeof error === "object" &&
+              error !== null &&
+              (error as { name?: string }).name === "AbortError")
+          ) {
+            return;
+          }
+
+          setTargetTimestamp(Date.now());
+        }
+      }
+
+      void loadCampaignRemaining();
+
+      return () => {
+        cancelled = true;
+        controller?.abort();
+      };
+    }
+
+    if (hasExplicitDuration && typeof timeRemainingMs === "number") {
+      setTargetTimestamp(deriveTargetFromDuration(timeRemainingMs));
+      return;
+    }
+
+    if (hasEndTime && endTime !== undefined) {
+      setTargetTimestamp(normalizeEndTime(endTime));
+    }
+  }, [
+    hasCampaign,
+    normalizedCampaignId,
+    hasExplicitDuration,
+    timeRemainingMs,
+    hasEndTime,
+    endTime
+  ]);
 
   useEffect(() => {
     setSegments(deriveSegments(targetTimestamp));

--- a/app/flashoffer/flashoffer-react/src/components/__tests__/CountdownTimer.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/__tests__/CountdownTimer.test.tsx
@@ -11,6 +11,10 @@ import { CountdownTimer } from "../CountdownTimer";
 import type { CountdownTimerProps } from "../CountdownTimer";
 
 const NOW = new Date("2024-01-01T00:00:00Z");
+const REMAINING_MS =
+  ((2 * 24 + 5) * 60 * 60 + 6 * 60 + 7) * 1000; // 2d 5h 6m 7s
+
+const ORIGINAL_FETCH = global.fetch;
 
 describe("CountdownTimer", () => {
   beforeEach(() => {
@@ -20,6 +24,13 @@ describe("CountdownTimer", () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    if (ORIGINAL_FETCH) {
+      global.fetch = ORIGINAL_FETCH;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- test cleanup
+      delete (global as { fetch?: typeof fetch }).fetch;
+    }
+    jest.resetAllMocks();
   });
 
   /**
@@ -32,19 +43,23 @@ describe("CountdownTimer", () => {
     props: Partial<CountdownTimerProps> = {},
     providerProps: Partial<FlashofferThemeProviderProps> = {}
   ) {
+    const baseProps: CountdownTimerProps = {
+      timeRemainingMs: REMAINING_MS,
+      ...props
+    };
+
     return render(
       <FlashofferThemeProvider
         applyCssBaseline={false}
         {...providerProps}
       >
-        <CountdownTimer endTime={NOW} {...props} />
+        <CountdownTimer {...baseProps} />
       </FlashofferThemeProvider>
     );
   }
 
   it("renders the remaining time segments", () => {
-    const endTime = new Date("2024-01-03T05:06:07Z");
-    renderTimer({ endTime });
+    renderTimer({ timeRemainingMs: REMAINING_MS });
 
     expect(
       screen.getByLabelText(/\d+ days remaining/i)
@@ -61,7 +76,7 @@ describe("CountdownTimer", () => {
   });
 
   it("stops at zero once the deadline passes", () => {
-    renderTimer({ endTime: new Date("2023-12-31T23:59:58Z") });
+    renderTimer({ timeRemainingMs: 2_000 });
     act(() => {
       jest.advanceTimersByTime(2_000);
     });
@@ -96,6 +111,53 @@ describe("CountdownTimer", () => {
 
     expect(screen.getByRole("timer")).toHaveStyle(
       "border-color: rgba(34, 197, 94, 0.4)"
+    );
+  });
+
+  it("fetches campaign time when a campaign identifier is provided", async () => {
+    const responsePayload = { time_remaining_ms: 65_000 };
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => responsePayload
+      } as unknown as Response) as unknown as typeof fetch;
+
+    renderTimer({ campaignId: "flashoffer-demo", timeRemainingMs: undefined });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/campaign/flashoffer-demo/time_remaining?ct=countdown-timer&cid=flashoffer-demo",
+      expect.objectContaining({ method: "GET" })
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByLabelText(/minutes remaining/i)).toHaveTextContent("01");
+    expect(screen.getByLabelText(/seconds remaining/i)).toHaveTextContent("05");
+  });
+
+  it("renders zero when campaign time retrieval fails", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({
+        ok: false,
+        json: async () => ({})
+      } as unknown as Response) as unknown as typeof fetch;
+
+    renderTimer({ campaignId: "unknown", timeRemainingMs: undefined });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByLabelText(/seconds remaining/i)).toHaveTextContent("00");
+  });
+
+  it("throws when neither campaign nor duration inputs are supplied", () => {
+    expect(() => renderTimer({ timeRemainingMs: undefined })).toThrow(
+      /requires either a campaignId, timeRemainingMs, or endTime/i
     );
   });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,24 @@ services:
     volumes:
       - ./app/flashoffer/analytics-backend:/app
 
+  campaign-backend:
+    build:
+      context: .
+      dockerfile: ./app/flashoffer/campaign-backend/Dockerfile
+    environment:
+      DATABASE_HOST: analytics-db
+      DATABASE_PORT: 5432
+      DATABASE_USER: analytics
+      DATABASE_PASSWORD: analytics
+      DATABASE_NAME: analytics
+      CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS:-http://localhost:5173,http://localhost:4173}
+    depends_on:
+      - analytics-db
+    ports:
+      - "8003:8000"
+    volumes:
+      - ./app/flashoffer/campaign-backend:/app
+
   quiz-backend:
     build:
       context: .
@@ -165,6 +183,7 @@ services:
       VITE_FLASHOFFER_ANALYTICS_ENDPOINT: ${FLASHOFFER_ANALYTICS_ENDPOINT:-http://localhost:8001/events}
       VITE_FLASHOFFER_ANALYTICS_RECENT_URL: ${FLASHOFFER_ANALYTICS_RECENT_URL:-http://localhost:8001/events/recent}
       VITE_FLASHOFFER_QUIZ_EVENTS_ENDPOINT: ${FLASHOFFER_QUIZ_EVENTS_ENDPOINT:-http://localhost:8002/api/events/quiz}
+      FLASHOFFER_CAMPAIGN_API: http://campaign-backend:8000
     ports:
       - "${FLASHOFFER_PORT:-4173}:4173"
       - "80:80"
@@ -172,6 +191,7 @@ services:
       - ./:/workspace
     depends_on:
       - analytics-backend
+      - campaign-backend
       - quiz-backend
 
   flashoffer-dev:
@@ -185,12 +205,14 @@ services:
       VITE_FLASHOFFER_ANALYTICS_ENDPOINT: ${FLASHOFFER_ANALYTICS_ENDPOINT:-http://localhost:8001/events}
       VITE_FLASHOFFER_ANALYTICS_RECENT_URL: ${FLASHOFFER_ANALYTICS_RECENT_URL:-http://localhost:8001/events/recent}
       VITE_FLASHOFFER_QUIZ_EVENTS_ENDPOINT: ${FLASHOFFER_QUIZ_EVENTS_ENDPOINT:-http://localhost:8002/api/events/quiz}
+      FLASHOFFER_CAMPAIGN_API: http://campaign-backend:8000
     ports:
       - "${FLASHOFFER_DEV_PORT:-5173}:5173"
     volumes:
       - ./:/workspace
     depends_on:
       - analytics-backend
+      - campaign-backend
       - quiz-backend
 
 volumes:


### PR DESCRIPTION
## Summary
- extend the CountdownTimer component to load campaign time remaining or accept static durations and add coverage for the new paths
- add a dedicated campaign-backend Flask service with database access, container build assets, and pytest coverage
- wire the flashoffer demo to use the flashoffer-demo campaign ID and proxy requests through Vite, nginx, and docker-compose
- ignore workspace node_modules in git

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e75364381c8321b280bc3ddd8a8d28