### PR TITLE
Move Flashoffer backend tests into dev Docker stages

### DIFF
--- a/app/flashoffer/analytics-backend/Dockerfile
+++ b/app/flashoffer/analytics-backend/Dockerfile
@@ -40,16 +40,20 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     && pip install /tmp/pie dominate \
     && rm -rf /tmp/pie /backend-common
 
-# Copy the application and tests as the final step so source edits only
-# invalidate the top layer.
+# Copy the application as the final step so source edits only invalidate the
+# top layer. Tests are copied into dedicated development stages so production
+# images remain slim.
 COPY app/flashoffer/analytics-backend/analytics_backend ./analytics_backend
-COPY app/flashoffer/analytics-backend/tests ./tests
 
 FROM base AS dev
 
 # The development target exposes Flask's default port for the live reload
 # server.
 EXPOSE 8000
+
+# Include the test suite for local workflows that execute pytest within the
+# dev container.
+COPY app/flashoffer/analytics-backend/tests ./tests
 
 # Run the Flask development server by default to support local workflows.
 CMD ["flask", "--app", "analytics_backend.app:create_app", "run", "--host=0.0.0.0", "--port=8000"]

--- a/app/flashoffer/campaign-backend/Dockerfile
+++ b/app/flashoffer/campaign-backend/Dockerfile
@@ -26,11 +26,15 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     && rm -rf /tmp/pie /backend-common
 
 COPY app/flashoffer/campaign-backend/campaign_backend ./campaign_backend
-COPY app/flashoffer/campaign-backend/tests ./tests
+
+# Tests live in dev-oriented stages so the production image stays lean.
 
 FROM base AS dev
 
 EXPOSE 8000
+
+# Provide the test suite for developers running pytest inside this target.
+COPY app/flashoffer/campaign-backend/tests ./tests
 
 CMD ["flask", "--app", "campaign_backend.app:create_app", "run", "--host=0.0.0.0", "--port=8000"]
 

--- a/app/flashoffer/quiz-backend/Dockerfile
+++ b/app/flashoffer/quiz-backend/Dockerfile
@@ -32,12 +32,16 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     && rm -rf /tmp/pie /backend-common
 
 COPY app/flashoffer/quiz-backend/quiz_backend ./quiz_backend
-COPY app/flashoffer/quiz-backend/tests ./tests
+
+# Defer copying tests to dev-oriented stages so production images exclude them.
 
 FROM base AS dev
 WORKDIR /app
 
 EXPOSE 8000
+
+# Surface the quiz test suite for local workflows executed inside the dev image.
+COPY app/flashoffer/quiz-backend/tests ./tests
 
 CMD ["flask", "--app", "quiz_backend.app:create_app", "run", "--host=0.0.0.0", "--port=8000"]
 


### PR DESCRIPTION
## Summary
- copy only runtime application packages in the shared base stage for each Flashoffer backend
- add dev-stage COPY instructions for the analytics, campaign, and quiz test suites so production images stay slim

## Testing
- not run (docker unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f500d8db808321a442652d25219bae