### PR TITLE
Proxy campaign events to analytics backend

### DIFF
--- a/app/flashoffer/campaign-manager/backend/campaign_manager/app.py
+++ b/app/flashoffer/campaign-manager/backend/campaign_manager/app.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any, Dict
+
+import httpx
 from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.responses import FileResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -45,6 +48,20 @@ def _static_dir() -> Path:
     return Path(raw_path)
 
 
+def _analytics_recent_url() -> str:
+    raw_recent = os.getenv("CAMPAIGN_MANAGER_ANALYTICS_RECENT_URL", "").strip()
+    if raw_recent:
+        return raw_recent
+
+    raw_base = os.getenv("CAMPAIGN_MANAGER_ANALYTICS_BASE", "http://analytics-backend:8000").strip()
+    if not raw_base:
+        raise RuntimeError(
+            "CAMPAIGN_MANAGER_ANALYTICS_BASE must be configured with a valid URL",
+        )
+    base = raw_base.rstrip("/")
+    return f"{base}/events/recent"
+
+
 def _create_auth_manager() -> AuthManager:
     username = os.getenv("CAMPAIGN_MANAGER_ADMIN_USERNAME", "admin")
     return AuthManager(
@@ -73,12 +90,24 @@ def create_app() -> FastAPI:
 
     repository = _create_repository()
     auth_manager = _create_auth_manager()
+    analytics_url = _analytics_recent_url()
 
     repository.initialize()
     auth_manager.reload_password()
 
     app = FastAPI(title="Flashoffer Campaign Manager", version="0.1.0")
     security = HTTPBearer(auto_error=False)
+
+    analytics_client = httpx.AsyncClient(
+        timeout=httpx.Timeout(10.0, connect=5.0),
+        headers={"Accept": "application/json"},
+    )
+    app.state.analytics_recent_url = analytics_url
+    app.state.analytics_client = analytics_client
+
+    @app.on_event("shutdown")
+    async def _close_analytics_client() -> None:  # pragma: no cover - FastAPI handles lifecycle
+        await analytics_client.aclose()
 
     static_dir = _static_dir()
     assets_dir = static_dir / "assets"
@@ -180,6 +209,62 @@ def create_app() -> FastAPI:
                 detail="Failed to load updated campaign",
             )
         return _as_response(record)
+
+    @app.get("/api/campaigns/{campaign_id}/events")
+    async def campaign_events(
+        campaign_id: str,
+        limit: int | None = None,
+        _: str = Depends(_require_token),
+    ) -> Dict[str, Any]:
+        """Proxy recent engagement events from the analytics backend."""
+
+        normalized_id = campaign_id.strip()
+        if not normalized_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Campaign identifier must not be blank",
+            )
+
+        params = {"campaign_id": normalized_id}
+        if limit is not None:
+            sanitized = max(1, min(limit, 200))
+            params["limit"] = str(sanitized)
+
+        client: httpx.AsyncClient = app.state.analytics_client
+        analytics_recent_url: str = app.state.analytics_recent_url
+
+        try:
+            response = await client.get(analytics_recent_url, params=params)
+        except httpx.RequestError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"Failed to contact analytics backend: {exc}",
+            ) from exc
+
+        if response.status_code >= 400:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=(
+                    "Analytics backend returned unexpected status "
+                    f"{response.status_code}"
+                ),
+            )
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Analytics backend response was not valid JSON",
+            ) from exc
+
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Analytics backend response must be a JSON object",
+            )
+
+        return payload
 
     index_path = static_dir / "index.html"
 

--- a/app/flashoffer/campaign-manager/backend/requirements.txt
+++ b/app/flashoffer/campaign-manager/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.115.0
+httpx==0.27.2
 itsdangerous==2.2.0
 psycopg2-binary==2.9.9
 pydantic==2.9.2

--- a/app/flashoffer/campaign-manager/backend/tests/test_campaign_events_endpoint.py
+++ b/app/flashoffer/campaign-manager/backend/tests/test_campaign_events_endpoint.py
@@ -1,0 +1,149 @@
+# Copyright (c) Flashoffer Developers
+# Released under the MIT license.
+
+"""Tests for the campaign events proxy endpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from campaign_manager.app import create_app
+from campaign_manager.auth import InvalidTokenError
+
+
+class StubRepository:
+    """Minimal repository stub used for dependency injection."""
+
+    def initialize(self) -> None:
+        pass
+
+    def list_campaigns(self):
+        return []
+
+    def fetch_campaign(self, campaign_id: str):
+        return None
+
+    def upsert_campaign(self, *, campaign_id: str, name, end_time) -> None:
+        pass
+
+
+class StubAuthManager:
+    """Stub auth manager that accepts a fixed token."""
+
+    def __init__(self, token: str = "test-token") -> None:
+        self.token = token
+
+    def reload_password(self) -> None:
+        pass
+
+    def validate_token(self, token: str) -> None:
+        if token != self.token:
+            raise InvalidTokenError("Invalid token")
+
+    def verify_credentials(self, username: str, password: str) -> bool:
+        return True
+
+    def issue_token(self) -> tuple[str, str]:
+        return (self.token, "2099-01-01T00:00:00Z")
+
+
+@pytest.fixture
+def configured_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Configure the FastAPI app with stub dependencies for testing."""
+
+    repository = StubRepository()
+    auth_manager = StubAuthManager()
+
+    monkeypatch.setattr("campaign_manager.app._create_repository", lambda: repository)
+    monkeypatch.setattr("campaign_manager.app._create_auth_manager", lambda: auth_manager)
+    monkeypatch.setenv("CAMPAIGN_MANAGER_ANALYTICS_RECENT_URL", "http://analytics.test/events/recent")
+    monkeypatch.setenv("CAMPAIGN_MANAGER_STATIC_DIR", str(tmp_path))
+
+    app = create_app()
+    return app, auth_manager
+
+
+def _authorized_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_campaign_events_successfully_proxies_response(configured_app):
+    app, auth_manager = configured_app
+
+    async def fake_get(url: str, params=None, headers=None):
+        assert url == "http://analytics.test/events/recent"
+        assert params == {"campaign_id": "launch", "limit": "200"}
+        request = httpx.Request("GET", url)
+        return httpx.Response(status_code=200, json={"events": ["ok"]}, request=request)
+
+    app.state.analytics_client.get = fake_get  # type: ignore[assignment]
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/campaigns/launch/events?limit=500",
+            headers=_authorized_headers(auth_manager.token),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"events": ["ok"]}
+
+
+def test_campaign_events_returns_bad_gateway_on_error_status(configured_app):
+    app, auth_manager = configured_app
+
+    async def fake_get(url: str, params=None, headers=None):
+        request = httpx.Request("GET", url)
+        return httpx.Response(status_code=503, request=request)
+
+    app.state.analytics_client.get = fake_get  # type: ignore[assignment]
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/campaigns/spring-sale/events",
+            headers=_authorized_headers(auth_manager.token),
+        )
+
+    assert response.status_code == 502
+    assert "503" in response.json()["detail"]
+
+
+def test_campaign_events_handles_request_exceptions(configured_app):
+    app, auth_manager = configured_app
+
+    async def fake_get(url: str, params=None, headers=None):
+        request = httpx.Request("GET", url)
+        raise httpx.ConnectError("boom", request=request)
+
+    app.state.analytics_client.get = fake_get  # type: ignore[assignment]
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/campaigns/summer/events",
+            headers=_authorized_headers(auth_manager.token),
+        )
+
+    assert response.status_code == 502
+    assert "Failed to contact analytics backend" in response.json()["detail"]
+
+
+def test_campaign_events_rejects_non_object_payloads(configured_app):
+    app, auth_manager = configured_app
+
+    async def fake_get(url: str, params=None, headers=None):
+        request = httpx.Request("GET", url)
+        return httpx.Response(status_code=200, content=b"[]", request=request)
+
+    app.state.analytics_client.get = fake_get  # type: ignore[assignment]
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/campaigns/autumn/events",
+            headers=_authorized_headers(auth_manager.token),
+        )
+
+    assert response.status_code == 502
+    assert "JSON object" in response.json()["detail"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,6 +177,7 @@ services:
       context: .
       dockerfile: ./app/flashoffer/campaign-manager/Dockerfile
     environment:
+      CAMPAIGN_MANAGER_ANALYTICS_BASE: http://analytics-backend:8000
       DATABASE_HOST: analytics-db
       DATABASE_PORT: 5432
       DATABASE_USER: analytics


### PR DESCRIPTION
## Summary
- add an analytics proxy endpoint to the campaign manager API so event data comes from the analytics backend
- configure the FastAPI app to reuse a shared httpx client and expose analytics base URL settings via docker-compose
- add backend tests that exercise success and error paths for the new proxy endpoint

## Testing
- PYTHONPATH=app/flashoffer/campaign-manager/backend:app/flashoffer/backend-common:app/shell/py/pie pytest app/flashoffer/campaign-manager/backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68e7e38d14dc832197629a21f5a79554