### PR TITLE
Remove cache mount IDs for shared locked caches

### DIFF
--- a/app/flashoffer/analytics-backend/Dockerfile
+++ b/app/flashoffer/analytics-backend/Dockerfile
@@ -35,7 +35,7 @@ COPY app/shell/py/pie /tmp/pie
 # Install application dependencies, the shared PIE package, and
 # dominate (used to render HTML emails). Cleaning the temporary
 # directory avoids keeping duplicate source trees in the final image.
-RUN --mount=type=cache,target=/root/.cache/pip,id=analytics-backend-pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install -r requirements.txt \
     && pip install /tmp/pie dominate \
     && rm -rf /tmp/pie /backend-common
@@ -64,15 +64,15 @@ ENV GUNICORN_WORKERS=4 \
 # Install nginx for reverse proxying and clean up apt metadata to keep the
 # image size in check. Caching apt metadata dramatically speeds up rebuilds
 # while still ensuring the runtime layer stays slim.
-RUN --mount=type=cache,target=/var/cache/apt,id=analytics-backend \
-    --mount=type=cache,target=/var/lib/apt/lists,id=analytics-backend \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update \
     && apt-get install --no-install-recommends -y nginx \
     && rm -rf /var/lib/apt/lists/*
 
 # Gunicorn is only required in the production image, so install it here to
 # avoid bloating the base stage.
-RUN --mount=type=cache,target=/root/.cache/pip,id=analytics-backend-pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install gunicorn
 
 # Provide the templated nginx config and startup script used in

--- a/app/flashoffer/analytics-db/Dockerfile
+++ b/app/flashoffer/analytics-db/Dockerfile
@@ -11,10 +11,10 @@
 # extension and recommended configuration out of the box.
 FROM timescale/timescaledb:latest-pg14
 
-RUN --mount=type=cache,target=/var/cache/apk,id=analytics-db \
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
   apk add --no-cache s3cmd python3 py3-pip postgresql-client ipython
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=analytics-db \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
   pip install --break-system-packages psycopg[binary] pandas
 
 COPY ./app/flashoffer/analytics-db/bin/ /root/bin/

--- a/app/flashoffer/campaign-backend/Dockerfile
+++ b/app/flashoffer/campaign-backend/Dockerfile
@@ -20,7 +20,7 @@ COPY app/flashoffer/campaign-backend/requirements.txt ./requirements.txt
 COPY app/flashoffer/backend-common /backend-common
 COPY app/shell/py/pie /tmp/pie
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=campaign-backend-pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install -r requirements.txt \
     && pip install /tmp/pie dominate \
     && rm -rf /tmp/pie /backend-common
@@ -39,13 +39,13 @@ FROM base AS prod
 ENV GUNICORN_WORKERS=4 \
     GUNICORN_BIND=unix:/tmp/gunicorn.sock
 
-RUN --mount=type=cache,target=/var/cache/apt,id=campaign-backend \
-    --mount=type=cache,target=/var/lib/apt/lists,id=campaign-backend \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update \
     && apt-get install --no-install-recommends -y nginx \
     && rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=campaign-backend-pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install gunicorn
 
 COPY app/flashoffer/campaign-backend/nginx.conf /etc/nginx/conf.d/default.conf

--- a/app/flashoffer/campaign-manager/Dockerfile
+++ b/app/flashoffer/campaign-manager/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /frontend
 
 COPY app/flashoffer/campaign-manager/package.json ./package.json
 COPY app/flashoffer/campaign-manager/package-lock.json ./package-lock.json
-RUN --mount=type=cache,target=/root/.npm,id=flashoffer-campaign-manager npm ci
+RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci
 
 COPY app/flashoffer/campaign-manager/tsconfig.json ./tsconfig.json
 COPY app/flashoffer/campaign-manager/tsconfig.node.json ./tsconfig.node.json
@@ -19,7 +19,7 @@ COPY app/flashoffer/campaign-manager/vite.config.ts ./vite.config.ts
 COPY app/flashoffer/campaign-manager/index.html ./index.html
 COPY app/flashoffer/campaign-manager/src ./src
 COPY app/flashoffer/flashoffer-react ./flashoffer-react
-RUN --mount=type=cache,target=/root/.npm,id=flashoffer-campaign-manager npm run build
+RUN --mount=type=cache,target=/root/.npm,sharing=locked npm run build
 
 FROM python:3.11-slim AS runtime
 
@@ -28,8 +28,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN --mount=type=cache,target=/var/cache/apt,id=flashoffer-campaign-manager \
-    --mount=type=cache,target=/var/lib/apt/lists,id=flashoffer-campaign-manager \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update \
     && apt-get install --no-install-recommends -y build-essential libpq-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -38,7 +38,7 @@ COPY app/flashoffer/campaign-manager/backend/requirements.txt ./requirements.txt
 COPY app/flashoffer/backend-common /backend-common
 COPY app/shell/py/pie /tmp/pie
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=flashoffer-campaign-manager-pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-cache-dir -r requirements.txt \
     && pip install /tmp/pie dominate flask loguru \
     && rm -rf /tmp/pie /backend-common

--- a/app/flashoffer/quiz-backend/Dockerfile
+++ b/app/flashoffer/quiz-backend/Dockerfile
@@ -26,7 +26,7 @@ COPY app/shell/py/pie /tmp/pie
 # Install application dependencies, the shared PIE package, and
 # dominate to support HTML email rendering. Cleaning the temporary
 # directory avoids keeping duplicate source trees in the final image.
-RUN --mount=type=cache,target=/root/.cache/pip,id=quiz-backend-pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install -r requirements.txt \
     && pip install /tmp/pie dominate \
     && rm -rf /tmp/pie /backend-common
@@ -48,13 +48,13 @@ ENV GUNICORN_WORKERS=4 \
 
 # Install nginx for reverse proxying and keep apt metadata cached during
 # builds to speed up rebuilds without bloating the runtime image.
-RUN --mount=type=cache,target=/var/cache/apt,id=quiz-backend \
-    --mount=type=cache,target=/var/lib/apt/lists,id=quiz-backend \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update \
     && apt-get install --no-install-recommends -y nginx \
     && rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=quiz-backend-pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install gunicorn
 
 COPY app/flashoffer/quiz-backend/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary
- drop cache mount IDs from Flashoffer Dockerfiles so locked sharing reuses common caches
- keep sharing=locked on pip, npm, apt, and apk mounts without fragmenting per-image caches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e93b17c660832188996977e0cc6365