### PR TITLE
Add campaign-aware quiz analytics to campaign manager

### DIFF
--- a/app/flashoffer/campaign-manager/backend/campaign_manager/app.py
+++ b/app/flashoffer/campaign-manager/backend/campaign_manager/app.py
@@ -5,9 +5,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import httpx
 from fastapi import Depends, FastAPI, HTTPException, status
@@ -62,6 +63,20 @@ def _analytics_recent_url() -> str:
     return f"{base}/events/recent"
 
 
+def _quiz_recent_url() -> str:
+    raw_recent = os.getenv("CAMPAIGN_MANAGER_QUIZ_RECENT_URL", "").strip()
+    if raw_recent:
+        return raw_recent
+
+    raw_base = os.getenv("CAMPAIGN_MANAGER_QUIZ_BASE", "http://quiz-backend:8080").strip()
+    if not raw_base:
+        raise RuntimeError(
+            "CAMPAIGN_MANAGER_QUIZ_BASE must be configured with a valid URL",
+        )
+    base = raw_base.rstrip("/")
+    return f"{base}/api/events/quiz"
+
+
 def _create_auth_manager() -> AuthManager:
     username = os.getenv("CAMPAIGN_MANAGER_ADMIN_USERNAME", "admin")
     return AuthManager(
@@ -91,6 +106,7 @@ def create_app() -> FastAPI:
     repository = _create_repository()
     auth_manager = _create_auth_manager()
     analytics_url = _analytics_recent_url()
+    quiz_url = _quiz_recent_url()
 
     repository.initialize()
     auth_manager.reload_password()
@@ -103,6 +119,7 @@ def create_app() -> FastAPI:
         headers={"Accept": "application/json"},
     )
     app.state.analytics_recent_url = analytics_url
+    app.state.quiz_recent_url = quiz_url
     app.state.analytics_client = analytics_client
 
     @app.on_event("shutdown")
@@ -225,46 +242,80 @@ def create_app() -> FastAPI:
                 detail="Campaign identifier must not be blank",
             )
 
-        params = {"campaign_id": normalized_id}
+        sanitized = 25
         if limit is not None:
             sanitized = max(1, min(limit, 200))
-            params["limit"] = str(sanitized)
+
+        params = {"campaign_id": normalized_id, "limit": str(sanitized)}
 
         client: httpx.AsyncClient = app.state.analytics_client
         analytics_recent_url: str = app.state.analytics_recent_url
+        quiz_recent_url: str = app.state.quiz_recent_url
 
         try:
-            response = await client.get(analytics_recent_url, params=params)
+            analytics_response, quiz_response = await asyncio.gather(
+                client.get(analytics_recent_url, params=params.copy()),
+                client.get(quiz_recent_url, params=params.copy()),
+            )
         except httpx.RequestError as exc:
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=f"Failed to contact analytics backend: {exc}",
+                detail=f"Failed to contact analytics services: {exc}",
             ) from exc
 
-        if response.status_code >= 400:
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=(
-                    "Analytics backend returned unexpected status "
-                    f"{response.status_code}"
-                ),
-            )
+        for backend, response in (
+            ("Analytics", analytics_response),
+            ("Quiz", quiz_response),
+        ):
+            if response.status_code >= 400:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=f"{backend} backend returned unexpected status {response.status_code}",
+                )
 
         try:
-            payload = response.json()
+            analytics_payload = analytics_response.json()
         except ValueError as exc:
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail="Analytics backend response was not valid JSON",
             ) from exc
 
-        if not isinstance(payload, dict):
+        try:
+            quiz_payload = quiz_response.json()
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Quiz backend response was not valid JSON",
+            ) from exc
+
+        if not isinstance(analytics_payload, dict):
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail="Analytics backend response must be a JSON object",
             )
+        if not isinstance(quiz_payload, dict):
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Quiz backend response must be a JSON object",
+            )
 
-        return payload
+        engagement_events: List[Dict[str, Any]] = []
+        raw_events = analytics_payload.get("events")
+        if isinstance(raw_events, list):
+            engagement_events = [event for event in raw_events if isinstance(event, dict)]
+
+        quiz_results: List[Dict[str, Any]] = []
+        raw_quiz_results = quiz_payload.get("results")
+        if isinstance(raw_quiz_results, list):
+            quiz_results = [result for result in raw_quiz_results if isinstance(result, dict)]
+
+        combined: List[Dict[str, Any]] = []
+        combined.extend(engagement_events)
+        combined.extend(_convert_quiz_result(result) for result in quiz_results)
+        combined.sort(key=_event_sort_key, reverse=True)
+
+        return {"events": combined[:sanitized]}
 
     index_path = static_dir / "index.html"
 
@@ -281,6 +332,49 @@ def create_app() -> FastAPI:
         return FileResponse(index_path)
 
     return app
+
+
+def _convert_quiz_result(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert quiz completion records into the console event schema."""
+
+    payload = result.get("payload") or {}
+    meta: Dict[str, Any] = {
+        "quiz_id": result.get("quiz_id"),
+        "user_id": result.get("user_id"),
+        "attempt_id": result.get("attempt_id"),
+        "campaign_id": result.get("campaign_id"),
+        "attempts": result.get("attempts"),
+        "passes": result.get("passes"),
+        "fails": result.get("fails"),
+        "payload": payload,
+    }
+    cleaned_meta = {key: value for key, value in meta.items() if value is not None or key == "payload"}
+
+    occurred_at = result.get("occurred_at")
+    received_at = result.get("received_at") or occurred_at
+
+    return {
+        "id": f"quiz-{result.get('id')}",
+        "event_type": "quiz-complete",
+        "target": result.get("quiz_id") or "quiz",
+        "occurred_at": occurred_at,
+        "received_at": received_at,
+        "site": "quiz-service",
+        "session_id": result.get("user_id") or "unknown-user",
+        "meta": cleaned_meta,
+    }
+
+
+def _event_sort_key(event: Dict[str, Any]) -> str:
+    """Return the timestamp used when ordering mixed event streams."""
+
+    received_at = event.get("received_at")
+    occurred_at = event.get("occurred_at")
+    if isinstance(received_at, str):
+        return received_at
+    if isinstance(occurred_at, str):
+        return occurred_at
+    return ""
 
 
 def _normalize_name(name: str | None) -> str | None:

--- a/app/flashoffer/campaign-manager/backend/tests/test_campaign_events_endpoint.py
+++ b/app/flashoffer/campaign-manager/backend/tests/test_campaign_events_endpoint.py
@@ -61,6 +61,7 @@ def configured_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setattr("campaign_manager.app._create_repository", lambda: repository)
     monkeypatch.setattr("campaign_manager.app._create_auth_manager", lambda: auth_manager)
     monkeypatch.setenv("CAMPAIGN_MANAGER_ANALYTICS_RECENT_URL", "http://analytics.test/events/recent")
+    monkeypatch.setenv("CAMPAIGN_MANAGER_QUIZ_RECENT_URL", "http://quiz.test/api/events/quiz")
     monkeypatch.setenv("CAMPAIGN_MANAGER_STATIC_DIR", str(tmp_path))
 
     app = create_app()
@@ -75,10 +76,44 @@ def test_campaign_events_successfully_proxies_response(configured_app):
     app, auth_manager = configured_app
 
     async def fake_get(url: str, params=None, headers=None):
-        assert url == "http://analytics.test/events/recent"
         assert params == {"campaign_id": "launch", "limit": "200"}
-        request = httpx.Request("GET", url)
-        return httpx.Response(status_code=200, json={"events": ["ok"]}, request=request)
+        request = httpx.Request("GET", url, params=params)
+        if url == "http://analytics.test/events/recent":
+            payload = {
+                "events": [
+                    {
+                        "id": "eng-1",
+                        "event_type": "cta_click",
+                        "target": "hero",
+                        "occurred_at": "2024-04-01T12:00:00Z",
+                        "received_at": "2024-04-01T12:00:01Z",
+                        "site": "press",
+                        "session_id": "sess-1",
+                        "meta": {"cta": "hero"},
+                    }
+                ]
+            }
+            return httpx.Response(status_code=200, json=payload, request=request)
+        if url == "http://quiz.test/api/events/quiz":
+            payload = {
+                "results": [
+                    {
+                        "id": 42,
+                        "quiz_id": "knowledge-check",
+                        "user_id": "user-7",
+                        "attempt_id": "attempt-9",
+                        "campaign_id": "launch",
+                        "occurred_at": "2024-04-01T11:59:59Z",
+                        "received_at": "2024-04-01T12:00:00Z",
+                        "attempts": 1,
+                        "passes": 1,
+                        "fails": 0,
+                        "payload": {"score": 100},
+                    }
+                ]
+            }
+            return httpx.Response(status_code=200, json=payload, request=request)
+        raise AssertionError(f"Unexpected URL {url}")
 
     app.state.analytics_client.get = fake_get  # type: ignore[assignment]
 
@@ -89,15 +124,29 @@ def test_campaign_events_successfully_proxies_response(configured_app):
         )
 
     assert response.status_code == 200
-    assert response.json() == {"events": ["ok"]}
+    data = response.json()
+    assert len(data["events"]) == 2
+    assert data["events"][0]["id"] == "eng-1"
+    quiz_event = next(event for event in data["events"] if event["event_type"] == "quiz-complete")
+    assert quiz_event["id"] == "quiz-42"
+    assert quiz_event["target"] == "knowledge-check"
+    assert quiz_event["session_id"] == "user-7"
+    assert quiz_event["meta"]["campaign_id"] == "launch"
+    assert quiz_event["meta"]["payload"] == {"score": 100}
 
 
 def test_campaign_events_returns_bad_gateway_on_error_status(configured_app):
     app, auth_manager = configured_app
 
     async def fake_get(url: str, params=None, headers=None):
-        request = httpx.Request("GET", url)
-        return httpx.Response(status_code=503, request=request)
+        request = httpx.Request("GET", url, params=params)
+        if url == "http://analytics.test/events/recent":
+            return httpx.Response(status_code=503, request=request)
+        return httpx.Response(
+            status_code=200,
+            json={"results": []},
+            request=request,
+        )
 
     app.state.analytics_client.get = fake_get  # type: ignore[assignment]
 
@@ -115,7 +164,7 @@ def test_campaign_events_handles_request_exceptions(configured_app):
     app, auth_manager = configured_app
 
     async def fake_get(url: str, params=None, headers=None):
-        request = httpx.Request("GET", url)
+        request = httpx.Request("GET", url, params=params)
         raise httpx.ConnectError("boom", request=request)
 
     app.state.analytics_client.get = fake_get  # type: ignore[assignment]
@@ -127,14 +176,16 @@ def test_campaign_events_handles_request_exceptions(configured_app):
         )
 
     assert response.status_code == 502
-    assert "Failed to contact analytics backend" in response.json()["detail"]
+    assert "analytics services" in response.json()["detail"]
 
 
 def test_campaign_events_rejects_non_object_payloads(configured_app):
     app, auth_manager = configured_app
 
     async def fake_get(url: str, params=None, headers=None):
-        request = httpx.Request("GET", url)
+        request = httpx.Request("GET", url, params=params)
+        if url == "http://analytics.test/events/recent":
+            return httpx.Response(status_code=200, json={"events": []}, request=request)
         return httpx.Response(status_code=200, content=b"[]", request=request)
 
     app.state.analytics_client.get = fake_get  # type: ignore[assignment]

--- a/app/flashoffer/campaign-manager/src/components/CampaignDashboard.tsx
+++ b/app/flashoffer/campaign-manager/src/components/CampaignDashboard.tsx
@@ -149,7 +149,7 @@ export const CampaignDashboard = ({
     eventPaneContent = (
       <Stack spacing={1.5} alignItems="center" justifyContent="center" sx={{ py: 6 }}>
         <Typography variant="h6" align="center">
-          Select a campaign to monitor events
+          Select a campaign to monitor engagement and quiz completions
         </Typography>
         <Typography variant="body2" color="text.secondary" align="center">
           Choose a row above to review the most recent activity captured for that campaign.
@@ -169,7 +169,7 @@ export const CampaignDashboard = ({
       <SectionHeader
         eyebrow="Campaigns"
         title="Manage Flashoffer campaign metadata"
-        subtitle="Create new campaigns or adjust deadlines in UTC while reviewing details in your local timezone."
+        subtitle="Create new campaigns or adjust deadlines in UTC while reviewing activity in your local timezone."
       />
       <Stack direction={{ xs: "column", sm: "row" }} spacing={2} justifyContent="space-between">
         <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems="center">

--- a/app/flashoffer/flashoffer-demo/src/quizAnalytics.ts
+++ b/app/flashoffer/flashoffer-demo/src/quizAnalytics.ts
@@ -66,6 +66,7 @@ export interface QuizCompletionPayload {
   isCorrect?: boolean;
   question: string;
   attempt: number;
+  campaignId?: string;
 }
 
 export async function logQuizCompletion(
@@ -90,6 +91,7 @@ export async function logQuizCompletion(
       attempt: payload.attempt,
     },
     occurred_at: new Date().toISOString(),
+    ...(payload.campaignId ? { campaign_id: payload.campaignId } : {}),
   };
 
   try {

--- a/app/flashoffer/flashoffer-demo/src/sections/QuizShowcaseSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/QuizShowcaseSection.tsx
@@ -53,6 +53,7 @@ export function QuizShowcaseSection() {
       selectedOptionId: answer.optionId,
       correctOptionId: "reminder",
       isCorrect: answer.isCorrect,
+      campaignId: "flashoffer-demo",
     });
   };
 

--- a/app/flashoffer/quiz-backend/quiz_backend/app.py
+++ b/app/flashoffer/quiz-backend/quiz_backend/app.py
@@ -58,6 +58,12 @@ def _load_quiz_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     if attempt_id is not None:
         attempt_id = str(attempt_id)
 
+    campaign_id = payload.get("campaign_id")
+    if campaign_id is not None:
+        campaign_id = str(campaign_id).strip()
+        if not campaign_id:
+            campaign_id = None
+
     details = dict(metadata)
     if payload.get("score") is not None:
         details["score"] = payload["score"]
@@ -69,6 +75,7 @@ def _load_quiz_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
         "quiz_id": str(payload["quiz_id"]),
         "user_id": str(payload["user_id"]),
         "attempt_id": attempt_id,
+        "campaign_id": campaign_id,
         "occurred_at": payload.get("occurred_at"),
         "attempts": 1,
         "passes": 1 if passed else 0,
@@ -121,6 +128,22 @@ def create_app() -> Flask:
 
         record = storage.record_completion(result)
         return jsonify({"result": record}), 201
+
+    @app.route("/api/events/quiz", methods=["GET"])
+    def list_quiz_events() -> Response:
+        try:
+            limit = int(request.args.get("limit", "25"))
+        except (TypeError, ValueError):
+            limit = 25
+        limit = max(1, min(limit, 200))
+
+        raw_campaign_id = request.args.get("campaign_id")
+        campaign_id = raw_campaign_id.strip() if raw_campaign_id else None
+        if campaign_id == "":
+            campaign_id = None
+
+        results = storage.fetch_recent_results(limit=limit, campaign_id=campaign_id)
+        return jsonify({"results": results})
 
     @app.route("/config", methods=["GET"])
     def config_dump() -> Response:

--- a/app/flashoffer/quiz-backend/quiz_backend/db.py
+++ b/app/flashoffer/quiz-backend/quiz_backend/db.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from importlib import resources
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 from psycopg2.extras import Json
 
@@ -26,6 +26,10 @@ CREATE_QUIZ_RESULTS_TABLE_SQL = _load_sql("create_quiz_results_table.sql")
 
 INSERT_QUIZ_RESULT_SQL = _load_sql("insert_quiz_result.sql")
 
+FETCH_RECENT_QUIZ_RESULTS_SQL = _load_sql("fetch_recent_quiz_results.sql")
+
+ENSURE_CAMPAIGN_ID_COLUMN_SQL = _load_sql("ensure_campaign_id_column.sql")
+
 
 class QuizResultsStore(PostgresPool):
     """Store that manages quiz completion tallies."""
@@ -34,6 +38,7 @@ class QuizResultsStore(PostgresPool):
         with self.connection() as conn:  # type: ignore[assignment]
             with conn.cursor() as cur:
                 cur.execute(CREATE_QUIZ_RESULTS_TABLE_SQL)
+                cur.execute(ENSURE_CAMPAIGN_ID_COLUMN_SQL)
             conn.commit()
 
     def record_completion(self, result: Dict[str, Any]) -> Dict[str, Any]:
@@ -51,6 +56,7 @@ class QuizResultsStore(PostgresPool):
                         result["quiz_id"],
                         result["user_id"],
                         result.get("attempt_id"),
+                        result.get("campaign_id"),
                         occurred_at,
                         attempts,
                         passes,
@@ -69,6 +75,7 @@ class QuizResultsStore(PostgresPool):
             "quiz_id": result["quiz_id"],
             "user_id": result["user_id"],
             "attempt_id": result.get("attempt_id"),
+            "campaign_id": result.get("campaign_id"),
             "occurred_at": occurred_at.isoformat(),
             "attempts": attempts,
             "passes": passes,
@@ -77,6 +84,41 @@ class QuizResultsStore(PostgresPool):
             "received_at": _parse_timestamp(row[1]).isoformat() if row else None,
         }
         return record
+
+    def fetch_recent_results(
+        self,
+        *,
+        limit: int = 25,
+        campaign_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        normalized_limit = max(1, min(limit, 200))
+        with self.connection() as conn:  # type: ignore[assignment]
+            with conn.cursor() as cur:
+                cur.execute(
+                    FETCH_RECENT_QUIZ_RESULTS_SQL,
+                    (campaign_id, campaign_id, normalized_limit),
+                )
+                rows = cur.fetchall()
+
+        results: List[Dict[str, Any]] = []
+        for row in rows:
+            results.append(
+                {
+                    "id": row[0],
+                    "quiz_id": row[1],
+                    "user_id": row[2],
+                    "attempt_id": row[3],
+                    "campaign_id": row[4],
+                    "occurred_at": _parse_timestamp(row[5]).isoformat(),
+                    "attempts": int(row[6]),
+                    "passes": int(row[7]),
+                    "fails": int(row[8]),
+                    "payload": row[9] or {},
+                    "received_at": _parse_timestamp(row[10]).isoformat(),
+                }
+            )
+
+        return results
 
 
 def _parse_timestamp(value: Any) -> datetime:

--- a/app/flashoffer/quiz-backend/quiz_backend/sql/create_quiz_results_table.sql
+++ b/app/flashoffer/quiz-backend/quiz_backend/sql/create_quiz_results_table.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS quiz_results (
     quiz_id TEXT NOT NULL,
     user_id TEXT NOT NULL,
     attempt_id TEXT,
+    campaign_id TEXT,
     occurred_at TIMESTAMPTZ NOT NULL,
     attempts INTEGER NOT NULL,
     passes INTEGER NOT NULL,

--- a/app/flashoffer/quiz-backend/quiz_backend/sql/ensure_campaign_id_column.sql
+++ b/app/flashoffer/quiz-backend/quiz_backend/sql/ensure_campaign_id_column.sql
@@ -1,0 +1,3 @@
+-- guarantee the optional campaign reference exists
+ALTER TABLE quiz_results
+ADD COLUMN IF NOT EXISTS campaign_id TEXT;

--- a/app/flashoffer/quiz-backend/quiz_backend/sql/fetch_recent_quiz_results.sql
+++ b/app/flashoffer/quiz-backend/quiz_backend/sql/fetch_recent_quiz_results.sql
@@ -1,0 +1,17 @@
+-- retrieve recent quiz completion results optionally filtered by campaign
+SELECT
+    id,
+    quiz_id,
+    user_id,
+    attempt_id,
+    campaign_id,
+    occurred_at,
+    attempts,
+    passes,
+    fails,
+    payload,
+    received_at
+FROM quiz_results
+WHERE (%s IS NULL OR campaign_id = %s)
+ORDER BY received_at DESC
+LIMIT %s

--- a/app/flashoffer/quiz-backend/quiz_backend/sql/insert_quiz_result.sql
+++ b/app/flashoffer/quiz-backend/quiz_backend/sql/insert_quiz_result.sql
@@ -3,10 +3,11 @@ INSERT INTO quiz_results (
     quiz_id,
     user_id,
     attempt_id,
+    campaign_id,
     occurred_at,
     attempts,
     passes,
     fails,
     payload
-) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
 RETURNING id, received_at

--- a/app/flashoffer/quiz-backend/tests/test_app.py
+++ b/app/flashoffer/quiz-backend/tests/test_app.py
@@ -15,7 +15,7 @@ def test_healthcheck(client):
     assert response.get_json() == {"status": "ok"}
 
 
-def _build_payload(*, passed: bool) -> dict:
+def _build_payload(*, passed: bool, campaign_id: str | None = None) -> dict:
     return {
         "quiz_id": "algebra-basics",
         "user_id": str(uuid4()),
@@ -26,11 +26,12 @@ def _build_payload(*, passed: bool) -> dict:
         "score": 92 if passed else 54,
         "duration_seconds": 135,
         "metadata": {"source": "pytest"},
+        "campaign_id": campaign_id,
     }
 
 
 def test_quiz_completion_is_persisted(client, flask_app):
-    payload = _build_payload(passed=True)
+    payload = _build_payload(passed=True, campaign_id="launch-2024")
 
     response = client.post("/api/events/quiz", json=payload)
     assert response.status_code == 201
@@ -44,7 +45,7 @@ def test_quiz_completion_is_persisted(client, flask_app):
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT quiz_id, user_id, attempts, passes, fails
+                SELECT quiz_id, user_id, attempts, passes, fails, campaign_id
                 FROM quiz_results
                 """
             )
@@ -54,6 +55,7 @@ def test_quiz_completion_is_persisted(client, flask_app):
     assert rows[0][2] == 1
     assert rows[0][3] == 1
     assert rows[0][4] == 0
+    assert rows[0][5] == "launch-2024"
 
 
 def test_invalid_event_type_returns_error(client):
@@ -74,3 +76,22 @@ def test_missing_passed_flag_returns_error(client):
     assert response.status_code == 400
     data = response.get_json()
     assert "passed" in data["error"]
+
+
+def test_quiz_events_endpoint_returns_recent_results(client):
+    first = _build_payload(passed=True, campaign_id="alpha")
+    second = _build_payload(passed=False, campaign_id="beta")
+    client.post("/api/events/quiz", json=first)
+    client.post("/api/events/quiz", json=second)
+
+    response = client.get("/api/events/quiz", query_string={"campaign_id": "alpha", "limit": "5"})
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert "results" in body
+    assert len(body["results"]) == 1
+    result = body["results"][0]
+    assert result["campaign_id"] == "alpha"
+    assert result["quiz_id"] == "algebra-basics"
+    assert result["user_id"]
+    assert result["attempts"] == 1


### PR DESCRIPTION
## Summary
- persist an optional campaign_id on quiz completion events and expose a recent results endpoint
- surface quiz completions alongside user engagement events in the campaign manager API and UI copy
- include campaign identifiers when logging quiz completions from the demo experience

## Testing
- PYTHONPATH=app/flashoffer/quiz-backend pytest app/flashoffer/quiz-backend/tests *(fails: ModuleNotFoundError: No module named 'flask')*
- PYTHONPATH=app/flashoffer/campaign-manager/backend pytest app/flashoffer/campaign-manager/backend/tests *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68e83f5ce45c83218c97bf218fe66ad6