### PR TITLE
Add campaign backend and update countdown timer integration

### DIFF
--- a/app/flashoffer/campaign-backend/Dockerfile
+++ b/app/flashoffer/campaign-backend/Dockerfile
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1.6
+######################################################################
+# Campaign API image
+#
+# The campaign backend serves countdown metadata for Flashoffer demos.
+# This build mirrors other Flashoffer services so operations teams can
+# reuse deployment runbooks across analytics, quiz, and campaign APIs.
+######################################################################
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    FLASK_APP=campaign_backend.app:create_app \
+    CORS_ALLOW_ORIGINS=
+
+WORKDIR /app
+
+COPY app/flashoffer/campaign-backend/requirements.txt ./requirements.txt
+COPY app/flashoffer/backend-common /backend-common
+COPY app/shell/py/pie /tmp/pie
+
+RUN --mount=type=cache,target=/root/.cache/pip,id=campaign-backend-pip \
+    pip install -r requirements.txt \
+    && pip install /tmp/pie dominate \
+    && rm -rf /tmp/pie /backend-common
+
+COPY app/flashoffer/campaign-backend/campaign_backend ./campaign_backend
+COPY app/flashoffer/campaign-backend/tests ./tests
+
+FROM base AS dev
+
+EXPOSE 8000
+
+CMD ["flask", "--app", "campaign_backend.app:create_app", "run", "--host=0.0.0.0", "--port=8000"]
+
+FROM base AS prod
+
+ENV GUNICORN_WORKERS=4 \
+    GUNICORN_BIND=unix:/tmp/gunicorn.sock
+
+RUN --mount=type=cache,target=/var/cache/apt,id=campaign-backend \
+    --mount=type=cache,target=/var/lib/apt/lists,id=campaign-backend \
+    apt-get update \
+    && apt-get install --no-install-recommends -y nginx \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/root/.cache/pip,id=campaign-backend-pip \
+    pip install gunicorn
+
+COPY app/flashoffer/campaign-backend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY app/flashoffer/campaign-backend/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8000
+
+CMD ["/entrypoint.sh"]

--- a/app/flashoffer/campaign-backend/campaign_backend/__init__.py
+++ b/app/flashoffer/campaign-backend/campaign_backend/__init__.py
@@ -1,0 +1,5 @@
+"""Campaign backend package exposing the Flask application factory."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/app/flashoffer/campaign-backend/campaign_backend/app.py
+++ b/app/flashoffer/campaign-backend/campaign_backend/app.py
@@ -1,0 +1,136 @@
+"""Flask application that exposes campaign deadline metadata."""
+
+from __future__ import annotations
+
+import atexit
+import json
+import time
+from datetime import datetime, timezone
+
+from flask import Flask, Response, jsonify
+
+from pie.logging import logger
+
+from backend_common import DatabaseConfig, configure_cors
+
+from .db import CampaignStore
+
+
+def _compute_remaining_ms(end_time: datetime) -> int:
+    now = datetime.now(tz=timezone.utc)
+    delta = end_time.astimezone(timezone.utc) - now
+    return max(0, int(delta.total_seconds() * 1000))
+
+
+def create_app() -> Flask:
+    """Create and configure the campaign backend application."""
+
+    app = Flask(__name__)
+
+    config = DatabaseConfig.from_env()
+    storage = _initialise_storage(app, config)
+    atexit.register(storage.close)
+    app.config["DB_POOL"] = storage
+
+    apply_cors = configure_cors(app, component="campaign-backend")
+
+    @app.route("/health", methods=["GET"])
+    def healthcheck() -> Response:
+        with storage.connection() as conn:  # type: ignore[assignment]
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+                cur.fetchone()
+        return jsonify({"status": "ok"})
+
+    @app.route("/config", methods=["GET"])
+    def config_dump() -> Response:
+        details = {
+            "database": {
+                "host": config.host,
+                "port": config.port,
+                "name": config.database,
+            }
+        }
+        return Response(json.dumps(details), mimetype="application/json")
+
+    @app.route("/api/campaign/<campaign_id>/end_time", methods=["OPTIONS"])
+    def campaign_options(campaign_id: str) -> Response:  # noqa: D401 - CORS preflight
+        return apply_cors(Response(status=204))
+
+    @app.route("/api/campaign/<campaign_id>/end_time", methods=["GET"])
+    def campaign_end_time(campaign_id: str) -> Response:
+        campaign_id = campaign_id.strip()
+        if not campaign_id:
+            return apply_cors(
+                jsonify({"error": "campaign id must be provided"}),
+            ), 400
+
+        record = storage.fetch_end_time(campaign_id)
+        if record is None:
+            return apply_cors(jsonify({"error": "campaign not found"})), 404
+
+        payload = {
+            "campaign_id": campaign_id,
+            "end_time": record.astimezone(timezone.utc).isoformat(),
+            "remaining_ms": _compute_remaining_ms(record),
+        }
+        return apply_cors(jsonify(payload))
+
+    return app
+
+
+def _initialise_storage(app: Flask, config: DatabaseConfig) -> CampaignStore:
+    """Initialise the database connection with retry semantics."""
+
+    retry_interval = 5.0
+    timeout = 300.0
+    start = time.monotonic()
+    deadline = start + timeout
+    attempt = 1
+
+    storage_logger = logger.bind(
+        component="campaign-backend",
+        operation="database-initialisation",
+        flask_app=app.name,
+    )
+
+    while True:
+        store: CampaignStore | None = None
+        try:
+            store = CampaignStore(config)
+            store.initialize()
+        except Exception as exc:  # noqa: BLE001 - propagate context
+            if store is not None:
+                try:
+                    store.close()
+                except Exception:  # noqa: BLE001 - suppress cleanup errors
+                    pass
+
+            now = time.monotonic()
+            if now >= deadline:
+                storage_logger.opt(exception=exc).error(
+                    "Failed to connect to the database",
+                    attempts=attempt,
+                    timeout_seconds=timeout,
+                    elapsed_seconds=now - start,
+                )
+                raise
+
+            storage_logger.opt(exception=exc).warning(
+                "Database connection attempt failed",
+                attempt=attempt,
+                retry_interval_seconds=retry_interval,
+                seconds_until_timeout=max(0.0, deadline - now),
+            )
+            attempt += 1
+            time.sleep(retry_interval)
+        else:
+            storage_logger.info(
+                "Connected to the database",
+                attempts=attempt,
+                elapsed_seconds=time.monotonic() - start,
+            )
+            return store
+
+
+__all__ = ["create_app"]

--- a/app/flashoffer/campaign-backend/campaign_backend/db.py
+++ b/app/flashoffer/campaign-backend/campaign_backend/db.py
@@ -1,0 +1,82 @@
+"""Database helpers that power the campaign deadline API."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from backend_common import DatabaseConfig, PostgresPool
+
+
+class CampaignStore(PostgresPool):
+    """Store that exposes campaign metadata lookups."""
+
+    def initialize(self) -> None:
+        """Ensure the campaign table exists."""
+
+        with self.connection() as conn:  # type: ignore[assignment]
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS campaign (
+                        id TEXT PRIMARY KEY,
+                        name TEXT,
+                        end_time TIMESTAMPTZ NOT NULL,
+                        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                    )
+                    """
+                )
+            conn.commit()
+
+    def upsert_campaign(self, campaign_id: str, *, end_time: datetime) -> None:
+        """Create or update a campaign record."""
+
+        normalized = _ensure_utc(end_time)
+        with self.connection() as conn:  # type: ignore[assignment]
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO campaign (id, end_time)
+                    VALUES (%s, %s)
+                    ON CONFLICT (id)
+                    DO UPDATE SET end_time = EXCLUDED.end_time,
+                        updated_at = NOW()
+                    """,
+                    (campaign_id, normalized),
+                )
+            conn.commit()
+
+    def fetch_end_time(self, campaign_id: str) -> datetime | None:
+        """Return the campaign end time or ``None`` when missing."""
+
+        with self.connection() as conn:  # type: ignore[assignment]
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT end_time FROM campaign WHERE id = %s",
+                    (campaign_id,),
+                )
+                row = cur.fetchone()
+
+        if not row:
+            return None
+
+        return _ensure_utc(row[0])
+
+
+def _ensure_utc(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    if isinstance(value, str):
+        cleaned = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(cleaned)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    raise TypeError("Campaign timestamps must be datetime or ISO-8601 strings")
+
+
+__all__ = ["CampaignStore", "DatabaseConfig"]

--- a/app/flashoffer/campaign-backend/entrypoint.sh
+++ b/app/flashoffer/campaign-backend/entrypoint.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -eu
+
+GUNICORN_BIND="${GUNICORN_BIND:-unix:/tmp/gunicorn.sock}"
+GUNICORN_WORKERS="${GUNICORN_WORKERS:-4}"
+SOCKET_PATH="$GUNICORN_BIND"
+case "$GUNICORN_BIND" in
+  unix:*)
+    SOCKET_PATH="${GUNICORN_BIND#unix:}"
+    ;;
+  *)
+    SOCKET_PATH=""
+    ;;
+
+esac
+
+cleanup() {
+  if [ -n "${GUNICORN_PID:-}" ] && kill -0 "$GUNICORN_PID" 2>/dev/null; then
+    kill "$GUNICORN_PID" 2>/dev/null || true
+    wait "$GUNICORN_PID" 2>/dev/null || true
+  fi
+  if [ -n "${NGINX_PID:-}" ] && kill -0 "$NGINX_PID" 2>/dev/null; then
+    kill "$NGINX_PID" 2>/dev/null || true
+    wait "$NGINX_PID" 2>/dev/null || true
+  fi
+  if [ -n "$SOCKET_PATH" ] && [ -S "$SOCKET_PATH" ]; then
+    rm -f "$SOCKET_PATH"
+  fi
+}
+
+trap cleanup INT TERM EXIT
+
+if [ -n "$SOCKET_PATH" ]; then
+  SOCKET_DIR=$(dirname "$SOCKET_PATH")
+  mkdir -p "$SOCKET_DIR"
+  rm -f "$SOCKET_PATH"
+fi
+
+gunicorn \
+  --bind "$GUNICORN_BIND" \
+  --workers "$GUNICORN_WORKERS" \
+  --access-logfile - \
+  --error-logfile - \
+  "campaign_backend.app:create_app()" &
+GUNICORN_PID=$!
+
+nginx -g 'daemon off;' &
+NGINX_PID=$!
+
+while :; do
+  if ! kill -0 "$GUNICORN_PID" 2>/dev/null; then
+    wait "$GUNICORN_PID"
+    STATUS=$?
+    kill "$NGINX_PID" 2>/dev/null || true
+    wait "$NGINX_PID" 2>/dev/null || true
+    exit $STATUS
+  fi
+
+  if ! kill -0 "$NGINX_PID" 2>/dev/null; then
+    wait "$NGINX_PID"
+    STATUS=$?
+    kill "$GUNICORN_PID" 2>/dev/null || true
+    wait "$GUNICORN_PID" 2>/dev/null || true
+    exit $STATUS
+  fi
+
+  sleep 1
+done

--- a/app/flashoffer/campaign-backend/nginx.conf
+++ b/app/flashoffer/campaign-backend/nginx.conf
@@ -1,0 +1,13 @@
+server {
+    listen 8000;
+    server_name _;
+
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://unix:/tmp/gunicorn.sock;
+        proxy_redirect off;
+    }
+}

--- a/app/flashoffer/campaign-backend/requirements.txt
+++ b/app/flashoffer/campaign-backend/requirements.txt
@@ -1,0 +1,5 @@
+Flask==2.3.3
+loguru==0.7.2
+psycopg2-binary==2.9.9
+pytest==7.4.4
+../backend-common

--- a/app/flashoffer/campaign-backend/tests/conftest.py
+++ b/app/flashoffer/campaign-backend/tests/conftest.py
@@ -1,0 +1,37 @@
+import os
+from typing import Iterator
+
+import pytest
+
+from campaign_backend.app import create_app
+from campaign_backend.db import CampaignStore
+
+
+@pytest.fixture(scope="session")
+def flask_app() -> Iterator:
+    required_vars = [
+        "DATABASE_HOST",
+        "DATABASE_USER",
+        "DATABASE_PASSWORD",
+        "DATABASE_NAME",
+    ]
+    missing = [var for var in required_vars if not os.getenv(var)]
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise RuntimeError(
+            "Tests require the database containers to be running. Missing "
+            f"variables: {missing_list}"
+        )
+
+    app = create_app()
+    yield app
+    store: CampaignStore = app.config["DB_POOL"]
+    with store.connection() as conn:  # type: ignore[assignment]
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE campaign")
+        conn.commit()
+
+
+@pytest.fixture()
+def client(flask_app):
+    return flask_app.test_client()

--- a/app/flashoffer/campaign-backend/tests/test_app.py
+++ b/app/flashoffer/campaign-backend/tests/test_app.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timedelta, timezone
+
+from campaign_backend.db import CampaignStore
+
+
+def test_healthcheck(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "ok"}
+
+
+def test_campaign_end_time_returns_remaining_ms(client, flask_app):
+    store: CampaignStore = flask_app.config["DB_POOL"]
+    deadline = datetime.now(tz=timezone.utc) + timedelta(hours=1, minutes=30)
+    store.upsert_campaign("flashoffer-demo", end_time=deadline)
+
+    response = client.get("/api/campaign/flashoffer-demo/end_time")
+    assert response.status_code == 200
+
+    payload = response.get_json()
+    assert payload["campaign_id"] == "flashoffer-demo"
+
+    returned_deadline = datetime.fromisoformat(
+        payload["end_time"].replace("Z", "+00:00")
+    )
+    assert abs((returned_deadline - deadline).total_seconds()) < 1
+    assert 0 <= payload["remaining_ms"] <= 90 * 60 * 1000
+
+
+def test_missing_campaign_returns_not_found(client):
+    response = client.get("/api/campaign/unknown/end_time")
+    assert response.status_code == 404
+    body = response.get_json()
+    assert body["error"] == "campaign not found"
+
+
+def test_rejects_blank_campaign_identifier(client):
+    response = client.get("/api/campaign/%20/end_time")
+    assert response.status_code == 400
+    assert "campaign id must be provided" in response.get_json()["error"]

--- a/app/flashoffer/flashoffer-demo/src/sections/CountdownShowcaseSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/CountdownShowcaseSection.tsx
@@ -1,19 +1,11 @@
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import { useMemo } from "react";
 import { CountdownTimer, Section } from "flashoffer-react";
 
 export function CountdownShowcaseSection() {
-  const earlyAccessEnd = useMemo(
-    () => new Date(Date.now() + 1000 * 60 * 60 * 45),
-    []
-  );
-  const restockEnd = useMemo(
-    () => new Date(Date.now() + 1000 * 60 * 90),
-    []
-  );
-  const trackMeta = JSON.stringify({ variants: 2 });
+  const restockWindowMs = 1000 * 60 * 90;
+  const trackMeta = JSON.stringify({ variants: 2, campaignId: "flashoffer-demo" });
 
   return (
     <Box
@@ -40,7 +32,7 @@ export function CountdownShowcaseSection() {
         >
           <Box sx={{ width: "100%", maxWidth: 420 }}>
             <CountdownTimer
-              endTime={earlyAccessEnd}
+              campaignId="flashoffer-demo"
               timerLabel="Early access ends in"
               headline="Creator passes are almost gone."
               quantityRemaining={42}
@@ -49,7 +41,7 @@ export function CountdownShowcaseSection() {
           </Box>
           <Box sx={{ width: "100%", maxWidth: 420 }}>
             <CountdownTimer
-              endTime={restockEnd}
+              timeRemainingMs={restockWindowMs}
               timerLabel="Restock drops in"
               headline="Set an alert for the next batch."
             />

--- a/app/flashoffer/flashoffer-demo/src/vite-env.d.ts
+++ b/app/flashoffer/flashoffer-demo/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_FLASHOFFER_ANALYTICS_ENDPOINT?: string;
   readonly VITE_FLASHOFFER_ANALYTICS_RECENT_URL?: string;
+  readonly VITE_FLASHOFFER_CAMPAIGN_API_BASE?: string;
 }
 
 interface ImportMeta {

--- a/app/flashoffer/flashoffer-demo/vite.config.ts
+++ b/app/flashoffer/flashoffer-demo/vite.config.ts
@@ -15,6 +15,17 @@ const materialBase = toPosixPath(
 );
 const muiUtilsBase = toPosixPath(resolvePath(nodeModulesDir, "@mui/utils"));
 
+const campaignProxyTarget = process.env.VITE_FLASHOFFER_CAMPAIGN_API_BASE?.trim();
+const proxyTarget = campaignProxyTarget ? campaignProxyTarget.replace(/\/$/, "") : undefined;
+const proxyConfig = proxyTarget
+  ? {
+      "/api/campaign": {
+        target: proxyTarget,
+        changeOrigin: true
+      }
+    }
+  : undefined;
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -40,6 +51,12 @@ export default defineConfig({
         replacement: `${muiUtilsBase}/$1`
       }
     ]
+  },
+  server: {
+    proxy: proxyConfig
+  },
+  preview: {
+    proxy: proxyConfig
   },
   build: {
     outDir: "../build/static/js",

--- a/app/flashoffer/flashoffer-react/src/components/CountdownTimer.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/CountdownTimer.tsx
@@ -26,6 +26,11 @@ interface CountdownSegments {
   totalMs: number;
 }
 
+type CountdownDataMode =
+  | { kind: "campaign"; campaignId: string }
+  | { kind: "time-remaining"; remainingMs: number }
+  | { kind: "end-time"; targetTimestamp: number };
+
 /**
  * Normalizes end time inputs into a Unix timestamp in milliseconds.
  *
@@ -107,8 +112,18 @@ function formatSegmentValue(value: number): string {
 }
 
 export interface CountdownTimerProps {
-  /** Target time indicating when the promotion ends. */
-  endTime: Date | string | number;
+  /** Campaign identifier whose end time is loaded from the backend. */
+  campaignId?: string;
+  /**
+   * Target time indicating when the promotion ends. Supply this when the
+   * backend is unavailable and the deadline is known upfront.
+   */
+  endTime?: Date | string | number;
+  /**
+   * Direct countdown duration in milliseconds when an end time is unavailable.
+   * Cannot be combined with `campaignId`.
+   */
+  timeRemainingMs?: number;
   /** Optional number of items remaining for the promotion. */
   quantityRemaining?: number;
   /** Headline emphasizing the urgency of the promotion. */
@@ -129,21 +144,167 @@ const DEFAULT_QUANTITY_LABEL = "units remaining";
  * High-contrast countdown module pairing urgency copy with remaining
  * quantity.
  *
- * @param props - Component configuration describing end time and messaging.
+ * Provide `campaignId` to source the deadline from the Flashoffer campaign
+ * backend. When no campaign identifier is supplied, specify either
+ * `endTime` or `timeRemainingMs` to render a static countdown.
+ *
+ * @param props - Component configuration describing end time sourcing and
+ *   messaging.
  * @returns A visually urgent countdown surface.
  */
 export function CountdownTimer({
+  campaignId,
   endTime,
+  timeRemainingMs,
   quantityRemaining,
   headline = DEFAULT_HEADLINE,
   timerLabel = DEFAULT_TIMER_LABEL,
   quantityLabel = DEFAULT_QUANTITY_LABEL,
   intervalMs = 1000
 }: CountdownTimerProps) {
-  const targetTimestamp = useMemo(() => normalizeEndTime(endTime), [endTime]);
+  const countdownMode = useMemo<CountdownDataMode>(() => {
+    const trimmedCampaignId = campaignId?.trim() ?? "";
+    const hasCampaign = trimmedCampaignId.length > 0;
+    const hasRemaining = typeof timeRemainingMs === "number";
+    const hasEndTime = typeof endTime !== "undefined";
+
+    if (hasCampaign) {
+      if (hasRemaining || hasEndTime) {
+        throw new Error(
+          "CountdownTimer cannot mix campaignId with explicit time values."
+        );
+      }
+
+      return { kind: "campaign", campaignId: trimmedCampaignId };
+    }
+
+    if (hasRemaining) {
+      const parsedRemaining = Number(timeRemainingMs);
+      if (!Number.isFinite(parsedRemaining)) {
+        throw new Error(
+          "CountdownTimer received an invalid timeRemainingMs value."
+        );
+      }
+
+      return {
+        kind: "time-remaining",
+        remainingMs: Math.max(0, parsedRemaining)
+      };
+    }
+
+    if (hasEndTime) {
+      return {
+        kind: "end-time",
+        targetTimestamp: normalizeEndTime(endTime as Date | string | number)
+      };
+    }
+
+    throw new Error(
+      "CountdownTimer requires either a campaignId or a timeRemainingMs/endTime value."
+    );
+  }, [campaignId, endTime, timeRemainingMs]);
+
+  const [targetTimestamp, setTargetTimestamp] = useState<number>(() => {
+    if (countdownMode.kind === "end-time") {
+      return countdownMode.targetTimestamp;
+    }
+
+    if (countdownMode.kind === "time-remaining") {
+      return Date.now() + countdownMode.remainingMs;
+    }
+
+    return Date.now();
+  });
+
   const [segments, setSegments] = useState<CountdownSegments>(() =>
     deriveSegments(targetTimestamp)
   );
+
+  useEffect(() => {
+    if (countdownMode.kind === "campaign") {
+      if (typeof globalThis.fetch !== "function") {
+        setTargetTimestamp(Date.now());
+        return;
+      }
+
+      let cancelled = false;
+      const AbortCtor = globalThis.AbortController;
+      const controller = typeof AbortCtor === "function" ? new AbortCtor() : null;
+
+      const resolveTarget = (data: Record<string, unknown>): number | null => {
+        const remainingCandidates = [
+          data["remainingMs"],
+          data["remaining_ms"],
+          data["remainingMilliseconds"]
+        ];
+
+        for (const candidate of remainingCandidates) {
+          if (typeof candidate === "number" && Number.isFinite(candidate)) {
+            return Date.now() + Math.max(0, candidate);
+          }
+        }
+
+        const endTimeCandidate =
+          data["endTime"] ?? data["end_time"] ?? data["deadline"];
+        if (typeof endTimeCandidate === "string" || endTimeCandidate instanceof Date) {
+          try {
+            return normalizeEndTime(endTimeCandidate);
+          } catch (error) {
+            console.warn("Failed to parse campaign end time", error);
+          }
+        } else if (typeof endTimeCandidate === "number") {
+          return normalizeEndTime(endTimeCandidate);
+        }
+
+        return null;
+      };
+
+      const fetchEndTime = async () => {
+        try {
+          const response = await globalThis.fetch(
+            `/api/campaign/${encodeURIComponent(countdownMode.campaignId)}/end_time`,
+            {
+              signal: controller?.signal,
+              headers: { Accept: "application/json" }
+            }
+          );
+
+          if (!response.ok) {
+            throw new Error(`Unexpected response: ${response.status}`);
+          }
+
+          const payload = (await response.json()) as Record<string, unknown>;
+          const nextTarget = resolveTarget(payload);
+
+          if (cancelled) {
+            return;
+          }
+
+          setTargetTimestamp(nextTarget ?? Date.now());
+        } catch (error) {
+          if (cancelled) {
+            return;
+          }
+          console.warn("Failed to load campaign end time", error);
+          setTargetTimestamp(Date.now());
+        }
+      };
+
+      void fetchEndTime();
+
+      return () => {
+        cancelled = true;
+        controller?.abort();
+      };
+    }
+
+    if (countdownMode.kind === "time-remaining") {
+      setTargetTimestamp(Date.now() + countdownMode.remainingMs);
+      return;
+    }
+
+    setTargetTimestamp(countdownMode.targetTimestamp);
+  }, [countdownMode]);
 
   useEffect(() => {
     setSegments(deriveSegments(targetTimestamp));

--- a/app/flashoffer/flashoffer-react/src/components/__tests__/CountdownTimer.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/__tests__/CountdownTimer.test.tsx
@@ -13,14 +13,33 @@ import type { CountdownTimerProps } from "../CountdownTimer";
 const NOW = new Date("2024-01-01T00:00:00Z");
 
 describe("CountdownTimer", () => {
+  const originalFetch = globalThis.fetch;
+
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(NOW);
+    jest.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    globalThis.fetch = originalFetch;
+    jest.restoreAllMocks();
   });
+
+  function buildProps(
+    overrides: Partial<CountdownTimerProps> = {}
+  ): CountdownTimerProps {
+    if (
+      overrides.campaignId === undefined &&
+      overrides.timeRemainingMs === undefined &&
+      overrides.endTime === undefined
+    ) {
+      return { ...overrides, endTime: NOW } as CountdownTimerProps;
+    }
+
+    return overrides as CountdownTimerProps;
+  }
 
   /**
    * Renders the countdown timer within the Flashoffer theme.
@@ -37,7 +56,7 @@ describe("CountdownTimer", () => {
         applyCssBaseline={false}
         {...providerProps}
       >
-        <CountdownTimer endTime={NOW} {...props} />
+        <CountdownTimer {...buildProps(props)} />
       </FlashofferThemeProvider>
     );
   }
@@ -96,6 +115,77 @@ describe("CountdownTimer", () => {
 
     expect(screen.getByRole("timer")).toHaveStyle(
       "border-color: rgba(34, 197, 94, 0.4)"
+    );
+  });
+
+  it("requests campaign deadlines when a campaign identifier is supplied", async () => {
+    const oneHourFromNow = new Date(NOW.getTime() + 3_600_000);
+    const mockResponse = {
+      ok: true,
+      json: async () => ({ end_time: oneHourFromNow.toISOString() })
+    } as unknown as Response;
+    const fetchSpy = jest.fn().mockResolvedValue(mockResponse);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    renderTimer({ campaignId: "flashoffer-demo" });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/campaign/flashoffer-demo/end_time",
+      expect.objectContaining({
+        headers: { Accept: "application/json" }
+      })
+    );
+    expect(screen.getByLabelText(/hours remaining/i)).toHaveTextContent("01");
+  });
+
+  it("falls back to zeroed segments when the campaign lookup fails", async () => {
+    const failingFetch = jest
+      .fn()
+      .mockRejectedValue(new Error("network unavailable"));
+    globalThis.fetch = failingFetch as unknown as typeof globalThis.fetch;
+
+    renderTimer({ campaignId: "flashoffer-demo" });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByLabelText(/seconds remaining/i)).toHaveTextContent("00");
+    expect(screen.getByLabelText(/minutes remaining/i)).toHaveTextContent("00");
+  });
+
+  it("throws when combining a campaign identifier with an explicit deadline", () => {
+    expect(() =>
+      render(
+        <FlashofferThemeProvider applyCssBaseline={false}>
+          {/*
+           * Casting keeps TypeScript satisfied while intentionally supplying
+           * an invalid prop combination.
+           */}
+          <CountdownTimer
+            {...({
+              campaignId: "flashoffer-demo",
+              endTime: NOW
+            } as CountdownTimerProps)}
+          />
+        </FlashofferThemeProvider>
+      )
+    ).toThrow(/cannot mix campaignid/i);
+  });
+
+  it("throws when no campaign or time source is provided", () => {
+    expect(() =>
+      render(
+        <FlashofferThemeProvider applyCssBaseline={false}>
+          <CountdownTimer {...({} as CountdownTimerProps)} />
+        </FlashofferThemeProvider>
+      )
+    ).toThrow(
+      /requires either a campaignid or a timeremainingms\/endtime value/i
     );
   });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,24 @@ services:
     volumes:
       - ./app/flashoffer/quiz-backend:/app
 
+  campaign-backend:
+    build:
+      context: .
+      dockerfile: ./app/flashoffer/campaign-backend/Dockerfile
+    environment:
+      DATABASE_HOST: analytics-db
+      DATABASE_PORT: 5432
+      DATABASE_USER: analytics
+      DATABASE_PASSWORD: analytics
+      DATABASE_NAME: analytics
+      CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS:-http://localhost:5173,http://localhost:4173}
+    depends_on:
+      - analytics-db
+    ports:
+      - "8003:8000"
+    volumes:
+      - ./app/flashoffer/campaign-backend:/app
+
   flashoffer:
     build:
       context: .
@@ -165,6 +183,7 @@ services:
       VITE_FLASHOFFER_ANALYTICS_ENDPOINT: ${FLASHOFFER_ANALYTICS_ENDPOINT:-http://localhost:8001/events}
       VITE_FLASHOFFER_ANALYTICS_RECENT_URL: ${FLASHOFFER_ANALYTICS_RECENT_URL:-http://localhost:8001/events/recent}
       VITE_FLASHOFFER_QUIZ_EVENTS_ENDPOINT: ${FLASHOFFER_QUIZ_EVENTS_ENDPOINT:-http://localhost:8002/api/events/quiz}
+      VITE_FLASHOFFER_CAMPAIGN_API_BASE: ${FLASHOFFER_CAMPAIGN_API_BASE:-http://localhost:8003}
     ports:
       - "${FLASHOFFER_PORT:-4173}:4173"
       - "80:80"
@@ -173,6 +192,7 @@ services:
     depends_on:
       - analytics-backend
       - quiz-backend
+      - campaign-backend
 
   flashoffer-dev:
     build:
@@ -185,6 +205,7 @@ services:
       VITE_FLASHOFFER_ANALYTICS_ENDPOINT: ${FLASHOFFER_ANALYTICS_ENDPOINT:-http://localhost:8001/events}
       VITE_FLASHOFFER_ANALYTICS_RECENT_URL: ${FLASHOFFER_ANALYTICS_RECENT_URL:-http://localhost:8001/events/recent}
       VITE_FLASHOFFER_QUIZ_EVENTS_ENDPOINT: ${FLASHOFFER_QUIZ_EVENTS_ENDPOINT:-http://localhost:8002/api/events/quiz}
+      VITE_FLASHOFFER_CAMPAIGN_API_BASE: ${FLASHOFFER_CAMPAIGN_API_BASE:-http://localhost:8003}
     ports:
       - "${FLASHOFFER_DEV_PORT:-5173}:5173"
     volumes:
@@ -192,6 +213,7 @@ services:
     depends_on:
       - analytics-backend
       - quiz-backend
+      - campaign-backend
 
 volumes:
   analytics_data:


### PR DESCRIPTION
## Summary
- add a campaign-backend Flask service that exposes `/api/campaign/<cid>/end_time`
- update the CountdownTimer component to support campaign-backed deadlines and static durations
- point the flashoffer demo at the campaign API and configure local proxies

## Testing
- npm test -- CountdownTimer

------
https://chatgpt.com/codex/tasks/task_e_68e7594998ac8321a98644381b63e79a