### PR TITLE
Ensure React act helper is defined in tests

### DIFF
--- a/app/flashoffer/flashoffer-react/setupTests.ts
+++ b/app/flashoffer/flashoffer-react/setupTests.ts
@@ -4,3 +4,18 @@
  */
 
 import "@testing-library/jest-dom";
+import * as React from "react";
+import { act as domAct } from "react-dom/test-utils";
+
+/**
+ * Ensure React's `act` helper is always available during tests, even when
+ * Jest resolves React from a build that does not attach the helper yet.
+ */
+
+type ReactWithAct = typeof React & { act?: typeof domAct };
+
+const reactWithAct = React as ReactWithAct;
+
+if (typeof reactWithAct.act !== "function") {
+  reactWithAct.act = domAct;
+}

--- a/app/flashoffer/flashoffer-react/src/analytics/__tests__/EngagementProvider.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/__tests__/EngagementProvider.test.tsx
@@ -3,7 +3,8 @@
  * Released under the MIT license.
  */
 
-import { act, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import { act } from "react";
 import type { MutableRefObject } from "react";
 import {
   EngagementProvider,

--- a/app/flashoffer/flashoffer-react/src/components/__tests__/CountdownTimer.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/__tests__/CountdownTimer.test.tsx
@@ -3,7 +3,8 @@
  * Released under the MIT license.
  */
 
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
 
 import { FlashofferThemeProvider } from "../../theme/FlashofferThemeProvider";
 import type { FlashofferThemeProviderProps } from "../../theme/FlashofferThemeProvider";

--- a/app/flashoffer/flashoffer-react/src/components/__tests__/MultipleChoiceQuiz.test.tsx
+++ b/app/flashoffer/flashoffer-react/src/components/__tests__/MultipleChoiceQuiz.test.tsx
@@ -3,7 +3,8 @@
  * Released under the MIT license.
  */
 
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react";
 
 import { FlashofferThemeProvider } from "../../theme/FlashofferThemeProvider";
 import { MultipleChoiceQuiz } from "../MultipleChoiceQuiz";


### PR DESCRIPTION
## Summary
- import `act` from React in Flashoffer React test suites to avoid the deprecated `react-dom/test-utils` helper
- polyfill React.act in the Jest setup so tests never crash when the helper is missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f2a25a238c8321afd869e96c191479