### PR TITLE
Add campaign ID support to Flashoffer engagement tracking

### DIFF
--- a/app/flashoffer/docs/flashoffer-react.md
+++ b/app/flashoffer/docs/flashoffer-react.md
@@ -214,8 +214,8 @@ and interaction events. The helpers expose consistent metadata for downstream
 analytics services and gracefully degrade when browser APIs are unavailable.
 
 Wrap the subtree you want to measure in an `EngagementProvider`. The provider
-requires a `site` identifier and can optionally post batches to an HTTP
-`endpoint`.
+requires a `site` identifier and can optionally include a `campaignId` for
+attribution while posting batches to an HTTP `endpoint`.
 
 ```tsx
 import {
@@ -229,7 +229,11 @@ export function LandingWithAnalytics() {
   const recordInteraction = useRecordInteraction("primary-cta");
 
   return (
-    <EngagementProvider site="marketing-site" endpoint="/api/events">
+    <EngagementProvider
+      site="marketing-site"
+      campaignId="spring-preview"
+      endpoint="/api/events"
+    >
       <AutoTrack />
       <ViewTracker trackId="hero">
         <HeroBanner

--- a/app/flashoffer/docs/flashoffer-react/reference/functions/EngagementProvider.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/functions/EngagementProvider.md
@@ -6,15 +6,14 @@
 
 > **EngagementProvider**(`__namedParameters`): `Element`
 
-Creates the context that emits the
-[engagement events](../engagement-events.md) for tracked elements and page
-activity.
+Creates the context that emits the [engagement events](../engagement-events.md)
+for tracked elements and page activity.
 
-Defined in: src/analytics/EngagementProvider.tsx:84
+Defined in: src/analytics/EngagementProvider.tsx:118
 
 ## Parameters
 
-### \_\_namedParameters
+### __namedParameters
 
 [`EngagementProviderProps`](../interfaces/EngagementProviderProps.md)
 

--- a/app/flashoffer/docs/flashoffer-react/reference/functions/ViewTracker.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/functions/ViewTracker.md
@@ -4,16 +4,18 @@
 
 # Function: ViewTracker()
 
-> **ViewTracker**(`__namedParameters`): `ReactElement`\<`any`, `string` \| `JSXElementConstructor`\<`any`\>\>
+> **ViewTracker**(`__namedParameters`): `Element`
 
-Defined in: src/analytics/EngagementProvider.tsx:567
+Render a component that tracks when its children enter and leave the viewport.
+
+Defined in: src/analytics/EngagementProvider.tsx:667
 
 ## Parameters
 
-### \_\_namedParameters
+### __namedParameters
 
 [`ViewTrackerProps`](../interfaces/ViewTrackerProps.md)
 
 ## Returns
 
-`ReactElement`\<`any`, `string` \| `JSXElementConstructor`\<`any`\>\>
+`Element`

--- a/app/flashoffer/docs/flashoffer-react/reference/functions/useEngagement.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/functions/useEngagement.md
@@ -6,7 +6,9 @@
 
 > **useEngagement**(): [`EngagementContextValue`](../interfaces/EngagementContextValue.md)
 
-Defined in: src/analytics/EngagementProvider.tsx:525
+Convenience hook that exposes the engagement tracking context.
+
+Defined in: src/analytics/EngagementProvider.tsx:625
 
 ## Returns
 

--- a/app/flashoffer/docs/flashoffer-react/reference/functions/useRecordInteraction.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/functions/useRecordInteraction.md
@@ -4,12 +4,11 @@
 
 # Function: useRecordInteraction()
 
-> **useRecordInteraction**(`defaultTarget?`, `defaultMeta?`): (`target`, `meta`) => `void`
+> **useRecordInteraction**(`defaultTarget?`, `defaultMeta?`): (`target?`, `meta?`) => `void`
 
-Returns a callback that records `interaction` events described in the
-[engagement events](../engagement-events.md) guide.
+Return a callback that records interaction events with optional defaults.
 
-Defined in: src/analytics/EngagementProvider.tsx:582
+Defined in: src/analytics/EngagementProvider.tsx:682
 
 ## Parameters
 
@@ -19,21 +18,21 @@ Defined in: src/analytics/EngagementProvider.tsx:582
 
 ### defaultMeta?
 
-`Record`\<`string`, `unknown`\> = `{}`
+`Record`\<`string`, `unknown`\>
 
 ## Returns
 
-> (`target`, `meta`): `void`
+> (`target?`, `meta?`) => `void`
 
 ### Parameters
 
-#### target
+#### target?
 
-`string` = `...`
+`string`
 
-#### meta
+#### meta?
 
-`Record`\<`string`, `unknown`\> = `defaultMeta`
+`Record`\<`string`, `unknown`\>
 
 ### Returns
 

--- a/app/flashoffer/docs/flashoffer-react/reference/functions/useViewTracker.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/functions/useViewTracker.md
@@ -4,9 +4,11 @@
 
 # Function: useViewTracker()
 
-> **useViewTracker**(`trackId`, `meta`): (`node`) => `void`
+> **useViewTracker**(`trackId`, `meta?`): (`node`) => `void`
 
-Defined in: src/analytics/EngagementProvider.tsx:533
+Create a ref callback that wires intersection observers for a tracked element.
+
+Defined in: src/analytics/EngagementProvider.tsx:633
 
 ## Parameters
 
@@ -14,13 +16,13 @@ Defined in: src/analytics/EngagementProvider.tsx:533
 
 `string`
 
-### meta
+### meta?
 
-`Record`\<`string`, `unknown`\> = `{}`
+`Record`\<`string`, `unknown`\>
 
 ## Returns
 
-> (`node`): `void`
+> (`node`) => `void`
 
 ### Parameters
 

--- a/app/flashoffer/docs/flashoffer-react/reference/interfaces/EngagementContextValue.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/interfaces/EngagementContextValue.md
@@ -4,7 +4,7 @@
 
 # Interface: EngagementContextValue
 
-Defined in: src/analytics/EngagementProvider.tsx:39
+Defined in: src/analytics/EngagementProvider.tsx:46
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: src/analytics/EngagementProvider.tsx:39
 
 > **register**: (`trackId`, `element`, `meta?`) => () => `void`
 
-Defined in: src/analytics/EngagementProvider.tsx:40
+Defined in: src/analytics/EngagementProvider.tsx:47
 
 #### Parameters
 
@@ -42,7 +42,7 @@ Defined in: src/analytics/EngagementProvider.tsx:40
 
 > **attachElement**: (`trackId`, `element`, `meta?`) => () => `void`
 
-Defined in: src/analytics/EngagementProvider.tsx:45
+Defined in: src/analytics/EngagementProvider.tsx:52
 
 #### Parameters
 
@@ -72,7 +72,7 @@ Defined in: src/analytics/EngagementProvider.tsx:45
 
 > **detachElement**: (`element`) => `void`
 
-Defined in: src/analytics/EngagementProvider.tsx:50
+Defined in: src/analytics/EngagementProvider.tsx:57
 
 #### Parameters
 
@@ -90,7 +90,7 @@ Defined in: src/analytics/EngagementProvider.tsx:50
 
 > **recordInteraction**: (`target`, `meta?`) => `void`
 
-Defined in: src/analytics/EngagementProvider.tsx:51
+Defined in: src/analytics/EngagementProvider.tsx:58
 
 #### Parameters
 
@@ -112,7 +112,7 @@ Defined in: src/analytics/EngagementProvider.tsx:51
 
 > **getActiveTargets**: () => `string`[]
 
-Defined in: src/analytics/EngagementProvider.tsx:52
+Defined in: src/analytics/EngagementProvider.tsx:59
 
 #### Returns
 

--- a/app/flashoffer/docs/flashoffer-react/reference/interfaces/EngagementEvent.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/interfaces/EngagementEvent.md
@@ -4,7 +4,7 @@
 
 # Interface: EngagementEvent
 
-Defined in: src/analytics/EngagementProvider.tsx:14
+Defined in: src/analytics/EngagementProvider.tsx:20
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: src/analytics/EngagementProvider.tsx:14
 
 > **type**: `string`
 
-Defined in: src/analytics/EngagementProvider.tsx:15
+Defined in: src/analytics/EngagementProvider.tsx:21
 
 ***
 
@@ -20,7 +20,7 @@ Defined in: src/analytics/EngagementProvider.tsx:15
 
 > **target**: `string`
 
-Defined in: src/analytics/EngagementProvider.tsx:16
+Defined in: src/analytics/EngagementProvider.tsx:22
 
 ***
 
@@ -28,7 +28,7 @@ Defined in: src/analytics/EngagementProvider.tsx:16
 
 > **meta**: `Record`\<`string`, `unknown`\>
 
-Defined in: src/analytics/EngagementProvider.tsx:17
+Defined in: src/analytics/EngagementProvider.tsx:23
 
 ***
 
@@ -36,4 +36,4 @@ Defined in: src/analytics/EngagementProvider.tsx:17
 
 > **at**: `string`
 
-Defined in: src/analytics/EngagementProvider.tsx:18
+Defined in: src/analytics/EngagementProvider.tsx:24

--- a/app/flashoffer/docs/flashoffer-react/reference/interfaces/EngagementProviderProps.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/interfaces/EngagementProviderProps.md
@@ -4,7 +4,7 @@
 
 # Interface: EngagementProviderProps
 
-Defined in: src/analytics/EngagementProvider.tsx:27
+Defined in: src/analytics/EngagementProvider.tsx:33
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: src/analytics/EngagementProvider.tsx:27
 
 > `optional` **endpoint**: `string`
 
-Defined in: src/analytics/EngagementProvider.tsx:28
+Defined in: src/analytics/EngagementProvider.tsx:34
 
 ***
 
@@ -20,7 +20,15 @@ Defined in: src/analytics/EngagementProvider.tsx:28
 
 > **site**: `string`
 
-Defined in: src/analytics/EngagementProvider.tsx:29
+Defined in: src/analytics/EngagementProvider.tsx:35
+
+***
+
+### campaignId?
+
+> `optional` **campaignId**: `string`
+
+Defined in: src/analytics/EngagementProvider.tsx:36
 
 ***
 
@@ -28,7 +36,7 @@ Defined in: src/analytics/EngagementProvider.tsx:29
 
 > **children**: `ReactNode`
 
-Defined in: src/analytics/EngagementProvider.tsx:30
+Defined in: src/analytics/EngagementProvider.tsx:37
 
 ***
 
@@ -36,7 +44,7 @@ Defined in: src/analytics/EngagementProvider.tsx:30
 
 > `optional` **flushInterval**: `null` \| `number`
 
-Defined in: src/analytics/EngagementProvider.tsx:31
+Defined in: src/analytics/EngagementProvider.tsx:38
 
 ***
 
@@ -44,7 +52,7 @@ Defined in: src/analytics/EngagementProvider.tsx:31
 
 > `optional` **heartbeatInterval**: `number`
 
-Defined in: src/analytics/EngagementProvider.tsx:32
+Defined in: src/analytics/EngagementProvider.tsx:39
 
 ***
 
@@ -52,7 +60,7 @@ Defined in: src/analytics/EngagementProvider.tsx:32
 
 > `optional` **idleTimeout**: `number`
 
-Defined in: src/analytics/EngagementProvider.tsx:33
+Defined in: src/analytics/EngagementProvider.tsx:40
 
 ***
 
@@ -60,7 +68,7 @@ Defined in: src/analytics/EngagementProvider.tsx:33
 
 > `optional` **scrollThresholds**: `number`[]
 
-Defined in: src/analytics/EngagementProvider.tsx:34
+Defined in: src/analytics/EngagementProvider.tsx:41
 
 ***
 
@@ -68,7 +76,7 @@ Defined in: src/analytics/EngagementProvider.tsx:34
 
 > `optional` **viewThresholds**: `number`[]
 
-Defined in: src/analytics/EngagementProvider.tsx:35
+Defined in: src/analytics/EngagementProvider.tsx:42
 
 ***
 
@@ -76,4 +84,4 @@ Defined in: src/analytics/EngagementProvider.tsx:35
 
 > `optional` **maxBatch**: `number`
 
-Defined in: src/analytics/EngagementProvider.tsx:36
+Defined in: src/analytics/EngagementProvider.tsx:43

--- a/app/flashoffer/docs/flashoffer-react/reference/interfaces/ViewTrackerProps.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/interfaces/ViewTrackerProps.md
@@ -4,11 +4,7 @@
 
 # Interface: ViewTrackerProps
 
-Defined in: src/analytics/EngagementProvider.tsx:559
-
-## Indexable
-
-\[`key`: `string`\]: `unknown`
+Defined in: src/analytics/EngagementProvider.tsx:659
 
 ## Properties
 
@@ -16,7 +12,7 @@ Defined in: src/analytics/EngagementProvider.tsx:559
 
 > **trackId**: `string`
 
-Defined in: src/analytics/EngagementProvider.tsx:560
+Defined in: src/analytics/EngagementProvider.tsx:660
 
 ***
 
@@ -24,7 +20,7 @@ Defined in: src/analytics/EngagementProvider.tsx:560
 
 > `optional` **meta**: `Record`\<`string`, `unknown`\>
 
-Defined in: src/analytics/EngagementProvider.tsx:561
+Defined in: src/analytics/EngagementProvider.tsx:661
 
 ***
 
@@ -32,7 +28,7 @@ Defined in: src/analytics/EngagementProvider.tsx:561
 
 > `optional` **as**: `ElementType`
 
-Defined in: src/analytics/EngagementProvider.tsx:562
+Defined in: src/analytics/EngagementProvider.tsx:662
 
 ***
 
@@ -40,4 +36,12 @@ Defined in: src/analytics/EngagementProvider.tsx:562
 
 > `optional` **children**: `ReactNode`
 
-Defined in: src/analytics/EngagementProvider.tsx:563
+Defined in: src/analytics/EngagementProvider.tsx:663
+
+***
+
+### [key: string]
+
+> **[key: string]**: `unknown`
+
+Defined in: src/analytics/EngagementProvider.tsx:664

--- a/app/flashoffer/flashoffer-demo/src/main.tsx
+++ b/app/flashoffer/flashoffer-demo/src/main.tsx
@@ -23,7 +23,11 @@ if (!rootElement) {
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <EngagementProvider site="flashoffer-demo" endpoint={analyticsEndpoint}>
+    <EngagementProvider
+      site="flashoffer-demo"
+      campaignId="flashoffer-demo"
+      endpoint={analyticsEndpoint}
+    >
       <App />
       <AutoTrack />
     </EngagementProvider>

--- a/app/flashoffer/flashoffer-react/src/analytics/EngagementProvider.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/EngagementProvider.tsx
@@ -33,6 +33,7 @@ interface ActiveViewState {
 export interface EngagementProviderProps {
   endpoint?: string;
   site: string;
+  campaignId?: string;
   children: ReactNode;
   flushInterval?: number | null;
   heartbeatInterval?: number;
@@ -117,6 +118,7 @@ function calculateScrollRatio(): { ratio: number; pixels: number } {
 export function EngagementProvider({
   endpoint,
   site,
+  campaignId,
   children,
   flushInterval = 5000,
   heartbeatInterval = 15000,
@@ -125,6 +127,10 @@ export function EngagementProvider({
   viewThresholds = [0.25, 0.5, 0.75, 1],
   maxBatch = 25,
 }: EngagementProviderProps) {
+  const normalizedCampaignId = useMemo(() => {
+    const trimmed = campaignId?.trim();
+    return trimmed ? trimmed : undefined;
+  }, [campaignId]);
   const queueRef = useRef<EngagementEvent[]>([]);
   const sessionIdRef = useRef<string>(fallbackUuid());
   const trackedElementsRef = useRef(
@@ -261,19 +267,29 @@ export function EngagementProvider({
         return;
       }
       const events = queueRef.current.splice(0, queueRef.current.length);
-      const body = JSON.stringify({
+      const payload = {
         site,
         session_id: sessionIdRef.current,
         events,
         reason,
-      });
+        ...(normalizedCampaignId
+          ? { campaign_id: normalizedCampaignId }
+          : {}),
+      };
+      const body = JSON.stringify(payload);
       if (canUseBeacon(sync)) {
         deliverWithBeacon(currentEndpoint, events, body);
         return;
       }
       await deliverWithFetch(currentEndpoint, events, body, sync);
     },
-    [deliverWithBeacon, deliverWithFetch, evaluateFlushEndpoint, site]
+    [
+      deliverWithBeacon,
+      deliverWithFetch,
+      evaluateFlushEndpoint,
+      normalizedCampaignId,
+      site,
+    ]
   );
 
   useEffect(() => {

--- a/app/flashoffer/flashoffer-react/src/analytics/__tests__/EngagementProvider.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/__tests__/EngagementProvider.test.tsx
@@ -100,6 +100,60 @@ describe("EngagementProvider connection failure handling", () => {
   });
 });
 
+describe("EngagementProvider payload metadata", () => {
+  const globalScope = globalThis as GlobalWithOptionalFetch;
+  const originalFetch = globalScope.fetch;
+  let fetchMock: jest.MockedFunction<typeof fetch>;
+
+  beforeEach(() => {
+    fetchMock = jest
+      .fn(async () => ({ ok: true } as Response))
+      .mockName("fetch") as jest.MockedFunction<typeof fetch>;
+    globalScope.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalScope.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("includes a sanitised campaign identifier when provided", async () => {
+    const recordRef = {
+      current: (() => undefined) as RecordFn,
+    } as MutableRefObject<RecordFn>;
+
+    const view = render(
+      <EngagementProvider
+        endpoint="/engagement"
+        site="test-site"
+        campaignId="  spring-promo  "
+        maxBatch={1}
+        flushInterval={null}
+        heartbeatInterval={60_000}
+        idleTimeout={60_000}
+        scrollThresholds={[]}
+        viewThresholds={[]}
+      >
+        <Recorder recordRef={recordRef} />
+      </EngagementProvider>
+    );
+
+    await act(async () => {
+      recordRef.current("cta-click");
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(fetchMock.mock.calls[0][1]?.body ?? "{}");
+    expect(payload).toMatchObject({
+      site: "test-site",
+      campaign_id: "spring-promo",
+    });
+
+    view.unmount();
+  });
+});
+
 describe("EngagementProvider lifetime", () => {
   const globalScope = globalThis as GlobalWithOptionalFetch;
   const originalFetch = globalScope.fetch;


### PR DESCRIPTION
## Summary
- allow `EngagementProvider` to accept an optional `campaignId` and include it in flushed engagement payloads
- cover the campaign identifier logic with unit tests and document the new property for consumers
- propagate the `flashoffer-demo` campaign identifier through the demo app so emitted events include it

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e7763fa48c832190153e303629f35f