### PR TITLE
Standardize Flashoffer Docker stage names

### DIFF
--- a/app/flashoffer/AGENTS.md
+++ b/app/flashoffer/AGENTS.md
@@ -8,6 +8,8 @@
   theme provider.
 - Persist all timestamps in Coordinated Universal Time (UTC).
 - Convert UTC timestamps to a viewer's local timezone before displaying them.
+- Docker multi-stage builds must name development targets `dev` and production
+  targets `prod`.
 
 ## Flashoffer React Components
 

--- a/app/flashoffer/campaign-manager/Dockerfile
+++ b/app/flashoffer/campaign-manager/Dockerfile
@@ -114,7 +114,7 @@ EXPOSE 4173 5174
 
 ENTRYPOINT ["/workspace/dev-entrypoint.sh"]
 
-FROM backend-base AS production
+FROM backend-base AS prod
 
 RUN --mount=type=cache,target=/var/cache/apt,id=flashoffer-campaign-manager-prod \
     --mount=type=cache,target=/var/lib/apt/lists,id=flashoffer-campaign-manager-prod \

--- a/app/flashoffer/flashoffer-demo/Dockerfile
+++ b/app/flashoffer/flashoffer-demo/Dockerfile
@@ -36,7 +36,7 @@ RUN npm run build
 
 # Runtime image for running the demo via the Vite preview server. This is
 # primarily used for local development or integration tests.
-FROM node:22-slim AS runner
+FROM node:22-slim AS dev
 ENV NODE_ENV=production
 ENV PORT=4173
 WORKDIR /workspace
@@ -49,7 +49,7 @@ ENTRYPOINT ["flashoffer-entrypoint"]
 
 # Production image served by nginx. Only the static assets are copied in,
 # keeping the container small and secure.
-FROM nginx:1.27-alpine AS production
+FROM nginx:1.27-alpine AS prod
 WORKDIR /usr/share/nginx/html
 COPY app/flashoffer/flashoffer-demo/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=flashoffer-demo-build /workspace/app/flashoffer/build/static/js ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,7 +204,7 @@ services:
     build:
       context: .
       dockerfile: ./app/flashoffer/flashoffer-demo/Dockerfile
-      target: production
+      target: prod
     environment:
       PORT: ${FLASHOFFER_PORT:-4173}
       VITE_FLASHOFFER_ANALYTICS_ENDPOINT: ${FLASHOFFER_ANALYTICS_ENDPOINT:-http://localhost:8001/events}


### PR DESCRIPTION
## Summary
- document the dev/prod docker stage naming convention for Flashoffer assets
- rename Flashoffer Dockerfile targets to dev/prod and update docker-compose to match

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7fd8d53d08321bf1c5bafdd594926