### PR TITLE
docs: document AutoTrack selector behavior

### DIFF
--- a/app/flashoffer/flashoffer-react/src/analytics/AutoTrack.tsx
+++ b/app/flashoffer/flashoffer-react/src/analytics/AutoTrack.tsx
@@ -41,6 +41,14 @@ export interface AutoTrackProps {
   selector?: string;
 }
 
+/**
+ * Watches the document for nodes that expose tracking metadata and wires them
+ * up to the engagement provider. Elements matching the `selector` (defaults to
+ * `[data-track-id]`) are connected when they appear and automatically
+ * disconnected when they are removed.
+ *
+ * @param selector - CSS selector that identifies trackable elements.
+ */
 export function AutoTrack({ selector = DEFAULT_SELECTOR }: AutoTrackProps) {
   const { attachElement, detachElement } = useEngagement();
 


### PR DESCRIPTION
## Summary
- add a Typedoc block for `AutoTrack` explaining the auto-tracking workflow and `selector` prop

## Testing
- not run (not needed for docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68f2c0b24828832188a2ce83e6ad6f7c