### PR TITLE
Add coverage reporting commands to flashoffer-react

### DIFF
--- a/app/flashoffer/flashoffer-react/jest.config.ts
+++ b/app/flashoffer/flashoffer-react/jest.config.ts
@@ -13,7 +13,14 @@ const config: Config = {
   testMatch: ["<rootDir>/src/**/__tests__/**/*.test.(ts|tsx)"],
   moduleNameMapper: {
     "\\.(css|less|sass|scss)$": "<rootDir>/test/__mocks__/styleMock.ts"
-  }
+  },
+  collectCoverageFrom: [
+    "<rootDir>/src/**/*.{ts,tsx}",
+    "!<rootDir>/src/**/index.{ts,tsx}"
+  ],
+  coverageDirectory: "<rootDir>/coverage",
+  coverageProvider: "v8",
+  coverageReporters: ["text", "text-summary", "lcov", "html"]
 };
 
 export default config;

--- a/app/flashoffer/flashoffer-react/package.json
+++ b/app/flashoffer/flashoffer-react/package.json
@@ -30,6 +30,8 @@
     "lint": "eslint --ext .ts,.tsx src",
     "lint:ci": "eslint --ext .ts,.tsx src --rule \"complexity: ['error', { 'max': 10 }]\" --quiet",
     "test": "jest",
+    "test:coverage": "jest --coverage",
+    "test:coverage:ci": "jest --coverage --coverageReporters=text-summary --coverageReporters=lcov",
     "test:watch": "jest --watch"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- configure Jest to collect coverage from the component source tree and emit HTML, text, and lcov reports
- add npm scripts for running coverage locally and in CI-friendly mode

## Testing
- npm run test:coverage *(fails: Cannot find module '../../../theme/FlashofferThemeProvider' from 'src/components/__tests__/LoginView.test.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68f28961b5c88321a19ce63f4e90a386