### PR TITLE
Improve npm caching for Flashoffer demo Docker builds

### DIFF
--- a/app/flashoffer/flashoffer-demo/Dockerfile
+++ b/app/flashoffer/flashoffer-demo/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /workspace
 FROM base AS flashoffer-react-deps
 WORKDIR /workspace/app/flashoffer/flashoffer-react
 COPY app/flashoffer/flashoffer-react/package.json app/flashoffer/flashoffer-react/package-lock.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci
 
 # Build the production Flashoffer React bundle.
 FROM flashoffer-react-deps AS flashoffer-react-build
@@ -30,7 +30,7 @@ RUN npm run build
 FROM flashoffer-react-build AS flashoffer-demo-build
 WORKDIR /workspace/app/flashoffer/flashoffer-demo
 COPY app/flashoffer/flashoffer-demo/package.json app/flashoffer/flashoffer-demo/package-lock.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci
 COPY app/flashoffer/flashoffer-demo ./
 RUN npm run build
 

--- a/app/flashoffer/flashoffer-demo/Dockerfile.dev
+++ b/app/flashoffer/flashoffer-demo/Dockerfile.dev
@@ -7,12 +7,12 @@ ENV NODE_ENV=development
 FROM base AS flashoffer-react-deps
 WORKDIR /workspace/app/flashoffer/flashoffer-react
 COPY app/flashoffer/flashoffer-react/package.json app/flashoffer/flashoffer-react/package-lock.json ./
-RUN npm ci --include=dev
+RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci --include=dev
 
 FROM base AS flashoffer-demo-deps
 WORKDIR /workspace/app/flashoffer/flashoffer-demo
 COPY app/flashoffer/flashoffer-demo/package.json app/flashoffer/flashoffer-demo/package-lock.json ./
-RUN npm ci --include=dev
+RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci --include=dev
 
 FROM base AS dev
 ENV FLASHOFFER_MODE=dev


### PR DESCRIPTION
## Summary
- reuse cached npm packages during flashoffer demo production builds
- enable npm cache mount during dev container installs for faster rebuilds

## Testing
- not run (Dockerfile changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e93edd1af88321a05972f0053a337f