### PR TITLE
Add EventConsole hook and component test coverage

### DIFF
--- a/app/flashoffer/flashoffer-react/src/analytics/EventConsole.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/EventConsole.tsx
@@ -3,9 +3,15 @@
  * Released under the MIT license.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import "./EventConsole.css";
+
+import {
+  type CapturedEvent,
+  type ConsoleStatus,
+  useEventStream,
+} from "./hooks/useEventStream";
 
 /**
  * Properties for configuring the `EventConsole` component.
@@ -22,19 +28,11 @@ export interface EventConsoleProps {
   authToken?: string;
 }
 
-interface CapturedEvent {
-  id: string;
-  event_type: string;
-  target: string;
-  occurred_at: string;
-  received_at: string;
-  site: string;
-  session_id: string;
-  meta?: Record<string, unknown>;
-}
-
-type ConsoleStatus = "idle" | "connecting" | "updating" | "live" | "error";
-
+/**
+ * Format a timestamp for display within the event console.
+ *
+ * @param value - ISO timestamp or compatible string.
+ */
 function formatTime(value: string | null | undefined): string {
   if (!value) {
     return "—";
@@ -50,6 +48,12 @@ function formatTime(value: string | null | undefined): string {
   });
 }
 
+/**
+ * Calculate a human-readable latency between two timestamps.
+ *
+ * @param occurredAt - ISO timestamp indicating when the event occurred.
+ * @param receivedAt - ISO timestamp indicating when the event was captured.
+ */
 function describeLatency(occurredAt: string, receivedAt: string): string | null {
   const occurred = new Date(occurredAt);
   const received = new Date(receivedAt);
@@ -66,24 +70,6 @@ function describeLatency(occurredAt: string, receivedAt: string): string | null 
   return `${Math.round(delta / 60000)} min`;
 }
 
-function isAbortError(error: unknown): boolean {
-  return (
-    !!error &&
-    typeof error === "object" &&
-    "name" in error &&
-    (error as { name?: string }).name === "AbortError"
-  );
-}
-
-function extractEvents(
-  data: { events?: CapturedEvent[] } | undefined
-): CapturedEvent[] {
-  if (!data || !Array.isArray(data.events)) {
-    return [];
-  }
-  return data.events as CapturedEvent[];
-}
-
 /**
  * Render a live-updating console of campaign events fetched from the backend.
  */
@@ -93,126 +79,23 @@ export function EventConsole({
   limit = 25,
   authToken,
 }: EventConsoleProps) {
-  const [events, setEvents] = useState<CapturedEvent[]>([]);
-  const [status, setStatus] = useState<ConsoleStatus>("idle");
-  const [error, setError] = useState<Error | null>(null);
-  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
-
-  const applyLimitParam = useCallback(
-    (url: URL) => {
-      if (limit && !url.searchParams.has("limit")) {
-        url.searchParams.set("limit", String(limit));
-      }
-    },
-    [limit]
-  );
-
-  const handleLoadSuccess = useCallback((payload: CapturedEvent[]) => {
-    setEvents(payload);
-    setLastUpdated(new Date().toISOString());
-    setStatus("live");
-    setError(null);
-  }, []);
-
-  const handleLoadFailure = useCallback((cause: unknown) => {
-    setStatus("error");
-    setError(cause instanceof Error ? cause : new Error(String(cause)));
-  }, []);
-
-  useEffect(() => {
-    if (!eventsUrl) {
-      return () => undefined;
-    }
-
-    let cancelled = false;
-    let controller = new AbortController();
-
-    const load = async () => {
-      controller.abort();
-      controller = new AbortController();
-      try {
-        setStatus((current) => (current === "idle" ? "connecting" : "updating"));
-        const url = new URL(eventsUrl, window.location.href);
-        applyLimitParam(url);
-        const response = await fetch(url, {
-          credentials: "include",
-          signal: controller.signal,
-          headers: authToken ? { Authorization: `Bearer ${authToken}` } : undefined,
-        });
-        if (!response.ok) {
-          throw new Error(`Request failed with status ${response.status}`);
-        }
-        const data = (await response.json()) as { events?: CapturedEvent[] };
-        if (cancelled) {
-          return;
-        }
-        handleLoadSuccess(extractEvents(data));
-      } catch (err) {
-        if (cancelled || isAbortError(err)) {
-          return;
-        }
-        handleLoadFailure(err);
-      }
-    };
-
-    void load();
-    const interval = window.setInterval(() => {
-      void load();
-    }, pollInterval);
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-      window.clearInterval(interval);
-    };
-  }, [
-    applyLimitParam,
-    authToken,
+  const { events, status, error, lastUpdated } = useEventStream({
     eventsUrl,
-    handleLoadFailure,
-    handleLoadSuccess,
     pollInterval,
-  ]);
+    limit,
+    authToken,
+  });
 
-  const summary = useMemo(() => {
-    if (events.length === 0) {
-      return "Waiting for events… Scroll the page or click a call to action.";
-    }
-    const types = new Map<string, number>();
-    events.forEach((event) => {
-      const next = (types.get(event.event_type) || 0) + 1;
-      types.set(event.event_type, next);
-    });
-    const parts = Array.from(types.entries()).map(([type, count]) => `${count} ${type}`);
-    return `Showing ${events.length} recent events (${parts.join(", ")})`;
-  }, [events]);
-
-  const statusLabel = useMemo(() => {
-    switch (status) {
-      case "live":
-        return "Live";
-      case "updating":
-        return "Updating…";
-      case "connecting":
-        return "Connecting…";
-      case "error":
-        return "Error";
-      default:
-        return "Idle";
-    }
-  }, [status]);
+  const summary = useMemo(() => buildSummary(events), [events]);
+  const statusLabel = useMemo(() => getStatusLabel(status), [status]);
 
   return (
     <section className="event-console" aria-live="polite">
-      <header className="event-console__header">
-        <div>
-          <h2>Captured events</h2>
-          <p className="event-console__summary">{summary}</p>
-        </div>
-        <div className={`event-console__badge event-console__badge--${status}`}>
-          {statusLabel}
-        </div>
-      </header>
+      <EventConsoleStatusHeader
+        summary={summary}
+        status={status}
+        statusLabel={statusLabel}
+      />
 
       {error ? (
         <p className="event-console__error">
@@ -220,48 +103,135 @@ export function EventConsole({
         </p>
       ) : null}
 
-      <ul className="event-console__list">
-        {events.map((event) => {
-          const latency = describeLatency(event.occurred_at, event.received_at);
-          return (
-            <li key={event.id} className={`event-card event-card--${event.event_type}`}>
-              <div className="event-card__meta">
-                <span className="event-card__type">{event.event_type}</span>
-                <span className="event-card__target">{event.target}</span>
-                <span className="event-card__time" title={event.occurred_at}>
-                  {formatTime(event.occurred_at)}
-                </span>
-                {latency ? <span className="event-card__latency">+{latency}</span> : null}
-              </div>
-              <dl className="event-card__details">
-                <div>
-                  <dt>Site</dt>
-                  <dd>{event.site}</dd>
-                </div>
-                <div>
-                  <dt>Session</dt>
-                  <dd>{event.session_id}</dd>
-                </div>
-                <div>
-                  <dt>Received</dt>
-                  <dd title={event.received_at}>{formatTime(event.received_at)}</dd>
-                </div>
-              </dl>
-              <pre className="event-card__payload">
-                {JSON.stringify(event.meta ?? {}, null, 2)}
-              </pre>
-            </li>
-          );
-        })}
-      </ul>
+      <EventConsoleEventList events={events} />
 
-      <footer className="event-console__footer">
-        <span>
-          Last update {lastUpdated ? formatTime(lastUpdated) : "—"}
-        </span>
-      </footer>
+      <EventConsoleFooter lastUpdated={lastUpdated} />
     </section>
   );
+}
+
+/**
+ * Render the header summarizing the event stream status.
+ *
+ * @param summary - Narrative description of the current event selection.
+ * @param status - Connectivity status for the stream.
+ * @param statusLabel - Human-readable label describing {@link status}.
+ */
+function EventConsoleStatusHeader({
+  summary,
+  status,
+  statusLabel,
+}: {
+  summary: string;
+  status: ConsoleStatus;
+  statusLabel: string;
+}) {
+  return (
+    <header className="event-console__header">
+      <div>
+        <h2>Captured events</h2>
+        <p className="event-console__summary">{summary}</p>
+      </div>
+      <div className={`event-console__badge event-console__badge--${status}`}>
+        {statusLabel}
+      </div>
+    </header>
+  );
+}
+
+/**
+ * List captured events using the canonical console styling.
+ *
+ * @param events - Event payloads to display.
+ */
+function EventConsoleEventList({ events }: { events: CapturedEvent[] }) {
+  return (
+    <ul className="event-console__list">
+      {events.map((event) => {
+        const latency = describeLatency(event.occurred_at, event.received_at);
+        return (
+          <li key={event.id} className={`event-card event-card--${event.event_type}`}>
+            <div className="event-card__meta">
+              <span className="event-card__type">{event.event_type}</span>
+              <span className="event-card__target">{event.target}</span>
+              <span className="event-card__time" title={event.occurred_at}>
+                {formatTime(event.occurred_at)}
+              </span>
+              {latency ? <span className="event-card__latency">+{latency}</span> : null}
+            </div>
+            <dl className="event-card__details">
+              <div>
+                <dt>Site</dt>
+                <dd>{event.site}</dd>
+              </div>
+              <div>
+                <dt>Session</dt>
+                <dd>{event.session_id}</dd>
+              </div>
+              <div>
+                <dt>Received</dt>
+                <dd title={event.received_at}>{formatTime(event.received_at)}</dd>
+              </div>
+            </dl>
+            <pre className="event-card__payload">
+              {JSON.stringify(event.meta ?? {}, null, 2)}
+            </pre>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/**
+ * Present the timestamp of the most recent event update.
+ *
+ * @param lastUpdated - ISO timestamp representing the latest poll completion.
+ */
+function EventConsoleFooter({ lastUpdated }: { lastUpdated: string | null }) {
+  return (
+    <footer className="event-console__footer">
+      <span>Last update {lastUpdated ? formatTime(lastUpdated) : "—"}</span>
+    </footer>
+  );
+}
+
+/**
+ * Build a human-readable summary of the captured event stream.
+ *
+ * @param events - Events currently displayed in the console.
+ */
+function buildSummary(events: CapturedEvent[]): string {
+  if (events.length === 0) {
+    return "Waiting for events… Scroll the page or click a call to action.";
+  }
+  const types = new Map<string, number>();
+  events.forEach((event) => {
+    const next = (types.get(event.event_type) || 0) + 1;
+    types.set(event.event_type, next);
+  });
+  const parts = Array.from(types.entries()).map(([type, count]) => `${count} ${type}`);
+  return `Showing ${events.length} recent events (${parts.join(", ")})`;
+}
+
+/**
+ * Compute the label describing the current event stream status.
+ *
+ * @param status - Machine-readable connection status indicator.
+ */
+function getStatusLabel(status: ConsoleStatus): string {
+  switch (status) {
+    case "live":
+      return "Live";
+    case "updating":
+      return "Updating…";
+    case "connecting":
+      return "Connecting…";
+    case "error":
+      return "Error";
+    default:
+      return "Idle";
+  }
 }
 
 export default EventConsole;

--- a/app/flashoffer/flashoffer-react/src/analytics/__tests__/EventConsole.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/__tests__/EventConsole.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
+import { render, screen } from "@testing-library/react";
+import type { MockedFunction } from "jest-mock";
+
+import type { CapturedEvent } from "../hooks/useEventStream";
+import EventConsole from "../EventConsole";
+import { useEventStream } from "../hooks/useEventStream";
+
+jest.mock("../hooks/useEventStream");
+
+const useEventStreamMock = useEventStream as MockedFunction<
+  typeof useEventStream
+>;
+
+/**
+ * Provide a deterministic captured event for component rendering tests.
+ */
+function sampleEvent(): CapturedEvent {
+  return {
+    id: "evt-99",
+    event_type: "cta_click",
+    target: "hero",
+    occurred_at: "2024-02-01T10:00:00.000Z",
+    received_at: "2024-02-01T10:00:01.500Z",
+    site: "flashoffer.example",
+    session_id: "session-99",
+    meta: { campaign: "winter" },
+  };
+}
+
+describe("EventConsole", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the captured events and status header", () => {
+    useEventStreamMock.mockReturnValue({
+      events: [sampleEvent()],
+      status: "connecting",
+      error: null,
+      lastUpdated: "2024-02-01T10:00:02.000Z",
+    });
+
+    render(
+      <EventConsole
+        eventsUrl="/events"
+        pollInterval={1_000}
+        limit={5}
+        authToken="token"
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "Captured events" })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Showing 1 recent events (1 cta_click)",
+        { exact: false }
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText("Connecting…")).toBeInTheDocument();
+    expect(screen.getByText("cta_click")).toBeInTheDocument();
+    expect(screen.getByText("hero")).toBeInTheDocument();
+    expect(screen.getByText("session-99")).toBeInTheDocument();
+    const footer = screen.getByText(/Last update/);
+    expect(footer).toBeInTheDocument();
+    expect(footer.textContent).toContain("10:00:02");
+  });
+
+  it("displays an error message when the stream reports a failure", () => {
+    useEventStreamMock.mockReturnValue({
+      events: [],
+      status: "error",
+      error: new Error("unavailable"),
+      lastUpdated: null,
+    });
+
+    render(
+      <EventConsole eventsUrl="/events" pollInterval={1_000} limit={5} />
+    );
+
+    expect(
+      screen.getByText("Failed to load events: unavailable")
+    ).toBeInTheDocument();
+  });
+});

--- a/app/flashoffer/flashoffer-react/src/analytics/__tests__/useEventStream.test.ts
+++ b/app/flashoffer/flashoffer-react/src/analytics/__tests__/useEventStream.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { useEventStream, type CapturedEvent } from "../hooks/useEventStream";
+
+/**
+ * Create a representative captured event for testing.
+ *
+ * @param override - Optional event field overrides.
+ */
+function createEvent(
+  override: Partial<CapturedEvent> = {}
+): CapturedEvent {
+  return {
+    id: "evt-1",
+    event_type: "cta_click",
+    target: "checkout",
+    occurred_at: "2024-01-01T00:00:00.000Z",
+    received_at: "2024-01-01T00:00:01.000Z",
+    site: "flashoffer.test",
+    session_id: "session-1",
+    meta: { foo: "bar" },
+    ...override,
+  };
+}
+
+describe("useEventStream", () => {
+  const globalScope = globalThis as typeof globalThis & {
+    fetch?: typeof fetch;
+  };
+  const originalFetch = globalScope.fetch;
+
+  afterEach(() => {
+    globalScope.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("polls the backend endpoint and updates the hook state", async () => {
+    const events = [createEvent({ id: "evt-42" })];
+    const fetchMock = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ events }),
+    })) as jest.MockedFunction<typeof fetch>;
+    globalScope.fetch = fetchMock;
+
+    const { result, unmount } = renderHook(() =>
+      useEventStream({
+        eventsUrl: "/analytics/events",
+        pollInterval: 12_000,
+        limit: 50,
+        authToken: "secret-token",
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("live");
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [requestUrl, options] = fetchMock.mock.calls[0] ?? [];
+    expect(String(requestUrl)).toBe(
+      "http://localhost/analytics/events?limit=50"
+    );
+    expect(options?.headers).toEqual({
+      Authorization: "Bearer secret-token",
+    });
+    expect(result.current.events).toEqual(events);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastUpdated).not.toBeNull();
+
+    unmount();
+  });
+
+  it("resets to an idle state when the events URL is cleared", async () => {
+    const fetchMock = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ events: [createEvent()] }),
+    })) as jest.MockedFunction<typeof fetch>;
+    globalScope.fetch = fetchMock;
+
+    const { result, rerender, unmount } = renderHook(
+      (props: {
+        eventsUrl?: string;
+      }) =>
+        useEventStream({
+          eventsUrl: props.eventsUrl,
+          pollInterval: 3_000,
+        }),
+      {
+        initialProps: { eventsUrl: "/events" },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("live");
+    });
+
+    rerender({ eventsUrl: undefined });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("idle");
+    });
+
+    expect(result.current.events).toHaveLength(0);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastUpdated).toBeNull();
+
+    unmount();
+  });
+});

--- a/app/flashoffer/flashoffer-react/src/analytics/hooks/useEventStream.ts
+++ b/app/flashoffer/flashoffer-react/src/analytics/hooks/useEventStream.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type ConsoleStatus = "idle" | "connecting" | "updating" | "live" | "error";
+
+interface CapturedEvent {
+  id: string;
+  event_type: string;
+  target: string;
+  occurred_at: string;
+  received_at: string;
+  site: string;
+  session_id: string;
+  meta?: Record<string, unknown>;
+}
+
+interface EventStreamState {
+  events: CapturedEvent[];
+  status: ConsoleStatus;
+  error: Error | null;
+  lastUpdated: string | null;
+}
+
+interface EventStreamOptions {
+  eventsUrl?: string;
+  pollInterval?: number;
+  limit?: number;
+  authToken?: string;
+}
+
+/**
+ * Determine whether an error resulted from aborting a fetch request.
+ *
+ * @param error - Error thrown by a fetch request.
+ */
+function isAbortError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "name" in error &&
+    (error as { name?: string }).name === "AbortError"
+  );
+}
+
+/**
+ * Extract captured events from the backend response payload.
+ *
+ * @param data - Raw JSON payload returned by the backend.
+ */
+function extractEvents(
+  data: { events?: CapturedEvent[] } | undefined
+): CapturedEvent[] {
+  if (!data || !Array.isArray(data.events)) {
+    return [];
+  }
+  return data.events as CapturedEvent[];
+}
+
+/**
+ * Poll a backend endpoint for Flashoffer events while tracking request state.
+ *
+ * @param options - Configuration options for the event stream.
+ */
+export function useEventStream({
+  eventsUrl,
+  pollInterval = 3000,
+  limit = 25,
+  authToken,
+}: EventStreamOptions): EventStreamState {
+  const [events, setEvents] = useState<CapturedEvent[]>([]);
+  const [status, setStatus] = useState<ConsoleStatus>("idle");
+  const [error, setError] = useState<Error | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!eventsUrl) {
+      controllerRef.current?.abort();
+      controllerRef.current = null;
+      setEvents([]);
+      setStatus("idle");
+      setError(null);
+      setLastUpdated(null);
+      return () => undefined;
+    }
+
+    let cancelled = false;
+
+    /**
+     * Cancel any pending fetch request before issuing a new poll.
+     */
+    const abortOngoing = () => {
+      controllerRef.current?.abort();
+      controllerRef.current = new AbortController();
+    };
+
+    /**
+     * Ensure the request URL includes the configured result limit.
+     *
+     * @param url - Request URL prior to dispatching fetch.
+     */
+    const applyLimitParam = (url: URL) => {
+      if (limit && !url.searchParams.has("limit")) {
+        url.searchParams.set("limit", String(limit));
+      }
+    };
+
+    /**
+     * Apply event results from a successful polling request.
+     *
+     * @param payload - Event payload returned by the backend.
+     */
+    const handleLoadSuccess = (payload: CapturedEvent[]) => {
+      if (cancelled) {
+        return;
+      }
+      setEvents(payload);
+      setLastUpdated(new Date().toISOString());
+      setStatus("live");
+      setError(null);
+    };
+
+    /**
+     * Transition to an error state when polling fails.
+     *
+     * @param cause - Error thrown while attempting to poll events.
+     */
+    const handleLoadFailure = (cause: unknown) => {
+      if (cancelled || isAbortError(cause)) {
+        return;
+      }
+      setStatus("error");
+      setError(cause instanceof Error ? cause : new Error(String(cause)));
+    };
+
+    /**
+     * Fetch the most recent events from the backend endpoint.
+     */
+    const load = async () => {
+      abortOngoing();
+      const controller = controllerRef.current;
+      try {
+        setStatus((current) => (current === "idle" ? "connecting" : "updating"));
+        const url = new URL(eventsUrl, window.location.href);
+        applyLimitParam(url);
+        const response = await fetch(url, {
+          credentials: "include",
+          signal: controller?.signal,
+          headers: authToken
+            ? { Authorization: `Bearer ${authToken}` }
+            : undefined,
+        });
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        const data = (await response.json()) as { events?: CapturedEvent[] };
+        handleLoadSuccess(extractEvents(data));
+      } catch (err) {
+        handleLoadFailure(err);
+      }
+    };
+
+    void load();
+    const interval = window.setInterval(() => {
+      void load();
+    }, pollInterval);
+
+    return () => {
+      cancelled = true;
+      controllerRef.current?.abort();
+      window.clearInterval(interval);
+    };
+  }, [authToken, eventsUrl, limit, pollInterval]);
+
+  return useMemo(
+    () => ({
+      events,
+      status,
+      error,
+      lastUpdated,
+    }),
+    [events, status, error, lastUpdated]
+  );
+}
+
+export type { CapturedEvent, ConsoleStatus, EventStreamState };


### PR DESCRIPTION
## Summary
- add unit tests covering useEventStream polling behaviour, request configuration, and idle resets
- add EventConsole rendering tests that validate summary text, status badges, and error messaging with mocked stream data

## Testing
- npm test -- --runTestsByPath src/analytics/__tests__/useEventStream.test.ts src/analytics/__tests__/EventConsole.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e7e3726aa883219ae6ec873ec91e97