### PR TITLE
Add MIT headers to Flashoffer sources

### DIFF
--- a/app/flashoffer/analytics-backend/analytics_backend/__init__.py
+++ b/app/flashoffer/analytics-backend/analytics_backend/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Analytics backend package."""
 
 from __future__ import annotations

--- a/app/flashoffer/analytics-backend/analytics_backend/app.py
+++ b/app/flashoffer/analytics-backend/analytics_backend/app.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Flask application providing an ingestion API for analytics events."""
 
 from __future__ import annotations

--- a/app/flashoffer/analytics-backend/analytics_backend/db.py
+++ b/app/flashoffer/analytics-backend/analytics_backend/db.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Database utilities for the analytics backend."""
 
 from __future__ import annotations

--- a/app/flashoffer/analytics-backend/analytics_backend/sql/__init__.py
+++ b/app/flashoffer/analytics-backend/analytics_backend/sql/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+

--- a/app/flashoffer/analytics-backend/tests/conftest.py
+++ b/app/flashoffer/analytics-backend/tests/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 from __future__ import annotations
 
 import os

--- a/app/flashoffer/analytics-backend/tests/test_app.py
+++ b/app/flashoffer/analytics-backend/tests/test_app.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 from __future__ import annotations
 
 from datetime import datetime, timezone

--- a/app/flashoffer/analytics-backend/tests/test_db_config.py
+++ b/app/flashoffer/analytics-backend/tests/test_db_config.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 from __future__ import annotations
 
 import pytest

--- a/app/flashoffer/analytics-db/bin/dump_and_load.py
+++ b/app/flashoffer/analytics-db/bin/dump_and_load.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 # Streaming COPY → pandas in batches (memory-safe) with psycopg v3
 
 import codecs

--- a/app/flashoffer/backend-common/backend_common/__init__.py
+++ b/app/flashoffer/backend-common/backend_common/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Shared helpers for backend Flask services."""
 
 from .config import DatabaseConfig

--- a/app/flashoffer/backend-common/backend_common/config.py
+++ b/app/flashoffer/backend-common/backend_common/config.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Database configuration helpers shared across backend services."""
 
 from __future__ import annotations

--- a/app/flashoffer/backend-common/backend_common/cors.py
+++ b/app/flashoffer/backend-common/backend_common/cors.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """CORS configuration helpers."""
 
 from __future__ import annotations

--- a/app/flashoffer/backend-common/backend_common/pool.py
+++ b/app/flashoffer/backend-common/backend_common/pool.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Connection pooling primitives for backend services."""
 
 from __future__ import annotations

--- a/app/flashoffer/backend-common/setup.py
+++ b/app/flashoffer/backend-common/setup.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 from setuptools import setup, find_packages
 
 setup(

--- a/app/flashoffer/campaign-backend/campaign_backend/__init__.py
+++ b/app/flashoffer/campaign-backend/campaign_backend/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Campaign backend package exposing the Flask application factory."""
 
 from .app import create_app

--- a/app/flashoffer/campaign-backend/campaign_backend/app.py
+++ b/app/flashoffer/campaign-backend/campaign_backend/app.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Flask application that exposes campaign deadline metadata."""
 
 from __future__ import annotations

--- a/app/flashoffer/campaign-backend/campaign_backend/db.py
+++ b/app/flashoffer/campaign-backend/campaign_backend/db.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Database helpers that power the campaign deadline API."""
 
 from __future__ import annotations

--- a/app/flashoffer/campaign-backend/campaign_backend/sql/__init__.py
+++ b/app/flashoffer/campaign-backend/campaign_backend/sql/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+

--- a/app/flashoffer/campaign-backend/tests/conftest.py
+++ b/app/flashoffer/campaign-backend/tests/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 import os
 from typing import Iterator
 

--- a/app/flashoffer/campaign-backend/tests/test_app.py
+++ b/app/flashoffer/campaign-backend/tests/test_app.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 from datetime import datetime, timedelta, timezone
 
 from campaign_backend.db import CampaignStore

--- a/app/flashoffer/campaign_manager/backend/campaign_manager/__init__.py
+++ b/app/flashoffer/campaign_manager/backend/campaign_manager/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Campaign manager backend package."""
 
 from .app import create_app

--- a/app/flashoffer/campaign_manager/backend/campaign_manager/app.py
+++ b/app/flashoffer/campaign_manager/backend/campaign_manager/app.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """FastAPI application exposing campaign management endpoints."""
 
 from __future__ import annotations

--- a/app/flashoffer/campaign_manager/backend/campaign_manager/auth.py
+++ b/app/flashoffer/campaign_manager/backend/campaign_manager/auth.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Authentication helpers for the campaign manager API."""
 
 from __future__ import annotations

--- a/app/flashoffer/campaign_manager/backend/campaign_manager/db.py
+++ b/app/flashoffer/campaign_manager/backend/campaign_manager/db.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Database helpers for the campaign manager API."""
 
 from __future__ import annotations

--- a/app/flashoffer/campaign_manager/backend/campaign_manager/schemas.py
+++ b/app/flashoffer/campaign_manager/backend/campaign_manager/schemas.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Pydantic models used by the campaign manager API."""
 
 from __future__ import annotations

--- a/app/flashoffer/campaign_manager/vite.config.ts
+++ b/app/flashoffer/campaign_manager/vite.config.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import { resolve as resolvePath, sep } from "node:path";
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig, loadEnv } from "vite";

--- a/app/flashoffer/flashoffer-demo/src/App.test.tsx
+++ b/app/flashoffer/flashoffer-demo/src/App.test.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import App from "./App";
 

--- a/app/flashoffer/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer/flashoffer-demo/src/App.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Stack from "@mui/material/Stack";

--- a/app/flashoffer/flashoffer-demo/src/main.tsx
+++ b/app/flashoffer/flashoffer-demo/src/main.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { AutoTrack, EngagementProvider } from "flashoffer-react";

--- a/app/flashoffer/flashoffer-demo/src/quizAnalytics.ts
+++ b/app/flashoffer/flashoffer-demo/src/quizAnalytics.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 const QUIZ_EVENTS_ENDPOINT =
   typeof import.meta.env.VITE_FLASHOFFER_QUIZ_EVENTS_ENDPOINT === "string" &&
   import.meta.env.VITE_FLASHOFFER_QUIZ_EVENTS_ENDPOINT.trim() !== ""

--- a/app/flashoffer/flashoffer-demo/src/sections/CountdownShowcaseSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/CountdownShowcaseSection.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";

--- a/app/flashoffer/flashoffer-demo/src/sections/CtaShowcaseSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/CtaShowcaseSection.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";

--- a/app/flashoffer/flashoffer-demo/src/sections/CustomizationControlsSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/CustomizationControlsSection.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import Paper from "@mui/material/Paper";

--- a/app/flashoffer/flashoffer-demo/src/sections/FigureSpotlightSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/FigureSpotlightSection.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { Figure, Section } from "flashoffer-react";

--- a/app/flashoffer/flashoffer-demo/src/sections/FooterSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/FooterSection.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import { Footer, Section } from "flashoffer-react";

--- a/app/flashoffer/flashoffer-demo/src/sections/HeroShowcaseSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/HeroShowcaseSection.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import { HeroBanner, Section } from "flashoffer-react";
 import type { ReactNode } from "react";

--- a/app/flashoffer/flashoffer-demo/src/sections/OverviewSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/OverviewSection.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { Section } from "flashoffer-react";

--- a/app/flashoffer/flashoffer-demo/src/sections/PreviewShowcaseSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/PreviewShowcaseSection.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";

--- a/app/flashoffer/flashoffer-demo/src/sections/QuizShowcaseSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/QuizShowcaseSection.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";

--- a/app/flashoffer/flashoffer-demo/src/sections/content.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/content.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 const previewMedia = (
   gradientId: string,
   accentColor: string,

--- a/app/flashoffer/flashoffer-demo/src/sections/index.ts
+++ b/app/flashoffer/flashoffer-demo/src/sections/index.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 export * from "./types";
 export * from "./CustomizationControlsSection";
 export * from "./HeroShowcaseSection";

--- a/app/flashoffer/flashoffer-demo/src/sections/types.ts
+++ b/app/flashoffer/flashoffer-demo/src/sections/types.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 export type ThemePreset =
   | "ocean"
   | "sunset"

--- a/app/flashoffer/flashoffer-demo/src/setupTests.ts
+++ b/app/flashoffer/flashoffer-demo/src/setupTests.ts
@@ -1,1 +1,6 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import "@testing-library/jest-dom/vitest";

--- a/app/flashoffer/flashoffer-demo/src/vite-env.d.ts
+++ b/app/flashoffer/flashoffer-demo/src/vite-env.d.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {

--- a/app/flashoffer/flashoffer-demo/vite.config.ts
+++ b/app/flashoffer/flashoffer-demo/vite.config.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import { resolve as resolvePath, sep } from "node:path";
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig } from "vite";

--- a/app/flashoffer/flashoffer-react/jest.config.ts
+++ b/app/flashoffer/flashoffer-react/jest.config.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import type { Config } from "jest";
 
 const config: Config = {

--- a/app/flashoffer/flashoffer-react/setupTests.ts
+++ b/app/flashoffer/flashoffer-react/setupTests.ts
@@ -1,1 +1,6 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import "@testing-library/jest-dom";

--- a/app/flashoffer/flashoffer-react/src/analytics/AutoTrack.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/AutoTrack.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import { useEffect } from "react";
 import { useEngagement } from "./EngagementProvider";
 

--- a/app/flashoffer/flashoffer-react/src/analytics/EngagementProvider.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/EngagementProvider.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import {
   createContext,
   createElement,

--- a/app/flashoffer/flashoffer-react/src/analytics/EventConsole.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/EventConsole.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import "./EventConsole.css";

--- a/app/flashoffer/flashoffer-react/src/analytics/__tests__/AutoTrack.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/__tests__/AutoTrack.test.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import { render, waitFor } from "@testing-library/react";
 import AutoTrack from "../AutoTrack";
 

--- a/app/flashoffer/flashoffer-react/src/analytics/__tests__/EngagementProvider.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/__tests__/EngagementProvider.test.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import { act, render } from "@testing-library/react";
 import type { MutableRefObject } from "react";
 import {

--- a/app/flashoffer/flashoffer-react/src/analytics/index.ts
+++ b/app/flashoffer/flashoffer-react/src/analytics/index.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 export { AutoTrack } from "./AutoTrack";
 export type { AutoTrackProps } from "./AutoTrack";
 

--- a/app/flashoffer/flashoffer-react/src/components/Figure.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/Figure.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import type { SxProps, Theme } from "@mui/material/styles";

--- a/app/flashoffer/flashoffer-react/src/components/Footer.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/Footer.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
 import Stack from "@mui/material/Stack";

--- a/app/flashoffer/flashoffer-react/src/components/HeroBanner.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/HeroBanner.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";

--- a/app/flashoffer/flashoffer-react/src/components/OutlineCtaButton.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/OutlineCtaButton.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Button from "@mui/material/Button";
 import type { ButtonProps } from "@mui/material/Button";
 import type { AnchorHTMLAttributes, ReactNode } from "react";

--- a/app/flashoffer/flashoffer-react/src/components/PreviewCard.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/PreviewCard.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";

--- a/app/flashoffer/flashoffer-react/src/components/PrimaryCtaButton.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/PrimaryCtaButton.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Button from "@mui/material/Button";
 import type { ButtonProps } from "@mui/material/Button";
 import type { AnchorHTMLAttributes, ReactNode } from "react";

--- a/app/flashoffer/flashoffer-react/src/components/Section.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/Section.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Stack from "@mui/material/Stack";
 import type { ReactNode } from "react";
 import { SectionHeader } from "./SectionHeader";

--- a/app/flashoffer/flashoffer-react/src/components/SectionHeader.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/SectionHeader.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import type { ReactNode } from "react";

--- a/app/flashoffer/flashoffer-react/test/__mocks__/styleMock.ts
+++ b/app/flashoffer/flashoffer-react/test/__mocks__/styleMock.ts
@@ -1,1 +1,6 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 export default {} as Record<string, string>;

--- a/app/flashoffer/flashoffer-react/vite.config.ts
+++ b/app/flashoffer/flashoffer-react/vite.config.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import dts from "vite-plugin-dts";

--- a/app/flashoffer/quiz-backend/quiz_backend/__init__.py
+++ b/app/flashoffer/quiz-backend/quiz_backend/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Quiz backend service package."""
 
 from __future__ import annotations

--- a/app/flashoffer/quiz-backend/quiz_backend/app.py
+++ b/app/flashoffer/quiz-backend/quiz_backend/app.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Flask application providing an ingestion API for quiz events."""
 
 from __future__ import annotations

--- a/app/flashoffer/quiz-backend/quiz_backend/db.py
+++ b/app/flashoffer/quiz-backend/quiz_backend/db.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 """Persistence layer for quiz completion events."""
 
 from __future__ import annotations

--- a/app/flashoffer/quiz-backend/quiz_backend/sql/__init__.py
+++ b/app/flashoffer/quiz-backend/quiz_backend/sql/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+

--- a/app/flashoffer/quiz-backend/tests/conftest.py
+++ b/app/flashoffer/quiz-backend/tests/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 from __future__ import annotations
 
 import os

--- a/app/flashoffer/quiz-backend/tests/test_app.py
+++ b/app/flashoffer/quiz-backend/tests/test_app.py
@@ -1,3 +1,6 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
 from __future__ import annotations
 
 from datetime import datetime, timezone


### PR DESCRIPTION
## Summary
- add MIT copyright headers to Flashoffer backend, frontend, and test sources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e76df4ba9083218f5cd846e3c18b23