### PR TITLE
Organize Flashoffer API docs

### DIFF
--- a/app/flashoffer/docs/api/README.md
+++ b/app/flashoffer/docs/api/README.md
@@ -1,9 +1,12 @@
 # Flashoffer API Directory
 
-This document provides a high-level map of the public routes exposed by the
-Flashoffer backends. Each service is deployed independently and fronts its own
-base URL, but the path and behaviour summaries below are stable across
-environments.
+This directory collects the contract references for every public Flashoffer
+backend. Start with the overview tables below to see the available routes at a
+glance, then consult the dedicated guides for request and response details.
+
+- [Analytics backend](analytics-backend.md)
+- [Campaign backend](campaign-backend.md)
+- [Quiz backend](quiz-backend.md)
 
 ## Analytics Backend
 

--- a/app/flashoffer/docs/api/analytics-backend.md
+++ b/app/flashoffer/docs/api/analytics-backend.md
@@ -1,0 +1,96 @@
+# Analytics Backend API Guide
+
+The analytics service records client-side interaction telemetry and exposes
+recent activity for dashboards. All routes are served from the analytics base
+URL, typically `https://analytics.flashoffer.example` in production. Requests
+must include a service token in the `Authorization: Bearer` header. Provide the
+token value as `<token>` in the header field.
+
+## Health Check
+
+Use the health probe for uptime monitoring.
+
+```bash
+curl -i \
+  -H "Authorization: Bearer $ANALYTICS_TOKEN" \
+  https://analytics.flashoffer.example/health
+```
+
+A `200 OK` response confirms that the application and database connection are
+healthy. Any non-2xx response should trigger an alert because the ingestion
+pipeline will no longer accept events.
+
+## Recording Events
+
+Submit batched analytics payloads with the `/events` endpoint. Each payload
+contains the session metadata and an array of events collected on the client.
+
+```bash
+curl -i \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ANALYTICS_TOKEN" \
+  https://analytics.flashoffer.example/events \
+  -d '{
+    "session_id": "ca7af53d-b017-4f9e-9838-cc0d11dcb5b8",
+    "campaign_id": "spring-sprint",
+    "events": [
+      {"type": "view", "screen": "offer", "ts_ms": 1712751122334},
+      {"type": "cta_click", "cta": "Apply now", "ts_ms": 1712751124123}
+    ]
+  }'
+```
+
+The service validates timestamps and persists each event individually. A
+successful call returns `202 Accepted` with an empty body, signalling that the
+batch is queued for processing.
+
+### Client-Side Example
+
+Applications using the Flashoffer React SDK can send telemetry with the
+following helper:
+
+```ts
+import { sendAnalyticsBatch } from "@flashoffer/analytics-client";
+
+await sendAnalyticsBatch({
+  sessionId: window.flashoffer.sessionId,
+  campaignId: "spring-sprint",
+  events: [
+    { type: "view", screen: "offer", tsMs: Date.now() },
+    { type: "cta_click", cta: "Apply now", tsMs: Date.now() }
+  ]
+});
+```
+
+The SDK handles retries and backoff, so only the payload assembly is required.
+
+## Listing Recent Events
+
+The `/events/recent` route surfaces the latest 200 events for operational
+monitoring. Filter the results by campaign with the `campaign_id` query
+parameter.
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $ANALYTICS_TOKEN" \
+  "https://analytics.flashoffer.example/events/recent?campaign_id=spring-sprint" |
+  jq '.[0:3]'
+```
+
+The endpoint returns an array sorted by `ts_ms` descending. Each entry includes
+the normalized event fields and the session identifier for traceability.
+
+## Configuration Snapshot
+
+The `/config` route exposes a trimmed view of the deployment settings. Use it
+to compare staging and production infrastructure without leaking secrets.
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $ANALYTICS_TOKEN" \
+  https://analytics.flashoffer.example/config |
+  jq
+```
+
+Expect keys such as `database_host`, `database_port`, and `retention_days`.

--- a/app/flashoffer/docs/api/campaign-backend.md
+++ b/app/flashoffer/docs/api/campaign-backend.md
@@ -1,0 +1,96 @@
+# Campaign Backend API Guide
+
+The campaign backend provides canonical timelines for every Flashoffer launch.
+It powers client countdown timers and internal dashboards that track remaining
+inventory. The production base URL is typically
+`https://campaign.flashoffer.example`. Authenticate calls with the shared
+service token in the `Authorization: Bearer` header.
+
+## Health Check
+
+Use the health probe to confirm that the service and database are reachable.
+
+```bash
+curl -i \
+  -H "Authorization: Bearer $CAMPAIGN_TOKEN" \
+  https://campaign.flashoffer.example/health
+```
+
+A `200 OK` response signals that the application can serve traffic. Non-2xx
+responses warrant escalation because expiring campaigns will not emit updated
+end times.
+
+## Fetching Configuration
+
+Retrieve the deployment configuration to compare environment settings.
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $CAMPAIGN_TOKEN" \
+  https://campaign.flashoffer.example/config |
+  jq
+```
+
+The response includes the database host, port, and pool sizing details. No
+secret values are exposed.
+
+## Retrieving Campaign End Times
+
+The `/api/campaign/<campaign_id>/end_time` endpoint powers real-time countdown
+widgets. The route returns both the scheduled close timestamp and the remaining
+milliseconds.
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $CAMPAIGN_TOKEN" \
+  https://campaign.flashoffer.example/api/campaign/spring-sprint/end_time |
+  jq
+```
+
+A typical response contains the following payload:
+
+```json
+{
+  "campaign_id": "spring-sprint",
+  "end_time_utc": "2024-05-10T23:59:59Z",
+  "remaining_ms": 86400000
+}
+```
+
+### Integrating with React Countdown Widgets
+
+Flashoffer React applications can hydrate countdown banners with a simple fetch
+helper.
+
+```ts
+import { useEffect, useState } from "react";
+
+export function useCampaignDeadline(campaignId: string) {
+  const [deadline, setDeadline] = useState<Date | null>(null);
+
+  useEffect(() => {
+    async function loadDeadline() {
+      const response = await fetch(
+        `https://campaign.flashoffer.example/api/campaign/${campaignId}/end_time`,
+        {
+          headers: {
+            Authorization: `Bearer ${process.env.CAMPAIGN_TOKEN}`
+          }
+        }
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to load campaign deadline: ${response.status}`);
+      }
+      const body = await response.json();
+      setDeadline(new Date(body.end_time_utc));
+    }
+
+    void loadDeadline();
+  }, [campaignId]);
+
+  return deadline;
+}
+```
+
+This hook converts the UTC string into a `Date` instance for countdown math. A
+polling wrapper can re-query the endpoint every minute to keep timers precise.

--- a/app/flashoffer/docs/api/quiz-backend.md
+++ b/app/flashoffer/docs/api/quiz-backend.md
@@ -1,0 +1,122 @@
+# Quiz Backend API Guide
+
+The quiz backend manages the interactive assessments that gate Flashoffer
+campaigns. It stores questions, evaluates completions, and publishes the daily
+quiz. Production deployments live at `https://quiz.flashoffer.example` and
+require the shared bearer token for access.
+
+## Health Check
+
+Monitor uptime via the health probe.
+
+```bash
+curl -i \
+  -H "Authorization: Bearer $QUIZ_TOKEN" \
+  https://quiz.flashoffer.example/health
+```
+
+## Working with Quiz Events
+
+The `/api/quiz/events` collection lets you submit completion events and review
+recent attempts. Payloads include the user identifier, campaign context, and the
+score awarded by the grading flow.
+
+```bash
+curl -i \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $QUIZ_TOKEN" \
+  https://quiz.flashoffer.example/api/quiz/events \
+  -d '{
+    "campaign_id": "spring-sprint",
+    "user_id": "user-8421",
+    "score": 4,
+    "max_score": 5,
+    "passed": true
+  }'
+```
+
+The service responds with `201 Created` and echoes the stored record. Query the
+same collection with `GET` to list the most recent 200 events.
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $QUIZ_TOKEN" \
+  "https://quiz.flashoffer.example/api/quiz/events?campaign_id=spring-sprint" |
+  jq '.[0:5]'
+```
+
+Each entry contains the original payload plus a `recorded_at` timestamp for
+analytics pipelines.
+
+## Publishing the Question of the Day
+
+When a campaign uses the daily quiz mechanic, content managers publish the
+question via `/api/quiz/today`. The `GET` route returns metadata about the
+current question, including the prompt, choices, and the scheduled expiration.
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $QUIZ_TOKEN" \
+  https://quiz.flashoffer.example/api/quiz/today |
+  jq
+```
+
+Use the response to hydrate marketing surfaces or send reminder notifications.
+If no question is active the service returns `404 Not Found`.
+
+## Managing the Question Bank
+
+Authoring flows rely on the `/api/quiz/questions` collection. Use the `POST`
+route to insert new questions with validation.
+
+```bash
+curl -i \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $QUIZ_TOKEN" \
+  https://quiz.flashoffer.example/api/quiz/questions \
+  -d '{
+    "prompt": "How long does the Flashoffer boost stay active?",
+    "choices": [
+      "24 hours",
+      "48 hours",
+      "72 hours",
+      "Until the campaign ends"
+    ],
+    "answer_index": 3,
+    "campaign_ids": ["spring-sprint"],
+    "difficulty": "medium"
+  }'
+```
+
+The service enforces choice uniqueness and answer index bounds. Update an
+existing question by targeting its slug.
+
+```bash
+curl -i \
+  -X PUT \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $QUIZ_TOKEN" \
+  https://quiz.flashoffer.example/api/quiz/questions/how-long-does-the-boost-last \
+  -d '{
+    "answer_index": 2,
+    "difficulty": "hard"
+  }'
+```
+
+A successful update returns the revised question object. To bootstrap content,
+call the AI-assisted generator.
+
+```bash
+curl -s \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $QUIZ_TOKEN" \
+  https://quiz.flashoffer.example/api/quiz/questions/generate \
+  -d '{"topic": "cashback basics", "difficulty": "easy"}' |
+  jq
+```
+
+The generator responds with a draft question and choices that your moderation
+workflow can review before publishing.


### PR DESCRIPTION
## Summary
- move the Flashoffer API overview into `app/flashoffer/docs/api/README.md` with links to the service-specific guides
- add dedicated analytics backend documentation including ingestion and monitoring examples
- add campaign backend guidance for fetching deadlines and integrating countdown widgets
- add quiz backend guide covering event ingestion, daily questions, and question authoring flows

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f53dbe0e8c8321921af19fecd46f35