### PR TITLE
Fix quiz question of the day serializer mismatch

### DIFF
--- a/app/flashoffer/quiz-backend/quiz_backend/sql/fetch_question_of_day.sql
+++ b/app/flashoffer/quiz-backend/quiz_backend/sql/fetch_question_of_day.sql
@@ -10,7 +10,9 @@ SELECT
     options,
     correct_option_id,
     published_on,
-    expires_on
+    expires_on,
+    created_at,
+    updated_at
 FROM quiz_questions
 WHERE published_on <= %s
   AND (expires_on IS NULL OR expires_on > %s)


### PR DESCRIPTION
## Summary
- include the created_at and updated_at columns in the question-of-the-day query to match serializer expectations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f67436019c8321afbe08578cc8465f