### PR TITLE
Add standalone quiz question generator script

### DIFF
--- a/bin/quiz-gen
+++ b/bin/quiz-gen
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Generate a quiz question JSON payload using the OpenAI Chat Completions API."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import textwrap
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-5").strip() or "gpt-5"
+DEFAULT_USER_PROMPT = (
+    "Create a question about digital marketing measurement best practices."
+)
+
+
+@dataclass(frozen=True)
+class GenerationRequest:
+    prompt: str
+    model: str
+
+
+class GenerationRequestError(ValueError):
+    """Raised when an inbound generation request is invalid."""
+
+
+class GenerationModelError(RuntimeError):
+    """Raised when the OpenAI response cannot be converted into a question."""
+
+
+def log(message: str, *, stream: Any = sys.stdout) -> None:
+    print(f"[quiz-gen] {message}", file=stream, flush=True)
+
+
+def _build_generation_system_prompt() -> str:
+    today = _dt.datetime.now(tz=_dt.timezone.utc).date().isoformat()
+    return (
+        "You are Flashoffer's quiz authoring assistant. "
+        "Produce exactly one JSON object describing a multiple-choice quiz question. "
+        "The JSON must NOT be wrapped in any additional words or Markdown. "
+        "Structure the object with these keys: slug, question, helper_text, explanation, "
+        "success_message, error_message, options, correct_option_id, published_on, expires_on. "
+        "Rules: slug must be lowercase kebab-case (letters, digits, hyphen) with a maximum length of 48 characters. "
+        "question should be concise plain text without HTML. "
+        "Provide helper_text, explanation, success_message, and error_message when useful; otherwise use null. "
+        "options must contain at least three entries. Each entry needs id (lowercase string), label (answer text), "
+        "and optional description (<= 140 characters). "
+        "correct_option_id must exactly match one option id. "
+        f"Use '{today}' for published_on unless instructed otherwise. "
+        "Set expires_on to null unless a future ISO date is explicitly requested. "
+        "Return valid JSON only, with proper escaping and no comments."
+    )
+
+
+def _normalize_optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _load_question_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    required = {"slug", "question", "options", "correct_option_id", "published_on"}
+    missing = required - payload.keys()
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise ValueError(f"Missing required keys: {missing_list}")
+
+    slug = str(payload["slug"]).strip()
+    if not slug:
+        raise ValueError("Field 'slug' cannot be empty")
+
+    question = str(payload["question"]).strip()
+    if not question:
+        raise ValueError("Field 'question' cannot be empty")
+
+    options_raw = payload["options"]
+    if not isinstance(options_raw, list) or not options_raw:
+        raise ValueError("Field 'options' must be a non-empty array")
+
+    normalized_options: List[Dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, option in enumerate(options_raw):
+        if not isinstance(option, dict):
+            raise ValueError(f"Option at index {index} must be a JSON object")
+        option_id_raw = option.get("id")
+        option_id = str(option_id_raw).strip() if option_id_raw is not None else ""
+        if not option_id:
+            raise ValueError(f"Option at index {index} must include an 'id'")
+        if option_id in seen_ids:
+            raise ValueError(f"Duplicate option id '{option_id}' detected")
+        seen_ids.add(option_id)
+        normalized_option: Dict[str, Any] = dict(option)
+        normalized_option["id"] = option_id
+        if "label" in normalized_option and normalized_option["label"] is not None:
+            normalized_option["label"] = str(normalized_option["label"]).strip()
+        if "description" in normalized_option and normalized_option["description"] is not None:
+            normalized_option["description"] = str(normalized_option["description"]).strip()
+        normalized_options.append(normalized_option)
+
+    correct_option_id = str(payload["correct_option_id"]).strip()
+    if not correct_option_id:
+        raise ValueError("Field 'correct_option_id' cannot be empty")
+    if correct_option_id not in seen_ids:
+        raise ValueError("Field 'correct_option_id' must match an option id")
+
+    published_on = payload["published_on"]
+    expires_on = payload.get("expires_on")
+    expires_value = str(expires_on).strip() if isinstance(expires_on, str) else expires_on
+    normalized_expires_on = expires_value if expires_value else None
+
+    helper_text = _normalize_optional_text(payload.get("helper_text"))
+    explanation = _normalize_optional_text(payload.get("explanation"))
+    success_message = _normalize_optional_text(payload.get("success_message"))
+    error_message = _normalize_optional_text(payload.get("error_message"))
+
+    return {
+        "slug": slug,
+        "question": question,
+        "helper_text": helper_text,
+        "explanation": explanation,
+        "success_message": success_message,
+        "error_message": error_message,
+        "options": normalized_options,
+        "correct_option_id": correct_option_id,
+        "published_on": published_on,
+        "expires_on": normalized_expires_on,
+    }
+
+
+def _derive_openai_base_url() -> str:
+    base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1").strip()
+    if not base_url.lower().startswith("https://"):
+        raise GenerationRequestError("OpenAI base URL must use https")
+    return base_url.rstrip("/")
+
+
+def _call_openai_chat_completion(
+    api_key: str,
+    *,
+    model: str,
+    prompt: str,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    system_prompt = _build_generation_system_prompt()
+    user_prompt = prompt.strip() or DEFAULT_USER_PROMPT
+
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "response_format": {"type": "json_object"},
+    }
+
+    base_url = _derive_openai_base_url()
+    url = f"{base_url}/chat/completions"
+
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "quiz-gen/1.0",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=90) as response:
+            charset = response.headers.get_content_charset("utf-8")
+            data = response.read().decode(charset)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace") if exc.fp else exc.reason
+        raise GenerationModelError(
+            f"openai_request_failed: status={exc.code} detail={detail}"
+        ) from exc
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure
+        raise GenerationModelError(f"openai_request_failed: {exc}") from exc
+
+    try:
+        completion = json.loads(data)
+    except json.JSONDecodeError as exc:
+        raise GenerationModelError(f"invalid_json_from_model: {exc}") from exc
+
+    choices = completion.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise GenerationModelError("unexpected_openai_response: missing choices")
+
+    try:
+        message = choices[0]["message"]
+        content = message["content"]
+    except Exception as exc:  # noqa: BLE001 - guard against SDK changes
+        raise GenerationModelError(f"unexpected_openai_response: {exc}") from exc
+
+    if not content:
+        raise GenerationModelError("empty_completion")
+
+    try:
+        generated = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise GenerationModelError(f"invalid_json_from_model: {exc}") from exc
+
+    if not isinstance(generated, dict):
+        raise GenerationModelError("model_output_must_be_object")
+
+    try:
+        question_payload = _load_question_payload(generated)
+    except ValueError as exc:
+        raise GenerationModelError(f"model_output_invalid: {exc}") from exc
+
+    return question_payload, generated
+
+
+def _load_prompt(args: argparse.Namespace) -> str:
+    prompt_pieces: List[str] = []
+    if args.prompt:
+        prompt_pieces.append(args.prompt)
+    if args.prompt_file:
+        try:
+            with open(args.prompt_file, "r", encoding="utf-8") as handle:
+                prompt_pieces.append(handle.read())
+        except OSError as exc:
+            raise GenerationRequestError(f"failed to read prompt file: {exc}") from exc
+
+    combined = "\n\n".join(piece.strip() for piece in prompt_pieces if piece.strip())
+    return combined or ""
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a quiz question JSON payload ready for quiz-manager upload.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """
+            Example:
+              OPENAI_API_KEY=... bin/quiz-gen output.json --prompt "Email marketing metrics"
+            """
+        ).strip(),
+    )
+    parser.add_argument(
+        "output",
+        nargs="?",
+        default="quiz-question.json",
+        help="Destination file for the generated question JSON (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--prompt",
+        "-p",
+        help="Custom instructions for the quiz question",
+    )
+    parser.add_argument(
+        "--prompt-file",
+        "-f",
+        help="Read additional prompt text from a file",
+    )
+    parser.add_argument(
+        "--model",
+        "-m",
+        default=DEFAULT_MODEL,
+        help="OpenAI model identifier (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--save-raw",
+        help="Optional path to store the raw model output JSON",
+    )
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Iterable[str]) -> int:
+    args = parse_args(argv)
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        log("OPENAI_API_KEY environment variable is required", stream=sys.stderr)
+        return 1
+
+    try:
+        prompt = _load_prompt(args)
+        request = GenerationRequest(prompt=prompt, model=str(args.model or DEFAULT_MODEL).strip() or DEFAULT_MODEL)
+    except GenerationRequestError as exc:
+        log(f"Invalid request: {exc}", stream=sys.stderr)
+        return 1
+
+    log("Preparing OpenAI request...")
+
+    try:
+        question_payload, raw_payload = _call_openai_chat_completion(
+            api_key,
+            model=request.model,
+            prompt=request.prompt,
+        )
+    except GenerationModelError as exc:
+        log(f"Generation failed: {exc}", stream=sys.stderr)
+        return 2
+
+    slug = question_payload.get("slug", "(unknown)")
+    log(f"Received quiz question for slug '{slug}'")
+
+    output_path = os.path.abspath(args.output)
+    try:
+        with open(output_path, "w", encoding="utf-8") as handle:
+            json.dump(question_payload, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+    except OSError as exc:
+        log(f"Failed to write output file: {exc}", stream=sys.stderr)
+        return 3
+
+    log(f"Saved validated question to {output_path}")
+
+    if args.save_raw:
+        raw_path = os.path.abspath(args.save_raw)
+        try:
+            with open(raw_path, "w", encoding="utf-8") as handle:
+                json.dump(raw_payload, handle, ensure_ascii=False, indent=2)
+                handle.write("\n")
+        except OSError as exc:
+            log(f"Failed to write raw output: {exc}", stream=sys.stderr)
+            return 4
+        log(f"Saved raw model output to {raw_path}")
+
+    log("Generation completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add a standalone `bin/quiz-gen` helper to mirror the quiz question generation API flow
- validate the model output before writing it to disk and support optional raw payload saves

## Testing
- python bin/quiz-gen --help

------
https://chatgpt.com/codex/tasks/task_e_68f672dd0c7883219a157782a8dfa624