### PR TITLE
Upgrade Flashoffer psycopg dependencies to v3

### DIFF
--- a/app/flashoffer/analytics-backend/analytics_backend/db.py
+++ b/app/flashoffer/analytics-backend/analytics_backend/db.py
@@ -9,7 +9,8 @@ from datetime import datetime, timezone
 from importlib import resources
 from typing import Any, Dict, Iterable, List, Sequence
 
-from psycopg2.extras import Json, execute_values
+from psycopg.extras import execute_values
+from psycopg.types.json import Json
 
 from backend_common import DatabaseConfig, PostgresPool
 

--- a/app/flashoffer/analytics-backend/requirements.txt
+++ b/app/flashoffer/analytics-backend/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.3.3
 loguru==0.7.2
-psycopg2-binary==2.9.9
+psycopg[binary]==3.1.18
 pytest==7.4.4
 ../backend-common

--- a/app/flashoffer/analytics-backend/tests/test_db_config.py
+++ b/app/flashoffer/analytics-backend/tests/test_db_config.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import pytest
 
 pytest.importorskip("flask")
-pytest.importorskip("psycopg2")
+pytest.importorskip("psycopg")
 
 from analytics_backend.db import DatabaseConfig
 

--- a/app/flashoffer/backend-common/backend_common/pool.py
+++ b/app/flashoffer/backend-common/backend_common/pool.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import Iterator
 
-from psycopg2.pool import SimpleConnectionPool
+from psycopg_pool import SimpleConnectionPool
 
 from .config import DatabaseConfig
 
 
 class PostgresPool:
-    """Simple connection pool wrapper around psycopg2."""
+    """Simple connection pool wrapper around psycopg."""
 
     def __init__(self, config: DatabaseConfig) -> None:
         self._config = config

--- a/app/flashoffer/campaign-backend/requirements.txt
+++ b/app/flashoffer/campaign-backend/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.3.3
 loguru==0.7.2
-psycopg2-binary==2.9.9
+psycopg[binary]==3.1.18
 pytest==7.4.4
 ../backend-common

--- a/app/flashoffer/campaign-manager/backend/requirements.txt
+++ b/app/flashoffer/campaign-manager/backend/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.115.0
 httpx==0.27.2
 itsdangerous==2.2.0
-psycopg2-binary==2.9.9
+psycopg[binary]==3.1.18
 pydantic==2.9.2
 uvicorn[standard]==0.32.0
 ../backend-common

--- a/app/flashoffer/quiz-backend/quiz_backend/db.py
+++ b/app/flashoffer/quiz-backend/quiz_backend/db.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from importlib import resources
 from typing import Any, Dict, List, Optional
 
-from psycopg2.extras import Json
+from psycopg.types.json import Json
 
 from backend_common import DatabaseConfig, PostgresPool
 

--- a/app/flashoffer/quiz-backend/requirements.txt
+++ b/app/flashoffer/quiz-backend/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.3.3
 loguru==0.7.2
-psycopg2-binary==2.9.9
+psycopg[binary]==3.1.18
 pytest==7.4.4
 ../backend-common


### PR DESCRIPTION
## Summary
- switch Flashoffer backend connection pooling to psycopg 3 primitives
- update backend services to depend on psycopg[binary] 3.1.18 and adjust JSON helpers
- refresh analytics backend tests to gate on psycopg instead of psycopg2

## Testing
- pytest app/flashoffer/analytics-backend/tests/test_db_config.py *(fails: ModuleNotFoundError: No module named 'analytics_backend')*


------
https://chatgpt.com/codex/tasks/task_e_68e94059931883219643ec8bb2a118ec