### PR TITLE
Use React's act helper in Flashoffer React tests

### DIFF
--- a/app/flashoffer/flashoffer-react/src/analytics/__tests__/EngagementProvider.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/__tests__/EngagementProvider.test.tsx
@@ -3,7 +3,8 @@
  * Released under the MIT license.
  */
 
-import { act, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import { act } from "react";
 import type { MutableRefObject } from "react";
 import {
   EngagementProvider,

--- a/app/flashoffer/flashoffer-react/src/components/__tests__/CountdownTimer.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/__tests__/CountdownTimer.test.tsx
@@ -3,7 +3,8 @@
  * Released under the MIT license.
  */
 
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
 
 import { FlashofferThemeProvider } from "../../theme/FlashofferThemeProvider";
 import type { FlashofferThemeProviderProps } from "../../theme/FlashofferThemeProvider";

--- a/app/flashoffer/flashoffer-react/src/components/__tests__/MultipleChoiceQuiz.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/__tests__/MultipleChoiceQuiz.test.tsx
@@ -3,7 +3,8 @@
  * Released under the MIT license.
  */
 
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react";
 
 import { FlashofferThemeProvider } from "../../theme/FlashofferThemeProvider";
 import { MultipleChoiceQuiz } from "../MultipleChoiceQuiz";


### PR DESCRIPTION
## Summary
- import `act` from React in Flashoffer React test suites to avoid the deprecated `react-dom/test-utils` helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f2a25a238c8321afd869e96c191479