### PR TITLE
Convert flashoffer demo selects to MUI Select

### DIFF
--- a/app/flashoffer/flashoffer-demo/package-lock.json
+++ b/app/flashoffer/flashoffer-demo/package-lock.json
@@ -37,6 +37,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^7.3.1",
         "@mui/utils": "^7.3.1",
+        "canvas-confetti": "^1.9.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },

--- a/app/flashoffer/flashoffer-demo/src/App.tsx
+++ b/app/flashoffer/flashoffer-demo/src/App.tsx
@@ -6,10 +6,14 @@
 import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
+import FormControl from "@mui/material/FormControl";
+import MenuItem from "@mui/material/MenuItem";
 import Stack from "@mui/material/Stack";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import type { PaletteMode, ThemeOptions } from "@mui/material/styles";
+import Select from "@mui/material/Select";
+import type { SelectChangeEvent } from "@mui/material/Select";
 import {
   Suspense,
   lazy,
@@ -328,38 +332,31 @@ export default function App() {
           }}
         >
           <Toolbar sx={{ justifyContent: "flex-end" }}>
-            <Stack direction="row" spacing={2}>
+            <Stack direction="row" spacing={2} alignItems="center">
               <Typography>
                 Palette
               </Typography>
-              <select
-                value={palettePreset}
-                onChange={(event) => {
-                  const nextPreset = event.target.value as ThemePreset;
-                  startTransition(() => {
-                    setPalettePreset(nextPreset);
-                  });
-                }}
-                aria-label="Select theme palette"
-                style={{
-                  marginTop: "0.5rem",
-                  padding: "0.5rem 0.75rem",
-                  borderRadius: "0.75rem",
-                  border: "1px solid rgba(148, 163, 184, 0.4)",
-                  backgroundColor: "var(--flashoffer-color-surface)",
-                  color: "var(--flashoffer-color-text-primary)",
-                  fontSize: "0.95rem"
-                }}
-                data-track-id="palette-selector"
-                data-track-label="Palette selector"
-                data-track-meta={JSON.stringify({ palette: palettePreset })}
-              >
-                {THEME_PRESET_ORDER.map((value) => (
-                  <option key={value} value={value}>
-                    {THEME_PRESET_LABELS[value]}
-                  </option>
-                ))}
-              </select>
+              <FormControl size="small" sx={{ minWidth: 180 }}>
+                <Select
+                  value={palettePreset}
+                  onChange={(event: SelectChangeEvent<ThemePreset>) => {
+                    const nextPreset = event.target.value as ThemePreset;
+                    startTransition(() => {
+                      setPalettePreset(nextPreset);
+                    });
+                  }}
+                  aria-label="Select theme palette"
+                  data-track-id="palette-selector"
+                  data-track-label="Palette selector"
+                  data-track-meta={JSON.stringify({ palette: palettePreset })}
+                >
+                  {THEME_PRESET_ORDER.map((value) => (
+                    <MenuItem key={value} value={value}>
+                      {THEME_PRESET_LABELS[value]}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
             </Stack>
           </Toolbar>
         </AppBar>

--- a/app/flashoffer/flashoffer-demo/src/sections/CustomizationControlsSection.tsx
+++ b/app/flashoffer/flashoffer-demo/src/sections/CustomizationControlsSection.tsx
@@ -5,7 +5,11 @@
 
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
+import FormControl from "@mui/material/FormControl";
+import MenuItem from "@mui/material/MenuItem";
 import Paper from "@mui/material/Paper";
+import Select from "@mui/material/Select";
+import type { SelectChangeEvent } from "@mui/material/Select";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { Section } from "flashoffer-react";
@@ -47,29 +51,22 @@ export function CustomizationControlsSection({
             <Typography variant="overline" color="text.secondary">
               Hero alignment
             </Typography>
-            <select
-              value={heroAlignment}
-              onChange={(event) => {
-                const nextAlignment = event.target.value as HeroAlignment;
-                onHeroAlignmentChange(nextAlignment);
-              }}
-              aria-label="Select hero alignment"
-              style={{
-                marginTop: "0.5rem",
-                padding: "0.5rem 0.75rem",
-                borderRadius: "0.75rem",
-                border: "1px solid rgba(148, 163, 184, 0.4)",
-                backgroundColor: "var(--flashoffer-color-surface)",
-                color: "var(--flashoffer-color-text-primary)",
-                fontSize: "0.95rem"
-              }}
-              data-track-id="hero-alignment"
-              data-track-label="Hero alignment selector"
-              data-track-meta={JSON.stringify({ alignment: heroAlignment })}
-            >
-              <option value="center">Centered</option>
-              <option value="left">Left aligned</option>
-            </select>
+            <FormControl fullWidth sx={{ mt: 1.5 }}>
+              <Select
+                value={heroAlignment}
+                onChange={(event: SelectChangeEvent<HeroAlignment>) => {
+                  const nextAlignment = event.target.value as HeroAlignment;
+                  onHeroAlignmentChange(nextAlignment);
+                }}
+                aria-label="Select hero alignment"
+                data-track-id="hero-alignment"
+                data-track-label="Hero alignment selector"
+                data-track-meta={JSON.stringify({ alignment: heroAlignment })}
+              >
+                <MenuItem value="center">Centered</MenuItem>
+                <MenuItem value="left">Left aligned</MenuItem>
+              </Select>
+            </FormControl>
           </Box>
         </Stack>
       </Stack>


### PR DESCRIPTION
## Summary
- replace native select elements in the flashoffer demo with MUI Select components for palette and hero alignment controls
- wire up the new selects to preserve tracking metadata while keeping layout and alignment consistent
- refresh the lockfile after installing dependencies required by the flashoffer React package

## Testing
- npm --prefix app/flashoffer/flashoffer-demo run test *(fails: missing optional dependency canvas-confetti referenced by flashoffer-react)*

------
https://chatgpt.com/codex/tasks/task_e_68f29359a53c8321b317617d9baeaa87