### PR TITLE
Add optional confetti celebration to quiz component

### DIFF
--- a/app/flashoffer/flashoffer-react/package-lock.json
+++ b/app/flashoffer/flashoffer-react/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^7.3.1",
         "@mui/utils": "^7.3.1",
+        "canvas-confetti": "^1.9.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -4059,6 +4060,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/app/flashoffer/flashoffer-react/package.json
+++ b/app/flashoffer/flashoffer-react/package.json
@@ -36,9 +36,10 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.3.1",
+    "@mui/utils": "^7.3.1",
+    "canvas-confetti": "^1.9.3",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "@mui/utils": "^7.3.1"
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/app/flashoffer/flashoffer-react/src/components/MultipleChoiceQuiz.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/MultipleChoiceQuiz.tsx
@@ -17,8 +17,11 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { alpha } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { useCallback, useEffect, useId, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import type { ChangeEvent, ReactNode } from "react";
+
+import type { QuizConfettiOptions } from "./QuizCelebrations";
+import { launchConfetti, resolveConfettiOptions } from "./QuizCelebrations";
 
 export interface MultipleChoiceOption {
   /** Unique identifier used for option selection. */
@@ -70,6 +73,8 @@ export interface MultipleChoiceQuizProps {
   endTime?: Date | string | number;
   /** Custom message announced when the quiz is closed. */
   closedMessage?: ReactNode;
+  /** Configures confetti celebrations for correct answers. */
+  confetti?: QuizConfettiOptions;
 }
 
 const DEFAULT_SUCCESS = "Great job! That answer is correct.";
@@ -374,7 +379,8 @@ export function MultipleChoiceQuiz({
   allowRetry,
   disabled = false,
   endTime,
-  closedMessage
+  closedMessage,
+  confetti
 }: MultipleChoiceQuizProps) {
   const questionId = useId();
   const groupId = useId();
@@ -449,6 +455,34 @@ export function MultipleChoiceQuiz({
     { allowRetry, correctOptionId, disabled: resolvedDisabled },
     { selectedId, submittedId }
   );
+
+  const resolvedConfetti = useMemo(() => resolveConfettiOptions(confetti), [confetti]);
+  const { enabled: confettiEnabled, preset: confettiPreset } = resolvedConfetti;
+  const hasCelebratedRef = useRef(false);
+
+  useEffect(() => {
+    if (!confettiEnabled) {
+      hasCelebratedRef.current = false;
+      return;
+    }
+
+    const shouldCelebrate = hasSubmitted && evaluation === true;
+    if (!shouldCelebrate) {
+      hasCelebratedRef.current = false;
+      return;
+    }
+
+    if (hasCelebratedRef.current) {
+      return;
+    }
+
+    launchConfetti(confettiPreset).catch((error) => {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn("Failed to launch quiz confetti", error);
+      }
+    });
+    hasCelebratedRef.current = true;
+  }, [confettiEnabled, confettiPreset, evaluation, hasSubmitted]);
 
   const handleSelectionChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -697,3 +731,5 @@ export function MultipleChoiceQuiz({
     </Card>
   );
 }
+
+export type { QuizConfettiOptions, QuizConfettiPreset } from "./QuizCelebrations";

--- a/app/flashoffer/flashoffer-react/src/components/QuizCelebrations.ts
+++ b/app/flashoffer/flashoffer-react/src/components/QuizCelebrations.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
+import type { CreateTypes, Options } from "canvas-confetti";
+
+/**
+ * Named presets that determine the appearance of the confetti animation.
+ */
+export type QuizConfettiPreset = "classic" | "streamers" | "burst";
+
+/**
+ * Configuration describing when to play a celebratory confetti animation.
+ */
+export interface QuizConfettiOptions {
+  /** Enables the confetti animation when the learner submits a correct answer. */
+  enabled: boolean;
+  /** Selects the visual preset to render. Defaults to `"classic"`. */
+  preset?: QuizConfettiPreset;
+}
+
+interface ConfettiShot {
+  options: Options;
+  delay?: number;
+}
+
+const CONFETTI_PRESETS: Record<QuizConfettiPreset, ConfettiShot[]> = {
+  classic: [
+    {
+      options: {
+        particleCount: 140,
+        spread: 65,
+        startVelocity: 45,
+        origin: { y: 0.6 }
+      }
+    },
+    {
+      options: {
+        particleCount: 90,
+        spread: 55,
+        startVelocity: 35,
+        decay: 0.92,
+        origin: { y: 0.6 }
+      },
+      delay: 120
+    }
+  ],
+  streamers: [
+    {
+      options: {
+        particleCount: 70,
+        angle: 60,
+        spread: 55,
+        startVelocity: 50,
+        origin: { x: 0, y: 0.6 }
+      }
+    },
+    {
+      options: {
+        particleCount: 70,
+        angle: 120,
+        spread: 55,
+        startVelocity: 50,
+        origin: { x: 1, y: 0.6 }
+      }
+    },
+    {
+      options: {
+        particleCount: 60,
+        spread: 75,
+        startVelocity: 35,
+        ticks: 120,
+        origin: { x: 0.5, y: 0.45 }
+      },
+      delay: 180
+    }
+  ],
+  burst: [
+    {
+      options: {
+        particleCount: 200,
+        spread: 100,
+        startVelocity: 55,
+        origin: { x: 0.5, y: 0.6 }
+      }
+    },
+    {
+      options: {
+        particleCount: 160,
+        spread: 120,
+        startVelocity: 60,
+        decay: 0.9,
+        scalar: 1.1,
+        origin: { x: 0.5, y: 0.55 }
+      },
+      delay: 140
+    },
+    {
+      options: {
+        particleCount: 180,
+        spread: 140,
+        startVelocity: 45,
+        ticks: 160,
+        scalar: 0.9,
+        origin: { x: 0.5, y: 0.5 }
+      },
+      delay: 300
+    }
+  ]
+};
+
+let cachedConfetti: Promise<CreateTypes> | null = null;
+
+async function loadConfettiInstance(): Promise<CreateTypes | null> {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  if (!cachedConfetti) {
+    cachedConfetti = import("canvas-confetti").then(({ default: confetti }) =>
+      confetti.create(undefined, { resize: true, useWorker: true })
+    );
+  }
+
+  try {
+    return await cachedConfetti;
+  } catch (error) {
+    cachedConfetti = null;
+    throw error;
+  }
+}
+
+function fireConfettiShots(confetti: CreateTypes, shots: ConfettiShot[]): void {
+  shots.forEach(({ options, delay }) => {
+    if (delay && delay > 0) {
+      globalThis.setTimeout(() => {
+        void confetti(options);
+      }, delay);
+      return;
+    }
+    void confetti(options);
+  });
+}
+
+/**
+ * Resolves author provided configuration into runtime confetti settings.
+ */
+export function resolveConfettiOptions(
+  options?: QuizConfettiOptions
+): { enabled: boolean; preset: QuizConfettiPreset } {
+  if (!options || options.enabled === false) {
+    return { enabled: false, preset: "classic" };
+  }
+
+  return { enabled: true, preset: options.preset ?? "classic" };
+}
+
+/**
+ * Plays the confetti animation for the provided preset.
+ */
+export async function launchConfetti(preset: QuizConfettiPreset): Promise<void> {
+  const confetti = await loadConfettiInstance();
+  if (!confetti) {
+    return;
+  }
+
+  const shots = CONFETTI_PRESETS[preset];
+  fireConfettiShots(confetti, shots);
+}
+

--- a/app/flashoffer/flashoffer-react/src/components/SectionHeader.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/SectionHeader.tsx
@@ -12,23 +12,28 @@ export interface SectionHeaderProps {
   eyebrow?: ReactNode;
   /** Main heading text. Defaults to Flashoffer marketing copy. */
   title?: ReactNode;
+  /** Supporting copy rendered beneath the section title. */
+  subtitle?: ReactNode;
   /** Horizontal alignment for the text stack. Defaults to "center". */
   align?: "left" | "center";
 }
 
 const DEFAULT_EYEBROW = "FLASHOFFER";
 const DEFAULT_TITLE = "Launch faster with reusable content blocks.";
+const DEFAULT_SUBTITLE = "";
 
 /**
- * Section heading with optional eyebrow and configurable alignment.
+ * Section heading with optional eyebrow, subtitle, and configurable alignment.
  *
  * Defaults render the "FLASHOFFER" eyebrow and the "Launch faster with
  * reusable content blocks." title. Text is centered unless `align="left"` is
- * provided, and either content slot can be omitted by passing `null`.
+ * provided. Eyebrow, title, or subtitle content can be omitted by passing
+ * `null`.
  */
 export function SectionHeader({
   eyebrow = DEFAULT_EYEBROW,
   title = DEFAULT_TITLE,
+  subtitle = DEFAULT_SUBTITLE,
   align = "center"
 }: SectionHeaderProps) {
   return (
@@ -46,6 +51,11 @@ export function SectionHeader({
       <Typography variant="h2">
         {title}
       </Typography>
+      {subtitle ? (
+        <Typography variant="body1" color="text.secondary">
+          {subtitle}
+        </Typography>
+      ) : null}
     </Stack>
   );
 }

--- a/app/flashoffer/flashoffer-react/src/components/__tests__/LoginView.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/__tests__/LoginView.test.tsx
@@ -5,9 +5,9 @@
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import { FlashofferThemeProvider } from "../../../theme/FlashofferThemeProvider";
-import { LoginView } from "../../LoginView";
-import type { LoginViewProps } from "../../LoginView";
+import { FlashofferThemeProvider } from "../../theme/FlashofferThemeProvider";
+import { LoginView } from "../LoginView";
+import type { LoginViewProps } from "../LoginView";
 
 describe("LoginView", () => {
   function renderLoginView(props: Partial<LoginViewProps> = {}) {

--- a/app/flashoffer/flashoffer-react/src/components/__tests__/MultipleChoiceQuiz.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/__tests__/MultipleChoiceQuiz.test.tsx
@@ -8,8 +8,24 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { FlashofferThemeProvider } from "../../theme/FlashofferThemeProvider";
 import { MultipleChoiceQuiz } from "../MultipleChoiceQuiz";
 import type { MultipleChoiceQuizProps } from "../MultipleChoiceQuiz";
+import { launchConfetti } from "../QuizCelebrations";
+
+jest.mock("../QuizCelebrations", () => {
+  const actual = jest.requireActual("../QuizCelebrations");
+  return {
+    ...actual,
+    launchConfetti: jest.fn().mockResolvedValue(undefined)
+  };
+});
 
 describe("MultipleChoiceQuiz", () => {
+  const launchConfettiMock =
+    launchConfetti as jest.MockedFunction<typeof launchConfetti>;
+
+  beforeEach(() => {
+    launchConfettiMock.mockClear();
+  });
+
   const BASE_OPTIONS: MultipleChoiceQuizProps["options"] = [
     {
       id: "story",
@@ -61,6 +77,34 @@ describe("MultipleChoiceQuiz", () => {
     expect(
       screen.getByText(/great job! that answer is correct\./i)
     ).toBeInTheDocument();
+  });
+
+  it("triggers confetti when a correct answer is submitted", async () => {
+    renderQuiz({ confetti: { enabled: true, preset: "streamers" } });
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: /saves per reel/i })
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /check answer/i }));
+    });
+
+    expect(launchConfettiMock).toHaveBeenCalledWith("streamers");
+  });
+
+  it("does not launch confetti for incorrect submissions", async () => {
+    renderQuiz({ confetti: { enabled: true } });
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: /story taps forward/i })
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /check answer/i }));
+    });
+
+    expect(launchConfettiMock).not.toHaveBeenCalled();
   });
 
   it("allows retrying incorrect responses", () => {

--- a/app/flashoffer/flashoffer-react/src/index.ts
+++ b/app/flashoffer/flashoffer-react/src/index.ts
@@ -41,7 +41,9 @@ export { MultipleChoiceQuiz } from "./components/MultipleChoiceQuiz";
 export type {
   MultipleChoiceAnswer,
   MultipleChoiceOption,
-  MultipleChoiceQuizProps
+  MultipleChoiceQuizProps,
+  QuizConfettiOptions,
+  QuizConfettiPreset
 } from "./components/MultipleChoiceQuiz";
 
 export { CountdownTimer } from "./components/CountdownTimer";


### PR DESCRIPTION
## Summary
- add optional confetti configuration and presets for the multiple choice quiz component
- introduce a shared QuizCelebrations helper backed by canvas-confetti and export new quiz types
- extend SectionHeader subtitle support and update related tests to cover celebrations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f28868c360832187ef495af47797f7