### PR TITLE
Add event console pane to campaign dashboard

### DIFF
--- a/app/flashoffer/campaign-manager/src/App.tsx
+++ b/app/flashoffer/campaign-manager/src/App.tsx
@@ -186,6 +186,7 @@ const App = (): JSX.Element => {
               onUpdate={handleUpdate}
               onLogout={handleLogout}
               expiresAt={expiresAt}
+              token={token}
             />
           ) : (
             <LoginView loading={loading} onSubmit={handleLogin} />

--- a/app/flashoffer/campaign-manager/src/api.ts
+++ b/app/flashoffer/campaign-manager/src/api.ts
@@ -105,6 +105,17 @@ export async function updateCampaign(
   return mapCampaign(response);
 }
 
+/**
+ * Builds the events endpoint URL for a campaign using the configured API base.
+ *
+ * @param campaignId - Unique identifier for the campaign to inspect.
+ * @returns URL that can be requested to retrieve recent campaign events.
+ */
+export function buildCampaignEventsUrl(campaignId: string): string {
+  const encodedId = encodeURIComponent(campaignId);
+  return `${API_BASE}/api/campaigns/${encodedId}/events`;
+}
+
 function mapCampaign(payload: ApiCampaign): CampaignSummary {
   return {
     campaignId: payload.campaign_id,

--- a/app/flashoffer/campaign-manager/src/components/CampaignDashboard.tsx
+++ b/app/flashoffer/campaign-manager/src/components/CampaignDashboard.tsx
@@ -26,6 +26,7 @@ interface CampaignDashboardProps {
   onRefresh: () => Promise<void> | void;
   onLogout: () => void;
   expiresAt: string | null;
+  token: string;
 }
 
 type DialogState =
@@ -40,6 +41,7 @@ export const CampaignDashboard = ({
   onRefresh,
   onLogout,
   expiresAt,
+  token,
 }: CampaignDashboardProps): JSX.Element => {
   const [dialog, setDialog] = useState<DialogState | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
@@ -157,7 +159,7 @@ export const CampaignDashboard = ({
   } else {
     eventPaneContent = (
       <Box sx={{ width: "100%" }}>
-        <EventConsole eventsUrl={eventsUrl} limit={50} />
+        <EventConsole eventsUrl={eventsUrl} limit={50} authToken={token} />
       </Box>
     );
   }

--- a/app/flashoffer/campaign-manager/src/components/CampaignDashboard.tsx
+++ b/app/flashoffer/campaign-manager/src/components/CampaignDashboard.tsx
@@ -3,12 +3,16 @@
  * Released under the MIT license.
  */
 
+import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
+import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import { useCallback, useMemo, useState } from "react";
-import { PrimaryCtaButton, Section, SectionHeader } from "flashoffer-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { EventConsole, PrimaryCtaButton, Section, SectionHeader } from "flashoffer-react";
 
+import { buildCampaignEventsUrl } from "../api";
 import type { CampaignPayload, CampaignSummary } from "../types";
 import { formatTimestampForDisplay } from "../utils";
 import { CampaignForm } from "./CampaignForm";
@@ -40,6 +44,7 @@ export const CampaignDashboard = ({
   const [dialog, setDialog] = useState<DialogState | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [formSaving, setFormSaving] = useState(false);
+  const [selectedCampaignId, setSelectedCampaignId] = useState<string | null>(null);
 
   const openCreate = useCallback(() => {
     setFormError(null);
@@ -57,6 +62,16 @@ export const CampaignDashboard = ({
     }
     setDialog(null);
   }, [formSaving]);
+
+  useEffect(() => {
+    if (!selectedCampaignId) {
+      return;
+    }
+    const exists = campaigns.some((campaign) => campaign.campaignId === selectedCampaignId);
+    if (!exists) {
+      setSelectedCampaignId(null);
+    }
+  }, [campaigns, selectedCampaignId]);
 
   const handleSubmit = useCallback(
     async (campaignId: string, payload: CampaignPayload) => {
@@ -82,12 +97,70 @@ export const CampaignDashboard = ({
     [dialog, onCreate, onUpdate],
   );
 
+  const handleSelectCampaign = useCallback((campaign: CampaignSummary | null) => {
+    setSelectedCampaignId(campaign ? campaign.campaignId : null);
+  }, []);
+
   const currentExpiry = useMemo(() => {
     if (!expiresAt) {
       return null;
     }
     return formatTimestampForDisplay(expiresAt);
   }, [expiresAt]);
+
+  const selectedCampaign = useMemo(() => {
+    if (!selectedCampaignId) {
+      return null;
+    }
+    return campaigns.find((campaign) => campaign.campaignId === selectedCampaignId) ?? null;
+  }, [campaigns, selectedCampaignId]);
+
+  const eventsUrl = useMemo(() => {
+    if (!selectedCampaign) {
+      return null;
+    }
+    return buildCampaignEventsUrl(selectedCampaign.campaignId);
+  }, [selectedCampaign]);
+
+  let eventPaneContent: JSX.Element;
+  if (loading && campaigns.length === 0) {
+    eventPaneContent = (
+      <Stack spacing={2} alignItems="center" justifyContent="center" sx={{ py: 6 }}>
+        <CircularProgress size={28} />
+        <Typography variant="body2" color="text.secondary" align="center">
+          Loading campaigns…
+        </Typography>
+      </Stack>
+    );
+  } else if (campaigns.length === 0) {
+    eventPaneContent = (
+      <Stack spacing={1.5} alignItems="center" justifyContent="center" sx={{ py: 6 }}>
+        <Typography variant="h6" align="center">
+          No campaigns available
+        </Typography>
+        <Typography variant="body2" color="text.secondary" align="center">
+          Create a campaign to start monitoring incoming event activity in real time.
+        </Typography>
+      </Stack>
+    );
+  } else if (!selectedCampaign || !eventsUrl) {
+    eventPaneContent = (
+      <Stack spacing={1.5} alignItems="center" justifyContent="center" sx={{ py: 6 }}>
+        <Typography variant="h6" align="center">
+          Select a campaign to monitor events
+        </Typography>
+        <Typography variant="body2" color="text.secondary" align="center">
+          Choose a row above to review the most recent activity captured for that campaign.
+        </Typography>
+      </Stack>
+    );
+  } else {
+    eventPaneContent = (
+      <Box sx={{ width: "100%" }}>
+        <EventConsole eventsUrl={eventsUrl} limit={50} />
+      </Box>
+    );
+  }
 
   return (
     <Section>
@@ -114,7 +187,28 @@ export const CampaignDashboard = ({
           </Button>
         </Stack>
       </Stack>
-      <CampaignTable campaigns={campaigns} loading={loading} onEdit={openEdit} />
+      <Stack spacing={4} sx={{ mt: 4 }}>
+        <CampaignTable
+          campaigns={campaigns}
+          loading={loading}
+          onEdit={openEdit}
+          onSelect={handleSelectCampaign}
+          selectedCampaignId={selectedCampaignId}
+        />
+        <Paper
+          variant="outlined"
+          elevation={0}
+          sx={{
+            borderRadius: 3,
+            borderColor: "divider",
+            backgroundColor: "background.paper",
+            px: { xs: 2, sm: 3 },
+            py: { xs: 3, sm: 4 },
+          }}
+        >
+          {eventPaneContent}
+        </Paper>
+      </Stack>
       {dialog && (
         <CampaignForm
           open

--- a/app/flashoffer/campaign-manager/src/components/CampaignTable.tsx
+++ b/app/flashoffer/campaign-manager/src/components/CampaignTable.tsx
@@ -5,8 +5,8 @@
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import { DataGrid, type GridColDef } from "@mui/x-data-grid";
-import { useMemo } from "react";
+import { DataGrid, type GridColDef, type GridRowSelectionModel } from "@mui/x-data-grid";
+import { useCallback, useMemo } from "react";
 
 import type { CampaignSummary } from "../types";
 import { formatTimestampForDisplay } from "../utils";
@@ -15,12 +15,16 @@ interface CampaignTableProps {
   campaigns: CampaignSummary[];
   loading: boolean;
   onEdit: (campaign: CampaignSummary) => void;
+  onSelect?: (campaign: CampaignSummary | null) => void;
+  selectedCampaignId?: string | null;
 }
 
 export const CampaignTable = ({
   campaigns,
   loading,
   onEdit,
+  onSelect,
+  selectedCampaignId,
 }: CampaignTableProps): JSX.Element => {
   const rows = useMemo(
     () =>
@@ -53,7 +57,10 @@ export const CampaignTable = ({
           <Button
             variant="outlined"
             size="small"
-            onClick={() => onEdit(params.row.campaign as CampaignSummary)}
+            onClick={(event) => {
+              event.stopPropagation();
+              onEdit(params.row.campaign as CampaignSummary);
+            }}
           >
             Edit
           </Button>
@@ -63,14 +70,30 @@ export const CampaignTable = ({
     [onEdit],
   );
 
+  const handleRowSelectionModelChange = useCallback(
+    (selection: GridRowSelectionModel) => {
+      if (!onSelect) {
+        return;
+      }
+      const [first] = selection;
+      if (!first) {
+        onSelect(null);
+        return;
+      }
+      const candidate = campaigns.find((item) => item.campaignId === String(first));
+      onSelect(candidate ?? null);
+    },
+    [campaigns, onSelect],
+  );
+
   return (
-    <Box sx={{ width: "100%", mt: 4 }}>
+    <Box sx={{ width: "100%" }}>
       <DataGrid
         rows={rows}
         columns={columns}
         autoHeight
         density="comfortable"
-        disableRowSelectionOnClick
+        disableRowSelectionOnClick={false}
         getRowId={(row) => row.id}
         loading={loading}
         pageSizeOptions={[5, 10, 25]}
@@ -78,6 +101,8 @@ export const CampaignTable = ({
           pagination: { paginationModel: { pageSize: 10, page: 0 } },
           sorting: { sortModel: [{ field: "campaignId", sort: "asc" }] },
         }}
+        onRowSelectionModelChange={handleRowSelectionModelChange}
+        rowSelectionModel={selectedCampaignId ? [selectedCampaignId] : []}
       />
     </Box>
   );

--- a/app/flashoffer/flashoffer-react/src/analytics/EventConsole.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/EventConsole.tsx
@@ -7,10 +7,19 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import "./EventConsole.css";
 
+/**
+ * Properties for configuring the `EventConsole` component.
+ *
+ * @property eventsUrl - Endpoint that serves recent campaign events.
+ * @property pollInterval - Milliseconds between successive fetches.
+ * @property limit - Maximum number of events to request per poll.
+ * @property authToken - Optional bearer token for authenticated requests.
+ */
 export interface EventConsoleProps {
   eventsUrl?: string;
   pollInterval?: number;
   limit?: number;
+  authToken?: string;
 }
 
 interface CapturedEvent {
@@ -75,10 +84,14 @@ function extractEvents(
   return data.events as CapturedEvent[];
 }
 
+/**
+ * Render a live-updating console of campaign events fetched from the backend.
+ */
 export function EventConsole({
   eventsUrl,
   pollInterval = 3000,
   limit = 25,
+  authToken,
 }: EventConsoleProps) {
   const [events, setEvents] = useState<CapturedEvent[]>([]);
   const [status, setStatus] = useState<ConsoleStatus>("idle");
@@ -124,6 +137,7 @@ export function EventConsole({
         const response = await fetch(url, {
           credentials: "include",
           signal: controller.signal,
+          headers: authToken ? { Authorization: `Bearer ${authToken}` } : undefined,
         });
         if (!response.ok) {
           throw new Error(`Request failed with status ${response.status}`);
@@ -153,6 +167,7 @@ export function EventConsole({
     };
   }, [
     applyLimitParam,
+    authToken,
     eventsUrl,
     handleLoadFailure,
     handleLoadSuccess,


### PR DESCRIPTION
## Summary
- track the selected campaign in the dashboard and render a split view with contextual event states
- expose row selection changes from the campaign table so the dashboard can react to user focus
- add an API helper to build campaign event URLs and pass the events feed to the console with a limit of 50

## Testing
- npm run build --prefix app/flashoffer/campaign-manager

------
https://chatgpt.com/codex/tasks/task_e_68e779e08d64832199b09b457b1d93d0