### PR TITLE
Add documentation for spacious typography preset factory

### DIFF
--- a/app/flashoffer/flashoffer-react/src/theme/FlashofferThemeProvider.tsx
+++ b/app/flashoffer/flashoffer-react/src/theme/FlashofferThemeProvider.tsx
@@ -205,6 +205,10 @@ export function createFlashofferTheme(overrides?: ThemeOptions): Theme {
   return createTheme(deepmerge(baseThemeOptions, overrides));
 }
 
+/**
+ * Create a spacious typography-first preset with mode-specific palettes and
+ * optional overrides for fine-grained adjustments.
+ */
 export function createSpaciousTypographyTheme(
   mode: PaletteMode = "light",
   overrides?: ThemeOptions


### PR DESCRIPTION
## Summary
- add a Typedoc comment documenting the spacious typography preset factory

## Testing
- npm test -- --watch=false *(fails: jest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c0bd46208321a9613ea76ed10332