### PR TITLE
Split flashoffer backend dependencies by environment

### DIFF
--- a/app/flashoffer/analytics-backend/Dockerfile
+++ b/app/flashoffer/analytics-backend/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /app
 # Copy dependency manifests and shared PIE utilities first so Docker can
 # reuse the layer when application code changes.
 COPY app/flashoffer/analytics-backend/requirements.txt ./requirements.txt
+COPY app/flashoffer/analytics-backend/requirements-dev.txt ./requirements-dev.txt
 COPY app/flashoffer/backend-common /backend-common
 COPY app/shell/py/pie /tmp/pie
 
@@ -46,6 +47,11 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
 COPY app/flashoffer/analytics-backend/analytics_backend ./analytics_backend
 
 FROM base AS dev
+
+# Install the development requirements so pytest and related tooling remain
+# available inside the dev container.
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip install -r requirements-dev.txt
 
 # The development target exposes Flask's default port for the live reload
 # server.

--- a/app/flashoffer/analytics-backend/requirements-dev.txt
+++ b/app/flashoffer/analytics-backend/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==7.4.4

--- a/app/flashoffer/analytics-backend/requirements.txt
+++ b/app/flashoffer/analytics-backend/requirements.txt
@@ -1,5 +1,4 @@
 Flask==2.3.3
 loguru==0.7.2
 psycopg[binary,pool]==3.2.10
-pytest==7.4.4
 ../backend-common

--- a/app/flashoffer/campaign-backend/Dockerfile
+++ b/app/flashoffer/campaign-backend/Dockerfile
@@ -17,6 +17,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 COPY app/flashoffer/campaign-backend/requirements.txt ./requirements.txt
+COPY app/flashoffer/campaign-backend/requirements-dev.txt ./requirements-dev.txt
 COPY app/flashoffer/backend-common /backend-common
 COPY app/shell/py/pie /tmp/pie
 
@@ -30,6 +31,11 @@ COPY app/flashoffer/campaign-backend/campaign_backend ./campaign_backend
 # Tests live in dev-oriented stages so the production image stays lean.
 
 FROM base AS dev
+
+# Install the dev requirements so pytest and related tooling stay available in
+# local workflows that execute commands inside this image.
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip install -r requirements-dev.txt
 
 EXPOSE 8000
 

--- a/app/flashoffer/campaign-backend/requirements-dev.txt
+++ b/app/flashoffer/campaign-backend/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==7.4.4

--- a/app/flashoffer/campaign-backend/requirements.txt
+++ b/app/flashoffer/campaign-backend/requirements.txt
@@ -1,5 +1,4 @@
 Flask==2.3.3
 loguru==0.7.2
 psycopg[binary,pool]==3.2.10
-pytest==7.4.4
 ../backend-common

--- a/app/flashoffer/docker/analytics.yml
+++ b/app/flashoffer/docker/analytics.yml
@@ -16,6 +16,7 @@ services:
     build:
       context: .
       dockerfile: ./app/flashoffer/analytics-backend/Dockerfile
+      target: dev
     environment:
       DATABASE_HOST: analytics-db
       DATABASE_PORT: 5432

--- a/app/flashoffer/docker/campaign.yml
+++ b/app/flashoffer/docker/campaign.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: ./app/flashoffer/campaign-backend/Dockerfile
+      target: dev
     environment:
       DATABASE_HOST: analytics-db
       DATABASE_PORT: 5432

--- a/app/flashoffer/docker/quiz.yml
+++ b/app/flashoffer/docker/quiz.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: ./app/flashoffer/quiz-backend/Dockerfile
+      target: dev
     environment:
       DATABASE_HOST: analytics-db
       DATABASE_PORT: 5432

--- a/app/flashoffer/quiz-backend/Dockerfile
+++ b/app/flashoffer/quiz-backend/Dockerfile
@@ -17,6 +17,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 COPY app/flashoffer/quiz-backend/requirements.txt ./requirements.txt
+COPY app/flashoffer/quiz-backend/requirements-dev.txt ./requirements-dev.txt
 COPY app/flashoffer/backend-common /backend-common
 COPY app/shell/py/pie /tmp/pie
 
@@ -37,6 +38,11 @@ COPY app/flashoffer/quiz-backend/quiz_backend ./quiz_backend
 
 FROM base AS dev
 WORKDIR /app
+
+# Ensure pytest and the other dev dependencies are present for local workflows
+# that execute within the dev image.
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip install -r requirements-dev.txt
 
 EXPOSE 8000
 

--- a/app/flashoffer/quiz-backend/requirements-dev.txt
+++ b/app/flashoffer/quiz-backend/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==7.4.4

--- a/app/flashoffer/quiz-backend/requirements.txt
+++ b/app/flashoffer/quiz-backend/requirements.txt
@@ -1,6 +1,5 @@
 Flask==2.3.3
 loguru==0.7.2
 psycopg[binary,pool]==3.2.10
-pytest==7.4.4
 ../backend-common
 openai==1.13.3

--- a/docs/reference/analytics-stack.md
+++ b/docs/reference/analytics-stack.md
@@ -167,8 +167,10 @@ application reaches the API through the host-mapped port.
   ```bash
   docker compose run --rm analytics-backend pytest
   ```
-  The suite boots TimescaleDB, applies migrations, submits sample payloads, and
-  truncates the hypertable when the run completes.
+  The dev image installs `requirements-dev.txt` on top of the runtime
+  dependencies, so pytest is ready to go. The suite boots TimescaleDB, applies
+  migrations, submits sample payloads, and truncates the hypertable when the
+  run completes.
 
 #### Database configuration summary
 - `DATABASE_URL` – Full PostgreSQL connection string that may include


### PR DESCRIPTION
## Summary
- add runtime-only and dev requirement manifests for the analytics, campaign, and quiz backends
- update Dockerfiles so production installs only runtime dependencies and dev stages include test tooling
- point flashoffer docker-compose services at the dev build target and document the pytest-ready image

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5057ca0248321bb5584db925e7d72