### PR TITLE
Add interactive quiz preview to quiz manager

### DIFF
--- a/app/flashoffer/quiz-manager/package-lock.json
+++ b/app/flashoffer/quiz-manager/package-lock.json
@@ -12,6 +12,8 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^7.1.0",
         "@mui/material": "^7.1.0",
+        "canvas-confetti": "^1.9.3",
+        "flashoffer-react": "file:../flashoffer-react",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -25,6 +27,44 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
         "vite": "^6.3.5"
+      }
+    },
+    "../flashoffer-react": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
+        "@mui/material": "^7.3.1",
+        "@mui/utils": "^7.3.1",
+        "canvas-confetti": "^1.9.3",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.1.0",
+        "@types/jest": "^29.5.12",
+        "@types/node": "^22.10.1",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.6",
+        "@typescript-eslint/eslint-plugin": "^8.15.0",
+        "@typescript-eslint/parser": "^8.15.0",
+        "@vitejs/plugin-react": "^4.6.0",
+        "eslint": "^8.57.0",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "ts-jest": "^29.2.5",
+        "ts-node": "^10.9.2",
+        "typedoc": "^0.28.0",
+        "typedoc-plugin-markdown": "^4.9.0",
+        "typescript": "^5.6.3",
+        "vite": "^7.0.4",
+        "vite-plugin-dts": "^4.5.4"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -71,7 +111,6 @@
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -387,7 +426,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -431,7 +469,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1230,7 +1267,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.1.0.tgz",
       "integrity": "sha512-ahUJdrhEv+mCp4XHW+tHIEYzZMSRLg8z4AjUOsj44QpD1ZaMxQoVOG2xiHvLFdcsIPbgSRx1bg1eQSheHBgvtg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.1",
         "@mui/core-downloads-tracker": "^7.1.0",
@@ -1789,7 +1825,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
       "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1853,7 +1888,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1985,7 +2019,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -2069,6 +2102,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2434,7 +2477,6 @@
       "integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2648,7 +2690,6 @@
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -2791,6 +2832,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flashoffer-react": {
+      "resolved": "../flashoffer-react",
+      "link": true
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
@@ -3592,7 +3637,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3737,7 +3781,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3747,7 +3790,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -4257,7 +4299,6 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4386,7 +4427,6 @@
       "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/app/flashoffer/quiz-manager/package.json
+++ b/app/flashoffer/quiz-manager/package.json
@@ -14,6 +14,8 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
+    "canvas-confetti": "^1.9.3",
+    "flashoffer-react": "file:../flashoffer-react",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/app/flashoffer/quiz-manager/src/QuizManager.jsx
+++ b/app/flashoffer/quiz-manager/src/QuizManager.jsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import React, {
   useCallback,
   useDeferredValue,
@@ -306,13 +311,36 @@ export default function QuizManager({
 
   const deferredForm = useDeferredValue(form);
 
+  const previewPayload = useMemo(
+    () => buildPayload(deferredForm, { silent: true }),
+    [buildPayload, deferredForm]
+  );
+
   const preview = useMemo(() => {
-    const payload = buildPayload(deferredForm, { silent: true });
-    if (!payload) {
+    if (!previewPayload) {
       return '';
     }
-    return JSON.stringify(payload, null, 2);
-  }, [buildPayload, deferredForm]);
+    return JSON.stringify(previewPayload, null, 2);
+  }, [previewPayload]);
+
+  const previewQuestion = useMemo(() => {
+    if (!previewPayload) {
+      return undefined;
+    }
+    return {
+      question: previewPayload.question,
+      helperText: previewPayload.helper_text ?? undefined,
+      options: previewPayload.options.map((option) => ({
+        id: option.id,
+        label: option.label,
+        description: option.description ?? undefined
+      })),
+      correctOptionId: previewPayload.correct_option_id,
+      explanation: previewPayload.explanation ?? undefined,
+      successMessage: previewPayload.success_message ?? undefined,
+      errorMessage: previewPayload.error_message ?? undefined
+    };
+  }, [previewPayload]);
 
   const handleSubmit = useCallback(async () => {
     setFormError('');
@@ -501,6 +529,7 @@ export default function QuizManager({
           handleRemoveOption={handleRemoveOption}
           handleSubmit={handleSubmit}
           preview={preview}
+          previewQuestion={previewQuestion}
           resetForm={resetForm}
         />
       ) : null}

--- a/app/flashoffer/quiz-manager/src/pages/CreateQuestionPage.jsx
+++ b/app/flashoffer/quiz-manager/src/pages/CreateQuestionPage.jsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import React from 'react';
 import {
   Alert,
@@ -15,6 +20,7 @@ import {
 } from '@mui/material';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import DeleteIcon from '@mui/icons-material/Delete';
+import { FlashofferThemeProvider, MultipleChoiceQuiz } from 'flashoffer-react';
 
 export default function CreateQuestionPage({
   canSubmit,
@@ -33,6 +39,7 @@ export default function CreateQuestionPage({
   handleRemoveOption,
   handleSubmit,
   preview,
+  previewQuestion,
   resetForm
 }) {
   return (
@@ -244,10 +251,36 @@ export default function CreateQuestionPage({
             </Button>
           </Stack>
 
+          {previewQuestion ? (
+            <Stack spacing={1}>
+              <Typography variant="h6" component="h2">
+                Question Preview
+              </Typography>
+              <Box className="quiz-manager__quiz-preview">
+                <FlashofferThemeProvider>
+                  <MultipleChoiceQuiz
+                    question={previewQuestion.question}
+                    helperText={previewQuestion.helperText}
+                    options={previewQuestion.options}
+                    correctOptionId={previewQuestion.correctOptionId}
+                    explanation={previewQuestion.explanation}
+                    successMessage={previewQuestion.successMessage}
+                    errorMessage={previewQuestion.errorMessage}
+                  />
+                </FlashofferThemeProvider>
+              </Box>
+            </Stack>
+          ) : null}
+
           {preview ? (
-            <Box className="quiz-manager__preview" component="pre">
-              {preview}
-            </Box>
+            <Stack spacing={1}>
+              <Typography variant="h6" component="h2">
+                Request Payload
+              </Typography>
+              <Box className="quiz-manager__preview" component="pre">
+                {preview}
+              </Box>
+            </Stack>
           ) : null}
         </Stack>
       </Stack>

--- a/app/flashoffer/quiz-manager/src/styles.css
+++ b/app/flashoffer/quiz-manager/src/styles.css
@@ -57,6 +57,13 @@ main {
   word-break: break-word;
 }
 
+.quiz-manager__quiz-preview {
+  padding: 1.25rem;
+  border-radius: 8px;
+  background-color: #f5f8ff;
+  color: #091222;
+}
+
 .quiz-manager__table-wrapper {
   background-color: transparent;
 }

--- a/app/flashoffer/quiz-manager/vite.config.js
+++ b/app/flashoffer/quiz-manager/vite.config.js
@@ -1,11 +1,57 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
+import { resolve as resolvePath, sep } from 'node:path';
+import { fileURLToPath, URL } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { resolveProxyConfig } from './config/proxy.js';
 
 const proxyConfig = resolveProxyConfig();
+const toPosixPath = (value) => value.split(sep).join('/');
+const projectRoot = fileURLToPath(new URL('./', import.meta.url));
+const nodeModulesDir = resolvePath(projectRoot, 'node_modules');
+const materialBase = toPosixPath(resolvePath(nodeModulesDir, '@mui/material'));
+const muiUtilsBase = toPosixPath(resolvePath(nodeModulesDir, '@mui/utils'));
+const canvasConfettiModule = toPosixPath(
+  resolvePath(nodeModulesDir, 'canvas-confetti', 'dist', 'confetti.module.mjs')
+);
+const flashofferSource = fileURLToPath(
+  new URL('../flashoffer-react/src/index.ts', import.meta.url)
+);
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: [
+      {
+        find: 'flashoffer-react',
+        replacement: flashofferSource
+      },
+      {
+        find: /^canvas-confetti$/,
+        replacement: canvasConfettiModule
+      },
+      {
+        find: /^@mui\/material$/i,
+        replacement: `${materialBase}/index.js`
+      },
+      {
+        find: /^@mui\/material\/(.*)$/i,
+        replacement: `${materialBase}/$1`
+      },
+      {
+        find: /^@mui\/utils$/i,
+        replacement: `${muiUtilsBase}/index.js`
+      },
+      {
+        find: /^@mui\/utils\/(.*)$/i,
+        replacement: `${muiUtilsBase}/$1`
+      }
+    ]
+  },
   server: {
     host: '0.0.0.0',
     port: 5175,


### PR DESCRIPTION
## Summary
- add an interactive MultipleChoiceQuiz preview that renders selected questions in the quiz manager
- load flashoffer-react directly from source with supporting aliases and styling updates for the preview
- include flashoffer-react and canvas-confetti dependencies for quiz preview rendering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f671945900832186cb147c543b70dd