### PR TITLE
Ensure psycopg pool dependency is installed

### DIFF
--- a/app/flashoffer/analytics-backend/requirements.txt
+++ b/app/flashoffer/analytics-backend/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.3.3
 loguru==0.7.2
-psycopg[binary]==3.2.10
+psycopg[binary,pool]==3.2.10
 pytest==7.4.4
 ../backend-common

--- a/app/flashoffer/backend-common/setup.py
+++ b/app/flashoffer/backend-common/setup.py
@@ -9,4 +9,7 @@ setup(
     description="Shared helpers for backend Flask services.",
     packages=find_packages(),
     python_requires=">=3.11",
+    install_requires=[
+        "psycopg[pool]>=3.2,<4",
+    ],
 )

--- a/app/flashoffer/campaign-backend/requirements.txt
+++ b/app/flashoffer/campaign-backend/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.3.3
 loguru==0.7.2
-psycopg[binary]==3.2.10
+psycopg[binary,pool]==3.2.10
 pytest==7.4.4
 ../backend-common

--- a/app/flashoffer/campaign-manager/backend/requirements.txt
+++ b/app/flashoffer/campaign-manager/backend/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.115.0
 httpx==0.27.2
 itsdangerous==2.2.0
-psycopg[binary]==3.2.10
+psycopg[binary,pool]==3.2.10
 pydantic==2.9.2
 uvicorn[standard]==0.32.0
 ../backend-common

--- a/app/flashoffer/quiz-backend/requirements.txt
+++ b/app/flashoffer/quiz-backend/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.3.3
 loguru==0.7.2
-psycopg[binary]==3.2.10
+psycopg[binary,pool]==3.2.10
 pytest==7.4.4
 ../backend-common


### PR DESCRIPTION
## Summary
- ensure all Flashoffer backend services install psycopg with the pool extra so the psycopg_pool module is present
- declare psycopg's pool extra as a dependency of the backend-common package metadata for safer reuse

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e95d23fb4c83219a1de48536901cc6