### PR TITLE
Add architecture docs for quiz systems

### DIFF
--- a/app/flashoffer/docs/README.md
+++ b/app/flashoffer/docs/README.md
@@ -20,6 +20,8 @@ playground and learn how to iterate on content safely.
   offer redemption, and analytics exports.
 - `quiz-backend/` describes the server-side quiz engines, database schemas, and
   operational runbooks used during high-traffic campaigns.
+- `quiz-manager/` captures the architecture and workflows for the React-based
+  question ingestion console used by content operators.
 
 Each directory follows the same structure: a high-level README, task-focused
 recipes, and troubleshooting appendices. Start with the README for orientation,

--- a/app/flashoffer/docs/quiz-backend/architecture.md
+++ b/app/flashoffer/docs/quiz-backend/architecture.md
@@ -1,0 +1,73 @@
+# Quiz Backend Architecture
+
+## Overview
+The quiz backend is a Flask application that exposes REST endpoints for quiz
+question management, daily quiz publishing, and completion telemetry. It relies
+on the shared `backend-common` package for database configuration, connection
+pooling, and CORS support. The service ships inside the `press-quiz-backend`
+image and runs behind an embedded Nginx proxy that terminates HTTP and forwards
+requests to Gunicorn workers.
+
+## Process Model
+`entrypoint.sh` starts Gunicorn with four workers bound to a Unix domain socket
+and launches Nginx in the same container. Nginx listens on port 8000 as defined
+in `nginx.conf` and proxies traffic to `/tmp/gunicorn.sock`, adding the standard
+forwarded headers expected by upstream load balancers. The entrypoint cleans up
+both processes and the socket when the container stops, keeping restarts
+idempotent.
+
+## Application Setup
+`create_app()` instantiates Flask, loads connection settings from environment
+variables via `DatabaseConfig.from_env()`, and initialises the Postgres-backed
+`QuizResultsStore`. Startup blocks until the database is reachable, retrying for
+up to five minutes. Once connected, the store is cached in
+`app.config['DB_POOL']`, and the `configure_cors()` helper attaches permissive
+responses to every quiz route. A process exit handler closes the connection pool
+gracefully.
+
+## Data Storage Layer
+`QuizResultsStore` extends the shared `PostgresPool` helper. During
+initialisation it executes SQL migrations shipped in `quiz_backend/sql/` to
+create the results and questions tables plus supporting indexes. The store
+provides typed methods:
+
+- `record_completion()` – Normalises event payloads, casts tallies, and inserts
+  rows via `INSERT_QUIZ_RESULT_SQL`, returning the stored record.
+- `fetch_recent_results()` – Queries recent completions with campaign filters
+  and bounded pagination.
+- `create_question()` and `update_question()` – Validate publication windows,
+  persist question metadata, and return the new or updated row.
+- `list_questions()` and `fetch_question_of_day()` – List catalog entries or
+  materialise the currently published question.
+
+Helper routines such as `_parse_date()` and `_parse_timestamp()` ensure ISO
+strings map cleanly to database types.
+
+## HTTP Endpoints
+The application defines a REST surface rooted at `/api/quiz/`:
+
+- `/api/quiz/events` accepts POSTed completion events, validating required keys
+  and enforcing a `event_type == "complete"` contract. The GET variant
+  paginates recent events.
+- `/api/quiz/questions` supports GET, POST, and PUT (via
+  `/api/quiz/questions/<slug>`) for listing, creating, and updating question
+  payloads. Requests pass through `_load_question_payload()` to guarantee slug,
+  option, and date integrity.
+- `/api/quiz/questions/generate` proxies to OpenAI when `OPENAI_API_KEY` is set.
+  It constructs a deterministic system prompt, validates the user prompt, and
+  returns both the normalised question and the raw model response.
+- `/api/quiz/today` returns the active question of the day or `404` when none is
+  scheduled.
+- `/health` runs a lightweight `SELECT 1` probe against Postgres.
+- `/config` surfaces database connection metadata for diagnostic tooling.
+
+Every mutating route returns explicit error messages on validation failures and
+logs server-side exceptions with structured context through `pie.logging`.
+
+## External Integrations
+The OpenAI client is optional: the module attempts to import `openai.OpenAI` at
+runtime and short-circuits the generator endpoint when the dependency or API key
+is missing. All outbound requests use `httpx.Client` instances configured with
+component-specific timeouts. Because CORS support is enabled at initialisation,
+the quiz manager frontend can call the backend directly during local
+development and from hosted environments.

--- a/app/flashoffer/docs/quiz-manager/architecture.md
+++ b/app/flashoffer/docs/quiz-manager/architecture.md
@@ -1,0 +1,63 @@
+# Quiz Manager Architecture
+
+## Overview
+The quiz manager is a standalone React single-page application compiled with
+Vite and shipped from the `quiz-manager` Docker image. The bundle boots inside
+an element tagged with a `data-endpoint` attribute so operators can retarget
+API hosts without rebuilding the frontend. A HashRouter hosts the UI under the
+`/` path to keep static hosting requirements minimal while preserving client-
+side navigation semantics. The application is served through the quiz-manager
+service defined in `app/flashoffer/docker/quiz.yml` alongside the quiz backend.
+
+## Bootstrapping and Routing
+`src/main.jsx` mounts the application when `DOMContentLoaded` fires. It reads
+`data-endpoint` from the root node, passes the value to `<QuizManager />`, and
+installs a hash-based router that renders the manager at `/#/` regardless of the
+hosting origin. This approach lets the same static assets run behind Nginx in
+Docker or inside the Press site without rewriting links. The router delegates
+all sub-routes to `<QuizManager />`, which manages a simple tab navigation
+constructed from the `PAGE_DEFINITIONS` table.
+
+## State and Data Flow
+`QuizManager.jsx` centralizes application state with React hooks. It builds an
+empty form model with helpers such as `createEmptyForm()` and
+`buildFormStateForQuestion()` so both manual authoring and existing question
+selection reuse the same shape. The component keeps track of async status flags
+for the upload form, question list, and generator workflow, allowing the pages
+to render contextual spinners and alerts. The manager normalizes inbound data,
+coerces date fields, and maintains option arrays with helpers like
+`normalizeOptionEntries()` to guarantee payloads align with backend validation.
+
+The component accepts `uploadEndpoint` and `listEndpoint` props, trimming any
+trailing slashes before constructing the canonical REST targets. CRUD
+operations use the native Fetch API: `fetchQuestions()` lists the latest 50
+entries, `submitQuestion()` posts new or updated payloads, and
+`requestGeneratedQuestion()` requests AI drafts from the backend. LocalStorage
+persists the last generator prompt via `GENERATOR_PROMPT_STORAGE_KEY`, and the
+value is hydrated during initialization for better operator ergonomics.
+
+## Page Composition
+The manager renders three child pages that receive state and handlers via props:
+
+- **CreateQuestionPage** – Presents the authoring form, file-import flow, and
+  Flashoffer React preview. It uses Material UI controls, wires option
+  management handlers, and embeds `FlashofferThemeProvider` with
+  `MultipleChoiceQuiz` to preview the payload before submission.
+- **GeneratorPage** – Captures optional prompts and kicks off the generator
+  request. It surfaces async errors and toggles the button label while the
+  backend request is pending.
+- **ExistingQuestionsPage** – Displays the catalog with Material UI tables,
+  offers manual refresh, and reports loading or error states. Selecting a row
+  loads the question into the form for edits.
+
+Each page is styled via `src/styles.css`, which defines the responsive layout
+classes consumed across the panels. Because the parent manages all mutations,
+page components remain stateless and easy to test.
+
+## Backend Integration
+By default the manager targets `/api/quiz/questions`, aligning with the quiz
+backend REST endpoints. When a deployment requires cross-origin calls, the
+backend’s `/config` route and CORS settings allow the UI to point at remote
+hosts. The quiz-manager Docker service proxies requests through the
+`quiz-backend` container during development, and production traffic should pass
+through the same Nginx layer configured in `app/flashoffer/quiz-backend`.


### PR DESCRIPTION
## Summary
- add an architecture deep dive for the quiz-manager React console
- document the quiz-backend service structure, storage layer, and endpoints
- link the new quiz documentation directory from the Flashoffer docs index

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f701b02c6c8321a8fa3c0e480ff621