### PR TITLE
Allow selecting quiz celebrations in demo and document confetti usage

### DIFF
--- a/app/flashoffer/docs/flashoffer-demo.md
+++ b/app/flashoffer/docs/flashoffer-demo.md
@@ -42,6 +42,9 @@ the top of the page:
   Spacious Typography Dark).
 - **Hero alignment** demonstrates how the hero banner adjusts copy, CTAs,
   and media when switching between centered and left-aligned presentations.
+- **Quiz celebration** showcases the confetti presets wired into
+  `MultipleChoiceQuiz` so you can gauge how each animation feels before
+  shipping it to production.
 
 To try different copy or preview cards, update the arrays declared in
 `src/App.tsx`. Reload the dev server (or rerun the build) after changing the

--- a/app/flashoffer/docs/flashoffer-react.md
+++ b/app/flashoffer/docs/flashoffer-react.md
@@ -189,10 +189,11 @@ arbitrary attributes to the underlying Material UI primitive.
   Provide `primaryCta`/`secondaryCta` props to render button controls, or leave
   them undefined for a purely informational card.
 - **`MultipleChoiceQuiz`** – Lightweight quiz block that renders selectable
-  answers, highlights the chosen option, and exposes an `onSubmit` callback for
-  instrumentation. Provide `endTime` to automatically close the quiz and
-  display tallies sourced from each option's `tally` value. Use it to capture
-  lightweight intent before handing a lead to sales tooling.
+  answers, highlights the chosen option, exposes an `onSubmit` callback for
+  instrumentation, and can trigger confetti celebrations via the `confetti`
+  prop. Provide `endTime` to automatically close the quiz and display tallies
+  sourced from each option's `tally` value. Use it to capture lightweight
+  intent before handing a lead to sales tooling.
 - **`CountdownTimer`** – Countdown surface that showcases urgency copy, time
   segments, and optional quantity remaining. Persist offer deadlines in UTC,
   convert them to the viewer's local time before display, and pass the UTC
@@ -213,6 +214,32 @@ arbitrary attributes to the underlying Material UI primitive.
 `flashoffer-react` also ships instrumentation utilities that record viewability
 and interaction events. The helpers expose consistent metadata for downstream
 analytics services and gracefully degrade when browser APIs are unavailable.
+
+### Quiz celebrations
+
+`QuizCelebrations` powers the confetti experiences surfaced by
+`MultipleChoiceQuiz`. Import the `QuizConfettiOptions` type and attach a preset
+to the `confetti` prop to select the animation learners see after correct
+submissions. The helper defaults to the "classic" preset when enabled.
+
+```tsx
+import { MultipleChoiceQuiz } from "flashoffer-react";
+
+<MultipleChoiceQuiz
+  question="How quickly can Flashoffer launch a promotion?"
+  options={[
+    { id: "days", label: "A few days" },
+    { id: "hours", label: "Under an hour" },
+    { id: "weeks", label: "Two weeks" }
+  ]}
+  correctOptionId="hours"
+  confetti={{ enabled: true, preset: "streamers" }}
+/>;
+```
+
+For custom experiences, call `launchConfetti("burst")` to fire the animation on
+any event or run `resolveConfettiOptions()` to normalise user configuration
+before passing it to bespoke logic.
 
 Wrap the subtree you want to measure in an `EngagementProvider`. The provider
 requires a `site` identifier and can optionally include a `campaignId` for

--- a/app/flashoffer/docs/flashoffer-react/reference/README.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/README.md
@@ -21,6 +21,7 @@
 - [MultipleChoiceAnswer](interfaces/MultipleChoiceAnswer.md)
 - [MultipleChoiceOption](interfaces/MultipleChoiceOption.md)
 - [MultipleChoiceQuizProps](interfaces/MultipleChoiceQuizProps.md)
+- [QuizConfettiOptions](interfaces/QuizConfettiOptions.md)
 - [QuizAnalyticsOptions](interfaces/QuizAnalyticsOptions.md)
 - [QuizCompletionPayload](interfaces/QuizCompletionPayload.md)
 - [PreviewCardProps](interfaces/PreviewCardProps.md)
@@ -31,6 +32,7 @@
 ## Type Aliases
 
 - [FlashofferThemePreset](type-aliases/FlashofferThemePreset.md)
+- [QuizConfettiPreset](type-aliases/QuizConfettiPreset.md)
 - [OutlineCtaButtonProps](type-aliases/OutlineCtaButtonProps.md)
 - [PrimaryCtaButtonProps](type-aliases/PrimaryCtaButtonProps.md)
 

--- a/app/flashoffer/docs/flashoffer-react/reference/functions/MultipleChoiceQuiz.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/functions/MultipleChoiceQuiz.md
@@ -47,6 +47,24 @@ alerts after each submission. The messaging can be tuned using the
 answer is configured, the component still surfaces the learner's selection
 through the `onAnswer` callback without rendering evaluation UI.
 
+To celebrate correct answers, provide the `confetti` prop with a
+`QuizConfettiOptions` object. The helper resolves presets declared in
+`QuizCelebrations` and automatically disables animations when `enabled` is set
+to `false`.
+
+```tsx
+<MultipleChoiceQuiz
+  question="Which preset ships the boldest Flashoffer gradients?"
+  options={[
+    { id: "forest", label: "Forest Canopy" },
+    { id: "monochrome", label: "Monochrome Focus" },
+    { id: "midnight", label: "Midnight Pulse" }
+  ]}
+  correctOptionId="midnight"
+  confetti={{ enabled: true, preset: "burst" }}
+/>;
+```
+
 ## Submission flow
 
 By default, learners can retry after an incorrect attempt when a correct

--- a/app/flashoffer/docs/flashoffer-react/reference/interfaces/MultipleChoiceQuizProps.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/interfaces/MultipleChoiceQuizProps.md
@@ -153,3 +153,15 @@ aggregated tallies.
 Defined in: src/components/MultipleChoiceQuiz.tsx:72
 
 Custom message announced to learners once the quiz has closed.
+
+***
+
+### confetti?
+
+> `optional` **confetti**: [`QuizConfettiOptions`](QuizConfettiOptions.md)
+
+Defined in: src/components/MultipleChoiceQuiz.tsx:77
+
+Configures the celebratory confetti animation shown after correct answers. Set
+`enabled` to `false` to disable the animation or provide a preset from
+`QuizCelebrations` to change the effect.

--- a/app/flashoffer/docs/flashoffer-react/reference/interfaces/QuizConfettiOptions.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/interfaces/QuizConfettiOptions.md
@@ -1,0 +1,40 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Interface: QuizConfettiOptions
+
+Configuration describing when to play a celebratory confetti animation.
+
+Defined in: src/components/QuizCelebrations.ts:16
+
+## Properties
+
+### enabled
+
+> **enabled**: `boolean`
+
+Turns the animation on or off. Set this to `false` to suppress confetti even
+when a quiz answer is correct.
+
+Defined in: src/components/QuizCelebrations.ts:18
+
+***
+
+### preset?
+
+> `optional` **preset**:
+> [`QuizConfettiPreset`](../type-aliases/QuizConfettiPreset.md)
+
+Selects the visual preset to render. Defaults to `"classic"` when omitted.
+
+Defined in: src/components/QuizCelebrations.ts:20
+
+## Usage
+
+```ts
+const celebration: QuizConfettiOptions = {
+  enabled: true,
+  preset: "streamers",
+};
+```

--- a/app/flashoffer/docs/flashoffer-react/reference/type-aliases/QuizConfettiPreset.md
+++ b/app/flashoffer/docs/flashoffer-react/reference/type-aliases/QuizConfettiPreset.md
@@ -1,0 +1,13 @@
+[**flashoffer-react**](../README.md)
+
+***
+
+# Type Alias: QuizConfettiPreset
+
+> **QuizConfettiPreset** = "classic" | "streamers" | "burst"
+
+Defined in: src/components/QuizCelebrations.ts:11
+
+Named presets that determine how `QuizCelebrations` renders the confetti burst.
+Use `"classic"` for a balanced spray, `"streamers"` for angled ribbons, and
+`"burst"` for a dense fireworks-style effect.

--- a/app/flashoffer/flashoffer-demo/package-lock.json
+++ b/app/flashoffer/flashoffer-demo/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^7.3.1",
         "@mui/utils": "^7.3.1",
+        "canvas-confetti": "^1.9.3",
         "flashoffer-react": "file:../flashoffer-react",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -37,6 +38,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^7.3.1",
         "@mui/utils": "^7.3.1",
+        "canvas-confetti": "^1.9.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -2141,6 +2143,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chai": {
       "version": "5.3.3",

--- a/app/flashoffer/flashoffer-demo/package.json
+++ b/app/flashoffer/flashoffer-demo/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.3.1",
     "@mui/utils": "^7.3.1",
+    "canvas-confetti": "^1.9.3",
     "flashoffer-react": "file:../flashoffer-react",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/app/flashoffer/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer/flashoffer-demo/src/App.tsx
@@ -10,7 +10,11 @@ import type { PaletteMode, ThemeOptions } from "@mui/material/styles";
 import { Suspense, lazy, startTransition, useMemo, useState } from "react";
 import { FlashofferThemeProvider } from "flashoffer-react";
 import type { FlashofferThemePreset } from "flashoffer-react";
-import type { HeroAlignment, ThemePreset } from "./sections/types";
+import type {
+  HeroAlignment,
+  QuizCelebrationSelection,
+  ThemePreset
+} from "./sections/types";
 import { THEME_PRESET_LABELS } from "./sections/types";
 
 const CustomizationControlsSection = lazy(async () => ({
@@ -216,6 +220,8 @@ const heroMedia = (
 export default function App() {
   const [palettePreset, setPalettePreset] = useState<ThemePreset>("ocean");
   const [heroAlignment, setHeroAlignment] = useState<HeroAlignment>("center");
+  const [quizCelebrationPreset, setQuizCelebrationPreset] =
+    useState<QuizCelebrationSelection>("classic");
 
   const themeConfig = useMemo(
     () => themePresets[palettePreset],
@@ -227,9 +233,10 @@ export default function App() {
       JSON.stringify({
         palette: palettePreset,
         presetLabel: THEME_PRESET_LABELS[palettePreset],
-        heroAlignment
+        heroAlignment,
+        quizCelebrationPreset
       }),
-    [heroAlignment, palettePreset]
+    [heroAlignment, palettePreset, quizCelebrationPreset]
   );
 
   const heroMeta = useMemo(
@@ -293,6 +300,12 @@ export default function App() {
                     setHeroAlignment(nextAlignment);
                   });
                 }}
+                quizCelebrationPreset={quizCelebrationPreset}
+                onQuizCelebrationPresetChange={(nextPreset) => {
+                  startTransition(() => {
+                    setQuizCelebrationPreset(nextPreset);
+                  });
+                }}
                 controlsMeta={controlsMeta}
               />
             </Suspense>
@@ -320,7 +333,9 @@ export default function App() {
               <FigureSpotlightSection />
             </Suspense>
             <Suspense fallback={null}>
-              <QuizShowcaseSection />
+              <QuizShowcaseSection
+                celebrationPreset={quizCelebrationPreset}
+              />
             </Suspense>
             <Suspense fallback={null}>
               <FooterSection />

--- a/app/flashoffer/flashoffer-demo/src/sections/CustomizationControlsSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/CustomizationControlsSection.tsx
@@ -9,14 +9,27 @@ import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { Section } from "flashoffer-react";
-import type { HeroAlignment, ThemePreset } from "./types";
-import { THEME_PRESET_LABELS, THEME_PRESET_ORDER } from "./types";
+import type {
+  HeroAlignment,
+  QuizCelebrationSelection,
+  ThemePreset
+} from "./types";
+import {
+  QUIZ_CELEBRATION_LABELS,
+  QUIZ_CELEBRATION_ORDER,
+  THEME_PRESET_LABELS,
+  THEME_PRESET_ORDER
+} from "./types";
 
 export interface CustomizationControlsSectionProps {
   palettePreset: ThemePreset;
   onPalettePresetChange: (nextPreset: ThemePreset) => void;
   heroAlignment: HeroAlignment;
   onHeroAlignmentChange: (nextAlignment: HeroAlignment) => void;
+  quizCelebrationPreset: QuizCelebrationSelection;
+  onQuizCelebrationPresetChange: (
+    nextPreset: QuizCelebrationSelection
+  ) => void;
   controlsMeta: string;
 }
 
@@ -25,6 +38,8 @@ export function CustomizationControlsSection({
   onPalettePresetChange,
   heroAlignment,
   onHeroAlignmentChange,
+  quizCelebrationPreset,
+  onQuizCelebrationPresetChange,
   controlsMeta
 }: CustomizationControlsSectionProps) {
   return (
@@ -42,15 +57,21 @@ export function CustomizationControlsSection({
           title="Customize the showcase"
         >
           <Typography color="text.secondary">
-            Switch palettes or tweak hero alignment to preview how Flashoffer
-            primitives adapt.
+            Switch palettes, adjust hero alignment, or pick a celebration
+            preset to preview how Flashoffer primitives adapt.
           </Typography>
         </Section>
         <Divider flexItem sx={{ borderColor: "divider" }} />
         <Stack
           direction={{ xs: "column", sm: "row" }}
           spacing={3}
-          divider={<Divider orientation="vertical" flexItem sx={{ display: { xs: "none", sm: "block" } }} />}
+          divider={
+            <Divider
+              orientation="vertical"
+              flexItem
+              sx={{ display: { xs: "none", sm: "block" } }}
+            />
+          }
           useFlexGap
         >
           <Box>
@@ -110,6 +131,38 @@ export function CustomizationControlsSection({
             >
               <option value="center">Centered</option>
               <option value="left">Left aligned</option>
+            </select>
+          </Box>
+          <Box>
+            <Typography variant="overline" color="text.secondary">
+              Quiz celebration
+            </Typography>
+            <select
+              value={quizCelebrationPreset}
+              onChange={(event) => {
+                const nextPreset = event.target
+                  .value as QuizCelebrationSelection;
+                onQuizCelebrationPresetChange(nextPreset);
+              }}
+              aria-label="Select quiz celebration"
+              style={{
+                marginTop: "0.5rem",
+                padding: "0.5rem 0.75rem",
+                borderRadius: "0.75rem",
+                border: "1px solid rgba(148, 163, 184, 0.4)",
+                backgroundColor: "var(--flashoffer-color-surface)",
+                color: "var(--flashoffer-color-text-primary)",
+                fontSize: "0.95rem"
+              }}
+              data-track-id="quiz-celebration"
+              data-track-label="Quiz celebration selector"
+              data-track-meta={JSON.stringify({ preset: quizCelebrationPreset })}
+            >
+              {QUIZ_CELEBRATION_ORDER.map((value) => (
+                <option key={value} value={value}>
+                  {QUIZ_CELEBRATION_LABELS[value]}
+                </option>
+              ))}
             </select>
           </Box>
         </Stack>

--- a/app/flashoffer/flashoffer-demo/src/sections/QuizShowcaseSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/QuizShowcaseSection.tsx
@@ -6,13 +6,15 @@
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   MultipleChoiceQuiz,
   Section,
   logQuizCompletion,
 } from "flashoffer-react";
 import type { MultipleChoiceAnswer } from "flashoffer-react";
+import type { QuizConfettiOptions } from "flashoffer-react";
+import type { QuizCelebrationSelection } from "./types";
 
 const QUIZ_OPTIONS = [
   {
@@ -50,18 +52,19 @@ const QUIZ_ANALYTICS_CONFIG = {
   endpoint: QUIZ_EVENTS_ENDPOINT,
 };
 
-const QUIZ_META = JSON.stringify({
-  question: "Best follow-up after a Flashoffer engagement",
-  options: QUIZ_OPTIONS.map((option) => option.id)
-});
-
 const QUIZ_QUESTION =
   "After a prospect explores a Flashoffer landing page, what follow-up drives " +
   "the highest conversion lift?";
 
 const DEMO_CAMPAIGN_ID = "flashoffer-demo";
 
-export function QuizShowcaseSection() {
+export interface QuizShowcaseSectionProps {
+  celebrationPreset: QuizCelebrationSelection;
+}
+
+export function QuizShowcaseSection({
+  celebrationPreset,
+}: QuizShowcaseSectionProps) {
   const campaignApiBase =
     typeof import.meta.env.VITE_FLASHOFFER_CAMPAIGN_API_BASE === "string" &&
     import.meta.env.VITE_FLASHOFFER_CAMPAIGN_API_BASE.trim() !== ""
@@ -69,6 +72,24 @@ export function QuizShowcaseSection() {
       : undefined;
   const [campaignEndTime, setCampaignEndTime] = useState<Date | null>(null);
   const attemptRef = useRef(0);
+
+  const confettiOptions = useMemo<QuizConfettiOptions>(
+    () =>
+      celebrationPreset === "disabled"
+        ? { enabled: false }
+        : { enabled: true, preset: celebrationPreset },
+    [celebrationPreset]
+  );
+
+  const quizMeta = useMemo(
+    () =>
+      JSON.stringify({
+        question: "Best follow-up after a Flashoffer engagement",
+        options: QUIZ_OPTIONS.map((option) => option.id),
+        celebrationPreset,
+      }),
+    [celebrationPreset]
+  );
 
   const handleAnswer = (answer: MultipleChoiceAnswer) => {
     attemptRef.current += 1;
@@ -141,7 +162,7 @@ export function QuizShowcaseSection() {
       component="section"
       data-track-id="quiz-showcase"
       data-track-label="Interactive quiz showcase"
-      data-track-meta={QUIZ_META}
+      data-track-meta={quizMeta}
     >
       <Section
         eyebrow="INTERACTIVE"
@@ -167,6 +188,7 @@ export function QuizShowcaseSection() {
               errorMessage="Think about which follow-up reduces friction instead of adding new steps."
               onAnswer={handleAnswer}
               endTime={campaignEndTime ?? undefined}
+              confetti={confettiOptions}
             />
           </Grid>
         </Grid>

--- a/app/flashoffer/flashoffer-demo/src/sections/types.ts
+++ b/app/flashoffer/flashoffer-demo/src/sections/types.ts
@@ -3,6 +3,8 @@
  * Released under the MIT license.
  */
 
+import type { QuizConfettiPreset } from "flashoffer-react";
+
 export type ThemePreset =
   | "ocean"
   | "sunset"
@@ -15,6 +17,7 @@ export type ThemePreset =
   | "spaciousLight"
   | "spaciousDark";
 export type HeroAlignment = "left" | "center";
+export type QuizCelebrationSelection = "disabled" | QuizConfettiPreset;
 
 export const THEME_PRESET_ORDER: readonly ThemePreset[] = [
   "ocean",
@@ -40,4 +43,21 @@ export const THEME_PRESET_LABELS: Record<ThemePreset, string> = {
   monochromeFocus: "Monochrome focus",
   spaciousLight: "Spacious typography (light)",
   spaciousDark: "Spacious typography (dark)"
+};
+
+export const QUIZ_CELEBRATION_ORDER: readonly QuizCelebrationSelection[] = [
+  "classic",
+  "streamers",
+  "burst",
+  "disabled"
+];
+
+export const QUIZ_CELEBRATION_LABELS: Record<
+  QuizCelebrationSelection,
+  string
+> = {
+  classic: "Classic confetti",
+  streamers: "Streamers",
+  burst: "Firework burst",
+  disabled: "Disabled"
 };

--- a/app/flashoffer/flashoffer-demo/vite.config.ts
+++ b/app/flashoffer/flashoffer-demo/vite.config.ts
@@ -19,6 +19,9 @@ const materialBase = toPosixPath(
   resolvePath(nodeModulesDir, "@mui/material")
 );
 const muiUtilsBase = toPosixPath(resolvePath(nodeModulesDir, "@mui/utils"));
+const confettiEntry = toPosixPath(
+  resolvePath(nodeModulesDir, "canvas-confetti/dist/confetti.module.mjs")
+);
 
 const campaignProxyTarget = process.env.VITE_FLASHOFFER_CAMPAIGN_API_BASE?.trim();
 const proxyTarget = campaignProxyTarget ? campaignProxyTarget.replace(/\/$/, "") : undefined;
@@ -54,6 +57,10 @@ export default defineConfig({
       {
         find: /^@mui\/utils\/(.*)$/i,
         replacement: `${muiUtilsBase}/$1`
+      },
+      {
+        find: /^canvas-confetti$/,
+        replacement: confettiEntry
       }
     ]
   },


### PR DESCRIPTION
## Summary
- add a quiz celebration selector to the flashoffer demo and pass the configuration to the quiz showcase
- document QuizCelebrations usage, including new reference entries for quiz confetti presets and options
- wire the canvas-confetti dependency and Vite alias so the demo and tests can resolve the animation module

## Testing
- npm test (from app/flashoffer/flashoffer-demo)


------
https://chatgpt.com/codex/tasks/task_e_68f28dc6fb688321897b851ae4c58c51