### PR TITLE
Add deadline handling to Flashoffer quiz

### DIFF
--- a/app/flashoffer/docs/flashoffer-react.md
+++ b/app/flashoffer/docs/flashoffer-react.md
@@ -190,8 +190,9 @@ arbitrary attributes to the underlying Material UI primitive.
   them undefined for a purely informational card.
 - **`MultipleChoiceQuiz`** – Lightweight quiz block that renders selectable
   answers, highlights the chosen option, and exposes an `onSubmit` callback for
-  instrumentation. Use it to capture lightweight intent before handing a lead
-  to sales tooling.
+  instrumentation. Provide `endTime` to automatically close the quiz and
+  display tallies sourced from each option's `tally` value. Use it to capture
+  lightweight intent before handing a lead to sales tooling.
 - **`CountdownTimer`** – Countdown surface that showcases urgency copy, time
   segments, and optional quantity remaining. Persist offer deadlines in UTC,
   convert them to the viewer's local time before display, and pass the UTC

--- a/app/flashoffer/docs/flashoffer-react/reference/functions/MultipleChoiceQuiz.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/functions/MultipleChoiceQuiz.md
@@ -59,6 +59,15 @@ after a correct response. Every submission triggers `onAnswer` with the
 selected option identifier and the computed correctness flag when
 available.
 
+## Deadlines and tallies
+
+Provide an `endTime` to automatically close the quiz at a scheduled
+deadline. Once the current time surpasses the end time, the component locks
+interactions, surfaces the configured `closedMessage` (or a default note),
+and displays the tallies attached to each option via the `tally` field.
+Tallies should represent the total number of submissions recorded for each
+choice.
+
 ## Accessibility
 
 The quiz wraps its content in semantic form elements and keeps the prompt

--- a/app/flashoffer/docs/flashoffer-react/reference/interfaces/MultipleChoiceOption.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/interfaces/MultipleChoiceOption.md
@@ -35,3 +35,13 @@ Primary label describing the answer choice.
 Defined in: src/components/MultipleChoiceQuiz.tsx:28
 
 Optional supporting copy rendered beneath the label.
+
+***
+
+### tally?
+
+> `optional` **tally**: `number`
+
+Defined in: src/components/MultipleChoiceQuiz.tsx:31
+
+Number of submissions associated with the answer choice.

--- a/app/flashoffer/docs/flashoffer-react/reference/interfaces/MultipleChoiceQuizProps.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/interfaces/MultipleChoiceQuizProps.md
@@ -35,7 +35,7 @@ Collection of answer choices presented to the learner.
 Defined in: src/components/MultipleChoiceQuiz.tsx:45
 
 Helper text that expands on the question prompt. Falls back to a default
-instruction when omitted.
+instruction when omitted while the quiz remains open.
 
 ***
 
@@ -132,3 +132,24 @@ answer is configured.
 Defined in: src/components/MultipleChoiceQuiz.tsx:66
 
 Disables interactions with the quiz component.
+
+***
+
+### endTime?
+
+> `optional` **endTime**: `Date` | `string` | `number`
+
+Defined in: src/components/MultipleChoiceQuiz.tsx:70
+
+Deadline after which the quiz stops accepting new responses and displays
+aggregated tallies.
+
+***
+
+### closedMessage?
+
+> `optional` **closedMessage**: `ReactNode`
+
+Defined in: src/components/MultipleChoiceQuiz.tsx:72
+
+Custom message announced to learners once the quiz has closed.

--- a/app/flashoffer/flashoffer-demo/src/sections/QuizShowcaseSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/QuizShowcaseSection.tsx
@@ -6,7 +6,7 @@
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { MultipleChoiceQuiz, Section } from "flashoffer-react";
 import type { MultipleChoiceAnswer } from "flashoffer-react";
 import { logQuizCompletion } from "../quizAnalytics";
@@ -17,19 +17,22 @@ const QUIZ_OPTIONS = [
     label: "A personalized reminder with a refreshed CTA",
     description:
       "Highlights the offer expiry, reinforces value, and links back to the " +
-      "landing page."
+      "landing page.",
+    tally: 264
   },
   {
     id: "case-study",
     label: "A case study download gate",
     description:
-      "Shares social proof but interrupts momentum with an additional form."
+      "Shares social proof but interrupts momentum with an additional form.",
+    tally: 86
   },
   {
     id: "survey",
     label: "A follow-up survey",
     description:
-      "Collects insights yet delays the decision to activate the promotion."
+      "Collects insights yet delays the decision to activate the promotion.",
+    tally: 41
   }
 ];
 
@@ -42,7 +45,15 @@ const QUIZ_QUESTION =
   "After a prospect explores a Flashoffer landing page, what follow-up drives " +
   "the highest conversion lift?";
 
+const DEMO_CAMPAIGN_ID = "flashoffer-demo";
+
 export function QuizShowcaseSection() {
+  const campaignApiBase =
+    typeof import.meta.env.VITE_FLASHOFFER_CAMPAIGN_API_BASE === "string" &&
+    import.meta.env.VITE_FLASHOFFER_CAMPAIGN_API_BASE.trim() !== ""
+      ? import.meta.env.VITE_FLASHOFFER_CAMPAIGN_API_BASE.trim()
+      : undefined;
+  const [campaignEndTime, setCampaignEndTime] = useState<Date | null>(null);
   const attemptRef = useRef(0);
 
   const handleAnswer = (answer: MultipleChoiceAnswer) => {
@@ -53,9 +64,63 @@ export function QuizShowcaseSection() {
       selectedOptionId: answer.optionId,
       correctOptionId: "reminder",
       isCorrect: answer.isCorrect,
-      campaignId: "flashoffer-demo",
+      campaignId: DEMO_CAMPAIGN_ID,
     });
   };
+
+  useEffect(() => {
+    if (!campaignApiBase || typeof fetch !== "function") {
+      return;
+    }
+
+    let cancelled = false;
+    const AbortCtor = typeof AbortController === "function" ? AbortController : null;
+    const controller = AbortCtor ? new AbortCtor() : null;
+    const baseUrl = campaignApiBase.replace(/\/+$/, "");
+    const endpoint = `${baseUrl}/api/campaign/${DEMO_CAMPAIGN_ID}/end_time`;
+
+    const loadDeadline = async () => {
+      try {
+        const response = await fetch(endpoint, {
+          method: "GET",
+          headers: { Accept: "application/json" },
+          signal: controller?.signal
+        });
+
+        if (!response.ok) {
+          throw new Error(`Campaign API responded with ${response.status}`);
+        }
+
+        const data = (await response.json()) as Record<string, unknown>;
+        if (cancelled) {
+          return;
+        }
+
+        const endTimeCandidate = data["end_time"] ?? data["endTime"];
+        if (typeof endTimeCandidate === "string") {
+          const parsed = new Date(endTimeCandidate);
+          if (Number.isFinite(parsed.getTime())) {
+            setCampaignEndTime(parsed);
+            return;
+          }
+        }
+
+        const remainingCandidate = data["remaining_ms"] ?? data["remainingMs"];
+        if (typeof remainingCandidate === "number" && Number.isFinite(remainingCandidate)) {
+          setCampaignEndTime(new Date(Date.now() + Math.max(0, remainingCandidate)));
+        }
+      } catch (error) {
+        console.warn("Unable to load flashoffer-demo campaign deadline", error);
+      }
+    };
+
+    void loadDeadline();
+
+    return () => {
+      cancelled = true;
+      controller?.abort();
+    };
+  }, [campaignApiBase]);
 
   return (
     <Box
@@ -87,6 +152,7 @@ export function QuizShowcaseSection() {
               successMessage="Exactly. Reinforcing urgency while keeping the path clear sustains conversion lift."
               errorMessage="Think about which follow-up reduces friction instead of adding new steps."
               onAnswer={handleAnswer}
+              endTime={campaignEndTime ?? undefined}
             />
           </Grid>
         </Grid>

--- a/app/flashoffer/flashoffer-react/src/components/MultipleChoiceQuiz.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/MultipleChoiceQuiz.tsx
@@ -17,7 +17,7 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { alpha } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { useCallback, useId, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import type { ChangeEvent, ReactNode } from "react";
 
 export interface MultipleChoiceOption {
@@ -27,6 +27,8 @@ export interface MultipleChoiceOption {
   label: ReactNode;
   /** Optional supporting copy rendered beneath the label. */
   description?: ReactNode;
+  /** Number of submissions associated with the answer choice. */
+  tally?: number;
 }
 
 export interface MultipleChoiceAnswer {
@@ -64,6 +66,10 @@ export interface MultipleChoiceQuizProps {
   allowRetry?: boolean;
   /** Disables interactions with the quiz component. */
   disabled?: boolean;
+  /** Deadline after which the quiz stops accepting new responses. */
+  endTime?: Date | string | number;
+  /** Custom message announced when the quiz is closed. */
+  closedMessage?: ReactNode;
 }
 
 const DEFAULT_SUCCESS = "Great job! That answer is correct.";
@@ -139,7 +145,7 @@ function useQuizState(
     (hasSubmitted && !resolvedAllowRetry) ||
     evaluation === true;
   const showRetryButton =
-    resolvedAllowRetry && hasSubmitted && evaluation !== true;
+    resolvedAllowRetry && hasSubmitted && evaluation !== true && !disabled;
 
   return {
     hasSubmitted,
@@ -251,14 +257,20 @@ function resolveOptionBackgroundColor(
 
 interface OptionContentProps {
   option: MultipleChoiceOption;
+  showTallies: boolean;
+  totalTallies: number;
 }
 
 /**
  * Renders the visible label block for a quiz option.
  */
-function OptionContent({ option }: OptionContentProps): ReactNode {
-  return (
-    <Stack spacing={option.description ? 0.5 : 0}>
+function OptionContent({
+  option,
+  showTallies,
+  totalTallies
+}: OptionContentProps): ReactNode {
+  const labelBlock = (
+    <Stack spacing={option.description ? 0.5 : 0} flex={1} minWidth={0}>
       <Typography variant="body1" fontWeight={600}>
         {option.label}
       </Typography>
@@ -267,6 +279,48 @@ function OptionContent({ option }: OptionContentProps): ReactNode {
           {option.description}
         </Typography>
       ) : null}
+    </Stack>
+  );
+
+  if (!showTallies) {
+    return labelBlock;
+  }
+
+  const tally = Math.max(0, option.tally ?? 0);
+  const countFormatter =
+    typeof Intl !== "undefined"
+      ? new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 })
+      : null;
+  const percentFormatter =
+    typeof Intl !== "undefined"
+      ? new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 })
+      : null;
+  const formattedCount = countFormatter ? countFormatter.format(tally) : `${tally}`;
+  const responseLabel = tally === 1 ? "response" : "responses";
+  const percentage = totalTallies > 0 ? (tally / totalTallies) * 100 : 0;
+  const formattedPercent = percentFormatter
+    ? percentFormatter.format(percentage)
+    : `${Math.round(percentage)}`;
+
+  return (
+    <Stack
+      direction="row"
+      spacing={2}
+      justifyContent="space-between"
+      alignItems="flex-start"
+      sx={{ width: "100%" }}
+    >
+      {labelBlock}
+      <Stack spacing={0} alignItems="flex-end">
+        <Typography variant="body2" fontWeight={600}>
+          {formattedCount} {responseLabel}
+        </Typography>
+        {totalTallies > 0 ? (
+          <Typography variant="caption" color="text.secondary">
+            {formattedPercent}% of responses
+          </Typography>
+        ) : null}
+      </Stack>
     </Stack>
   );
 }
@@ -318,13 +372,70 @@ export function MultipleChoiceQuiz({
   submitLabel = DEFAULT_SUBMIT_LABEL,
   tryAgainLabel = DEFAULT_TRY_AGAIN_LABEL,
   allowRetry,
-  disabled = false
+  disabled = false,
+  endTime,
+  closedMessage
 }: MultipleChoiceQuizProps) {
   const questionId = useId();
   const groupId = useId();
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [submittedId, setSubmittedId] = useState<string | null>(null);
+
+  const endTimestamp = useMemo(() => {
+    if (typeof endTime === "undefined" || endTime === null) {
+      return null;
+    }
+    if (endTime instanceof Date) {
+      const value = endTime.getTime();
+      return Number.isFinite(value) ? value : null;
+    }
+    if (typeof endTime === "number") {
+      return Number.isFinite(endTime) ? endTime : null;
+    }
+    if (typeof endTime === "string") {
+      const parsed = new Date(endTime);
+      const value = parsed.getTime();
+      return Number.isFinite(value) ? value : null;
+    }
+    return null;
+  }, [endTime]);
+
+  const [isClosed, setIsClosed] = useState(() => {
+    if (!endTimestamp) {
+      return false;
+    }
+    return Date.now() >= endTimestamp;
+  });
+
+  useEffect(() => {
+    if (!endTimestamp) {
+      setIsClosed(false);
+      return;
+    }
+
+    const now = Date.now();
+    if (now >= endTimestamp) {
+      setIsClosed(true);
+      return;
+    }
+
+    setIsClosed(false);
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setIsClosed(true);
+    }, endTimestamp - now);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [endTimestamp]);
+
+  const resolvedDisabled = disabled || isClosed;
 
   const {
     hasSubmitted,
@@ -335,7 +446,7 @@ export function MultipleChoiceQuiz({
     submitDisabled,
     showRetryButton
   } = useQuizState(
-    { allowRetry, correctOptionId, disabled },
+    { allowRetry, correctOptionId, disabled: resolvedDisabled },
     { selectedId, submittedId }
   );
 
@@ -347,7 +458,7 @@ export function MultipleChoiceQuiz({
   );
 
   const handleSubmit = useCallback(() => {
-    if (!selectedId) {
+    if (!selectedId || isClosed) {
       return;
     }
     setSubmittedId(selectedId);
@@ -357,7 +468,7 @@ export function MultipleChoiceQuiz({
         ? selectedId === correctOptionId
         : undefined
     });
-  }, [correctOptionId, onAnswer, selectedId]);
+  }, [correctOptionId, isClosed, onAnswer, selectedId]);
 
   const handleRetry = useCallback(() => {
     setSelectedId(null);
@@ -376,7 +487,7 @@ export function MultipleChoiceQuiz({
   }, [helperText]);
 
   const fallbackHelper = useMemo(() => {
-    if (helperText) {
+    if (helperText || isClosed) {
       return null;
     }
     return (
@@ -384,7 +495,7 @@ export function MultipleChoiceQuiz({
         Select the response that best answers the question.
       </FormHelperText>
     );
-  }, [helperText]);
+  }, [helperText, isClosed]);
 
   const feedbackContent = useMemo(() => {
     if (!showFeedback || typeof evaluation !== "boolean") {
@@ -411,6 +522,18 @@ export function MultipleChoiceQuiz({
     );
   }, [handleRetry, showRetryButton, tryAgainLabel]);
 
+  const totalTallies = useMemo(
+    () =>
+      options.reduce((total, option) => {
+        const tally = Number(option.tally ?? 0);
+        if (!Number.isFinite(tally)) {
+          return total;
+        }
+        return total + Math.max(0, tally);
+      }, 0),
+    [options]
+  );
+
   const optionItems = useMemo(
     () =>
       options.map((option) => {
@@ -435,7 +558,13 @@ export function MultipleChoiceQuiz({
             key={option.id}
             value={option.id}
             control={<Radio />}
-            label={<OptionContent option={option} />}
+            label={
+              <OptionContent
+                option={option}
+                showTallies={isClosed}
+                totalTallies={totalTallies}
+              />
+            }
             disabled={disableChoices}
             data-option-state={optionState}
             sx={(theme) => ({
@@ -469,9 +598,46 @@ export function MultipleChoiceQuiz({
       revealCorrectAnswer,
       selectedId,
       showFeedback,
-      submittedId
+      submittedId,
+      isClosed,
+      totalTallies
     ]
   );
+
+  const closureNotice = useMemo(() => {
+    if (!isClosed) {
+      return null;
+    }
+
+    const formattedDeadline = endTimestamp
+      ? new Date(endTimestamp).toLocaleString(undefined, {
+          dateStyle: "medium",
+          timeStyle: "short"
+        })
+      : null;
+
+    const defaultMessage = (
+      <Typography component="span" variant="body2">
+        This quiz closed on{" "}
+        <Typography component="span" variant="body2" fontWeight={600}>
+          {formattedDeadline ?? "the scheduled deadline"}
+        </Typography>
+        . Review the response tallies below.
+      </Typography>
+    );
+
+    return (
+      <Alert severity="info">
+        {closedMessage ? (
+          <Typography variant="body2" component="span">
+            {closedMessage}
+          </Typography>
+        ) : (
+          defaultMessage
+        )}
+      </Alert>
+    );
+  }, [closedMessage, endTimestamp, isClosed]);
 
   return (
     <Card component="section" elevation={3} sx={{ borderRadius: 3 }}>
@@ -488,6 +654,7 @@ export function MultipleChoiceQuiz({
             </Typography>
             {promptHelper}
           </Stack>
+          {closureNotice}
           <FormControl component="fieldset" disabled={disableChoices}>
             <FormLabel
               htmlFor={groupId}

--- a/app/flashoffer/flashoffer-react/src/components/__tests__/MultipleChoiceQuiz.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/__tests__/MultipleChoiceQuiz.test.tsx
@@ -3,36 +3,41 @@
  * Released under the MIT license.
  */
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 
 import { FlashofferThemeProvider } from "../../theme/FlashofferThemeProvider";
 import { MultipleChoiceQuiz } from "../MultipleChoiceQuiz";
 import type { MultipleChoiceQuizProps } from "../MultipleChoiceQuiz";
 
 describe("MultipleChoiceQuiz", () => {
+  const BASE_OPTIONS: MultipleChoiceQuizProps["options"] = [
+    {
+      id: "story",
+      label: "Story taps forward",
+      description: "Viewers who tap forward without exiting.",
+      tally: 18
+    },
+    {
+      id: "save",
+      label: "Saves per reel",
+      description: "Average number of saves across promoted reels.",
+      tally: 42
+    },
+    {
+      id: "session",
+      label: "Average session duration",
+      description: "Time spent engaging with bundled offers.",
+      tally: 9
+    }
+  ];
+
   function renderQuiz(props: Partial<MultipleChoiceQuizProps> = {}) {
     return render(
       <FlashofferThemeProvider applyCssBaseline={false}>
         <MultipleChoiceQuiz
           question="Which metric indicates the strongest engagement lift?"
           helperText="Select the option that best demonstrates sustained performance."
-          options={[
-            {
-              id: "story",
-              label: "Story taps forward",
-              description: "Viewers who tap forward without exiting."
-            },
-            {
-              id: "save",
-              label: "Saves per reel",
-              description: "Average number of saves across promoted reels."
-            },
-            {
-              id: "session",
-              label: "Average session duration",
-              description: "Time spent engaging with bundled offers."
-            }
-          ]}
+          options={BASE_OPTIONS}
           correctOptionId="save"
           {...props}
         />
@@ -114,5 +119,47 @@ describe("MultipleChoiceQuiz", () => {
       .closest("label");
 
     expect(correctOptionLabel?.dataset.optionState).toBe("correct");
+  });
+
+  it("disables interactions and displays tallies when the quiz is closed", () => {
+    const pastDeadline = new Date(Date.now() - 1000);
+    renderQuiz({ endTime: pastDeadline });
+
+    expect(screen.getByText(/this quiz closed on/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: /saves per reel/i })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /check answer/i })
+    ).toBeDisabled();
+    expect(screen.getByText(/42 responses/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /try again/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Select the response that best answers the question./i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("automatically closes once the deadline passes", () => {
+    jest.useFakeTimers();
+    const now = new Date("2024-01-01T00:00:00Z");
+    jest.setSystemTime(now);
+
+    try {
+      renderQuiz({ endTime: new Date(now.getTime() + 2500) });
+
+      expect(
+        screen.queryByText(/this quiz closed on/i)
+      ).not.toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(3000);
+      });
+
+      expect(screen.getByText(/this quiz closed on/i)).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add optional quiz deadline support with automatic tallies and closure messaging
- fetch the flashoffer-demo campaign deadline for the quiz showcase
- document the new MultipleChoiceQuiz props and behaviours

## Testing
- npm test -- MultipleChoiceQuiz

------
https://chatgpt.com/codex/tasks/task_e_68e8769944a883219d976781f5e340a9