### PR TITLE
Replace Flashoffer tooling scripts with Python CLI

### DIFF
--- a/bin/flashoffer-build
+++ b/bin/flashoffer-build
@@ -1,2 +1,0 @@
-export COMPOSE_FILE=docker-compose.yml:app/flashoffer/docker/analytics.yml:app/flashoffer/docker/quiz.yml:app/flashoffer/docker/campaign.yml:app/flashoffer/docker/flashoffer.yml
-docker compose build "$@" analytics-db analytics-backend quiz-backend campaign-backend flashoffer-dev

--- a/bin/quiz-backend
+++ b/bin/quiz-backend
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unified Flashoffer developer tooling CLI."""
+"""Wrapper around the Flashoffer CLI for the quiz-backend service."""
 
 from __future__ import annotations
 
@@ -15,10 +15,10 @@ from flashoffer_cli.cli import CLIError, main  # noqa: E402
 def run() -> int:
     try:
         return main(
-            default_service="flashoffer-dev",
-            allow_prod_switch=True,
-            allowed_services=None,
-            program_name="flashoffer",
+            default_service="quiz-backend",
+            allow_prod_switch=False,
+            allowed_services=["quiz-backend"],
+            program_name="quiz-backend",
         )
     except CLIError as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/bin/quiz-backend-build
+++ b/bin/quiz-backend-build
@@ -1,3 +1,0 @@
-#!/bin/bash
-COMPOSE_FILE=app/flashoffer/docker/analytics.yml:app/flashoffer/docker/quiz.yml
-docker compose build "$@" quiz-backend

--- a/bin/quiz-backend-push
+++ b/bin/quiz-backend-push
@@ -1,4 +1,0 @@
-#!/bin/bash
-CONTAINER_REGISTRY=registry.digitalocean.com/flashoffer
-docker tag press-quiz-backend ${CONTAINER_REGISTRY}/quiz-backend
-docker push ${CONTAINER_REGISTRY}/quiz-backend

--- a/cfg/flashoffer-cli.json
+++ b/cfg/flashoffer-cli.json
@@ -1,0 +1,70 @@
+{
+  "registry_env": "CONTAINER_REGISTRY",
+  "registry_default": "registry.digitalocean.com/flashoffer",
+  "services": {
+    "flashoffer-dev": {
+      "compose_files": [
+        "docker-compose.yml",
+        "app/flashoffer/docker/analytics.yml",
+        "app/flashoffer/docker/quiz.yml",
+        "app/flashoffer/docker/campaign.yml",
+        "app/flashoffer/docker/flashoffer.yml"
+      ],
+      "shared_services": [
+        "analytics-db",
+        "analytics-backend",
+        "quiz-backend",
+        "campaign-backend"
+      ],
+      "image": "press-flashoffer-dev",
+      "remote_suffix": "flashoffer-dev",
+      "supports": {
+        "install": true,
+        "npm": true,
+        "coverage": true,
+        "post_build_install": true
+      },
+      "npm_workdir": "/workspace/app/flashoffer/flashoffer-react"
+    },
+    "flashoffer": {
+      "compose_files": [
+        "docker-compose.yml",
+        "app/flashoffer/docker/analytics.yml",
+        "app/flashoffer/docker/quiz.yml",
+        "app/flashoffer/docker/campaign.yml",
+        "app/flashoffer/docker/flashoffer.yml"
+      ],
+      "shared_services": [
+        "analytics-db",
+        "analytics-backend",
+        "quiz-backend",
+        "campaign-backend"
+      ],
+      "image": "press-flashoffer",
+      "remote_suffix": "flashoffer",
+      "supports": {
+        "install": false,
+        "npm": false,
+        "coverage": false,
+        "post_build_install": false
+      }
+    },
+    "quiz-backend": {
+      "compose_files": [
+        "app/flashoffer/docker/analytics.yml",
+        "app/flashoffer/docker/quiz.yml"
+      ],
+      "shared_services": [
+        "analytics-db"
+      ],
+      "image": "press-quiz-backend",
+      "remote_suffix": "quiz-backend",
+      "supports": {
+        "install": false,
+        "npm": false,
+        "coverage": false,
+        "post_build_install": false
+      }
+    }
+  }
+}

--- a/src/flashoffer_cli/__init__.py
+++ b/src/flashoffer_cli/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for Flashoffer developer tooling CLI."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/src/flashoffer_cli/cli.py
+++ b/src/flashoffer_cli/cli.py
@@ -1,0 +1,262 @@
+"""Command-line interface for Flashoffer developer tooling."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+from .config import ServiceConfig, load_config
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+CONFIG_PATH = ROOT_DIR / "cfg" / "flashoffer-cli.json"
+
+
+class CLIError(RuntimeError):
+    """Raised when user-facing errors occur in the CLI."""
+
+
+def _ensure_docker() -> None:
+    if shutil.which("docker") is None:
+        raise CLIError("docker must be installed to run these commands")
+
+
+def _set_compose_env(config: ServiceConfig) -> None:
+    if "COMPOSE_FILE" not in os.environ:
+        os.environ["COMPOSE_FILE"] = config.compose_env_value()
+
+
+def _compose_base_args(command: str) -> List[str]:
+    args = ["docker", "compose", command]
+    if command == "up":
+        args.append("--remove-orphans")
+    return args
+
+
+def _run_subprocess(args: List[str]) -> None:
+    subprocess.run(args, check=True)
+
+
+def _compose_services_args(config: ServiceConfig) -> List[str]:
+    return [*config.shared_services, config.name]
+
+
+def _run_compose_command(command: str, config: ServiceConfig, extra: List[str]) -> None:
+    _ensure_docker()
+    args = _compose_base_args(command)
+    args.extend(extra)
+    args.extend(_compose_services_args(config))
+    _run_subprocess(args)
+
+
+def _host_user_id() -> str:
+    return str(os.getuid())
+
+
+def _run_install(config: ServiceConfig) -> None:
+    if not config.supports_install:
+        raise CLIError(f"install is not available for the {config.name} service")
+    _ensure_docker()
+    args = [
+        "docker",
+        "compose",
+        "run",
+        "--rm",
+        "--entrypoint",
+        "npm",
+        "-u",
+        _host_user_id(),
+        config.name,
+        "install",
+    ]
+    _run_subprocess(args)
+
+
+def _run_npm(config: ServiceConfig, npm_args: List[str]) -> None:
+    if not config.supports_npm:
+        raise CLIError(f"npm commands are not available for the {config.name} service")
+    if not npm_args:
+        raise CLIError("npm command requires arguments")
+    _ensure_docker()
+    args = [
+        "docker",
+        "compose",
+        "run",
+        "--rm",
+        "--entrypoint",
+        "npm",
+        "-u",
+        _host_user_id(),
+    ]
+    if config.npm_workdir:
+        args.extend(["--workdir", config.npm_workdir])
+    args.append(config.name)
+    args.extend(npm_args)
+    _run_subprocess(args)
+
+
+def _run_cov(config: ServiceConfig) -> None:
+    if not config.supports_coverage:
+        raise CLIError(f"cov command is not available for the {config.name} service")
+    _run_npm(config, ["run", "test:coverage"])
+
+
+def _run_bash(config: ServiceConfig) -> None:
+    _ensure_docker()
+    args = [
+        "docker",
+        "compose",
+        "run",
+        "--entrypoint",
+        "bash",
+        "--rm",
+        "--remove-orphans",
+        config.name,
+    ]
+    _run_subprocess(args)
+
+
+def _run_push(config: ServiceConfig, registry: str, args: List[str]) -> None:
+    parser = argparse.ArgumentParser(prog="push", add_help=False)
+    parser.add_argument("--tag", dest="tag", help="Remote image tag")
+    opts, leftovers = parser.parse_known_args(args)
+    if leftovers:
+        raise CLIError(f"Unknown push option(s): {' '.join(leftovers)}")
+    remote = opts.tag or config.default_remote_image(registry)
+    _ensure_docker()
+    _run_subprocess(["docker", "tag", config.image, remote])
+    _run_subprocess(["docker", "push", remote])
+
+
+def _normalize_command_args(args: List[str]) -> List[str]:
+    if args and args[0] == "--":
+        return args[1:]
+    return args
+
+
+def _build_parser(program_name: str, allow_prod: bool, services: Iterable[str]) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=program_name,
+        description=(
+            "Management script for Flashoffer services backed by Docker Compose. "
+            "Use --list-services to inspect available service profiles."
+        ),
+    )
+    parser.add_argument(
+        "--service",
+        choices=sorted(services),
+        help="Target a specific service profile",
+    )
+    if allow_prod:
+        parser.add_argument(
+            "--prod",
+            action="store_true",
+            help="Shortcut for --service flashoffer",
+        )
+    parser.add_argument(
+        "--list-services",
+        action="store_true",
+        help="List the configured service profiles",
+    )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        default="up",
+        help="Command to run (default: up)",
+    )
+    parser.add_argument(
+        "command_args",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments passed to the underlying command",
+    )
+    return parser
+
+
+def main(
+    argv: List[str] | None = None,
+    *,
+    default_service: str = "flashoffer-dev",
+    allow_prod_switch: bool = True,
+    allowed_services: Iterable[str] | None = None,
+    program_name: str | None = None,
+) -> int:
+    """Entry point for the Flashoffer CLI."""
+
+    config = load_config(CONFIG_PATH)
+    services_config = config.allowed_services(allowed_services)
+    if default_service not in services_config:
+        raise CLIError(f"Unknown default service {default_service!r}")
+    program = program_name or Path(sys.argv[0]).name
+    parser = _build_parser(program, allow_prod_switch, services_config)
+    args = parser.parse_args(argv)
+
+    if args.list_services:
+        for name in services_config:
+            print(name)
+        return 0
+
+    service_name = args.service or default_service
+    if allow_prod_switch and getattr(args, "prod", False):
+        if service_name not in {default_service, "flashoffer-dev"}:
+            raise CLIError("--prod cannot be combined with an explicit --service value")
+        service_name = "flashoffer"
+    elif args.command == "help":
+        parser.print_help()
+        return 0
+    elif args.command in {"-h", "--help"}:
+        parser.print_help()
+        return 0
+    if not allow_prod_switch and getattr(args, "prod", False):
+        raise CLIError("--prod is not supported for this command")
+
+    if service_name not in services_config:
+        raise CLIError(f"Unknown service: {service_name}")
+    service_config = services_config[service_name]
+
+    os.chdir(ROOT_DIR)
+    _set_compose_env(service_config)
+
+    command_args = _normalize_command_args(args.command_args or [])
+
+    registry = config.registry()
+
+    if args.command == "up":
+        _run_compose_command("up", service_config, command_args)
+        return 0
+    if args.command == "build":
+        _run_compose_command("build", service_config, command_args)
+        if service_config.post_build_install and service_config.supports_install:
+            _run_install(service_config)
+        return 0
+    if args.command == "install":
+        _run_install(service_config)
+        return 0
+    if args.command == "cov":
+        _run_cov(service_config)
+        return 0
+    if args.command == "npm":
+        _run_npm(service_config, command_args)
+        return 0
+    if args.command == "bash":
+        _run_bash(service_config)
+        return 0
+    if args.command == "push":
+        _run_push(service_config, registry, command_args)
+        return 0
+    if args.command in {"help", "-h", "--help"}:
+        parser.print_help()
+        return 0
+
+    raise CLIError(f"Unknown command: {args.command}")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    try:
+        raise SystemExit(main())
+    except CLIError as exc:  # pragma: no cover - CLI error handling
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/src/flashoffer_cli/config.py
+++ b/src/flashoffer_cli/config.py
@@ -1,0 +1,123 @@
+"""Configuration loading for the Flashoffer CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+
+@dataclass(frozen=True)
+class ServiceConfig:
+    """Represents configuration for a docker-compose backed service."""
+
+    name: str
+    compose_files: List[str]
+    shared_services: List[str]
+    image: str
+    remote_suffix: str
+    supports_install: bool
+    supports_npm: bool
+    supports_coverage: bool
+    post_build_install: bool
+    npm_workdir: str | None = None
+
+    def compose_env_value(self) -> str:
+        """Return the colon-separated compose file list."""
+
+        return ":".join(self.compose_files)
+
+    def default_remote_image(self, registry: str) -> str:
+        """Build the default remote image path for pushes."""
+
+        return f"{registry}/{self.remote_suffix}"
+
+
+@dataclass(frozen=True)
+class CLIConfig:
+    """Root configuration for the Flashoffer CLI."""
+
+    registry_env: str
+    registry_default: str
+    services: Dict[str, ServiceConfig]
+
+    def allowed_services(self, names: Iterable[str] | None = None) -> Dict[str, ServiceConfig]:
+        """Return a filtered set of services if ``names`` is provided."""
+
+        if names is None:
+            return self.services
+        subset = {name: self.services[name] for name in names}
+        return subset
+
+    def registry(self) -> str:
+        """Resolve the registry value from the environment."""
+
+        return os.environ.get(self.registry_env, self.registry_default)
+
+
+def _load_services(raw_services: Dict[str, object]) -> Dict[str, ServiceConfig]:
+    services: Dict[str, ServiceConfig] = {}
+    for name, raw_config in raw_services.items():
+        if not isinstance(raw_config, dict):
+            raise ValueError(f"Invalid configuration for service {name!r}")
+        compose_files = _require_list(raw_config, "compose_files")
+        shared_services = _require_list(raw_config, "shared_services")
+        image = _require_str(raw_config, "image")
+        remote_suffix = _require_str(raw_config, "remote_suffix")
+        supports = raw_config.get("supports", {})
+        if not isinstance(supports, dict):
+            raise ValueError(f"Invalid supports block for {name!r}")
+        npm_workdir = raw_config.get("npm_workdir")
+        if npm_workdir is not None and not isinstance(npm_workdir, str):
+            raise ValueError(f"npm_workdir must be a string for {name!r}")
+        services[name] = ServiceConfig(
+            name=name,
+            compose_files=compose_files,
+            shared_services=shared_services,
+            image=image,
+            remote_suffix=remote_suffix,
+            supports_install=bool(supports.get("install", False)),
+            supports_npm=bool(supports.get("npm", False)),
+            supports_coverage=bool(supports.get("coverage", False)),
+            post_build_install=bool(supports.get("post_build_install", False)),
+            npm_workdir=npm_workdir,
+        )
+    return services
+
+
+def _require_list(raw_config: Dict[str, object], key: str) -> List[str]:
+    value = raw_config.get(key)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{key} must be a list of strings")
+    return value
+
+
+def _require_str(raw_config: Dict[str, object], key: str) -> str:
+    value = raw_config.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be a string")
+    return value
+
+
+def load_config(path: Path) -> CLIConfig:
+    """Load configuration data from ``path``."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        raw_data = json.load(handle)
+    registry_env = raw_data.get("registry_env")
+    registry_default = raw_data.get("registry_default")
+    raw_services = raw_data.get("services")
+    if not isinstance(registry_env, str) or not registry_env:
+        raise ValueError("registry_env must be a non-empty string")
+    if not isinstance(registry_default, str) or not registry_default:
+        raise ValueError("registry_default must be a non-empty string")
+    if not isinstance(raw_services, dict) or not raw_services:
+        raise ValueError("services must be a non-empty mapping")
+    services = _load_services(raw_services)
+    return CLIConfig(
+        registry_env=registry_env,
+        registry_default=registry_default,
+        services=services,
+    )


### PR DESCRIPTION
## Summary
- replace the Flashoffer and quiz-backend bash wrappers with a shared Python CLI entry point
- move compose/service configuration into cfg/flashoffer-cli.json so profiles can be managed without editing code
- add a reusable flashoffer_cli package that powers both flashoffer and quiz-backend commands

## Testing
- python -m py_compile bin/flashoffer bin/quiz-backend src/flashoffer_cli/*.py

------
https://chatgpt.com/codex/tasks/task_e_68f2a2cc98248321a4b74ac8b96c05b1