### PR TITLE
chore: pin docker base images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,11 @@
 - Node.js projects: modify `package.json` and `package-lock.json` only when
   the dependency list changes.
 
+## Docker Images
+
+- Pin all Node.js Docker base images to `node:22-slim`.
+- Pin all Python Docker base images to `python:3.14-slim`.
+
 ## `docker-compose.yml`
 
 - Always document services with comments that explain ongoing maintenance and

--- a/app/flashoffer/AGENTS.md
+++ b/app/flashoffer/AGENTS.md
@@ -9,6 +9,7 @@
 - Persist all timestamps in Coordinated Universal Time (UTC).
 - Convert UTC timestamps to a viewer's local timezone before displaying them.
 - Pin all Flashoffer Docker Node base images to `node:22-slim`.
+- Pin all Flashoffer Docker Python base images to `python:3.14-slim`.
 
 ## Flashoffer React Components
 

--- a/app/flashoffer/analytics-backend/Dockerfile
+++ b/app/flashoffer/analytics-backend/Dockerfile
@@ -10,7 +10,7 @@
 
 # Use the slim Python image to keep the base layer small while still
 # providing the tooling required to install Python wheels.
-FROM python:3.11-slim AS base
+FROM python:3.14-slim AS base
 
 # Disable bytecode generation to reduce container filesystem churn and set
 # defaults used by both the dev and prod entrypoints.

--- a/app/flashoffer/campaign-backend/Dockerfile
+++ b/app/flashoffer/campaign-backend/Dockerfile
@@ -7,7 +7,7 @@
 # reuse deployment runbooks across analytics, quiz, and campaign APIs.
 ######################################################################
 
-FROM python:3.11-slim AS base
+FROM python:3.14-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/app/flashoffer/campaign-manager/Dockerfile
+++ b/app/flashoffer/campaign-manager/Dockerfile
@@ -21,7 +21,7 @@ COPY app/flashoffer/campaign-manager/src ./src
 COPY app/flashoffer/flashoffer-react ./flashoffer-react
 RUN --mount=type=cache,target=/root/.npm,id=flashoffer-campaign-manager npm run build
 
-FROM python:3.11-slim AS runtime
+FROM python:3.14-slim AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1

--- a/app/flashoffer/quiz-backend/Dockerfile
+++ b/app/flashoffer/quiz-backend/Dockerfile
@@ -7,7 +7,7 @@
 # backend image so the two services can share operational tooling.
 ######################################################################
 
-FROM python:3.11-slim AS base
+FROM python:3.14-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/app/pdoc/Dockerfile
+++ b/app/pdoc/Dockerfile
@@ -8,7 +8,7 @@
 
 # Start from the slim Python base to reduce image size while retaining pip
 # and build tooling.
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /pie
 

--- a/app/shell/Dockerfile
+++ b/app/shell/Dockerfile
@@ -7,7 +7,7 @@
 # -------------------------------------------------------------------
 
 # Base image: lightweight Python runtime
-FROM python:3.13-slim
+FROM python:3.14-slim
 
 # -------------------------------------------------------------------
 # System preparation


### PR DESCRIPTION
## Summary
- document the standardized Docker base image requirements for Node.js and Python
- update Flashoffer guidance to reflect the new Python image constraint
- align all Python-based Dockerfiles with the python:3.14-slim minimal base image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e93c7b2e408321a7f5cfdfbaf55a09