### PR TITLE
Add quiz-manager GPT question generation documentation

### DIFF
--- a/app/flashoffer/docs/README.md
+++ b/app/flashoffer/docs/README.md
@@ -20,6 +20,8 @@ playground and learn how to iterate on content safely.
   offer redemption, and analytics exports.
 - `quiz-backend/` describes the server-side quiz engines, database schemas, and
   operational runbooks used during high-traffic campaigns.
+- `quiz-manager/` explains the authoring UI, GPT-assisted question generation,
+  and the publication workflows content teams rely on.
 
 Each directory follows the same structure: a high-level README, task-focused
 recipes, and troubleshooting appendices. Start with the README for orientation,

--- a/app/flashoffer/docs/quiz-manager/gpt-assisted-question-generation.md
+++ b/app/flashoffer/docs/quiz-manager/gpt-assisted-question-generation.md
@@ -1,0 +1,54 @@
+# GPT-Assisted Question Generation Flow
+
+Quiz Manager lets content editors seed a topic description and rely on GPT to
+produce draft questions. The application coordinates prompt assembly,
+completion requests, and persistence so the generated question can be reviewed
+and published safely.
+
+The sequence below documents how the UI, quiz backend, OpenAI API, and quiz
+database collaborate whenever an editor clicks **Generate question**.
+
+```mermaid
+sequenceDiagram
+  participant Editor as Quiz Manager UI
+  participant Backend as Quiz Backend API
+  participant GPT as OpenAI Completions
+  participant Store as Quiz Database
+
+  Editor->>Backend: POST /api/quiz/questions/generate with topic brief
+  Backend->>Backend: Enrich prompt with validation rules and metadata
+  Backend->>GPT: Submit OpenAI request with system + user prompts
+  GPT-->>Backend: Return proposed question JSON payload
+  Backend->>Backend: Validate schema, sanitize HTML, score difficulty
+  Backend-->>Editor: Respond with question preview + reasoning trace
+  Editor->>Editor: Present preview, allow edits, stage publish action
+  Editor->>Backend: POST /api/quiz/questions with final question body
+  Backend->>Store: Persist record and versioned GPT audit trail
+  Backend-->>Editor: Confirm creation with canonical slug
+```
+
+## Operational Notes
+
+- The backend enforces schema validation before surfacing GPT output so editors
+  never see malformed payloads.
+- Quiz Manager stores the final prompt, completion, and moderator overrides to
+  maintain provenance for compliance reviews.
+- Editors can iteratively regenerate prompts; only the approved payload is
+  persisted to the quiz database.
+
+## Example Request
+
+A minimal `curl` call mirrors what Quiz Manager emits when GPT drafting is
+requested. Replace `OPENAI_API_KEY` with an environment-specific token.
+
+```
+curl -X POST \
+  https://quiz.flashoffer.example/api/quiz/questions/generate \
+  -H "Authorization: Bearer OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic": "Spring espresso trivia",
+    "target_audience": "baristas",
+    "difficulty": "intermediate"
+  }'
+```


### PR DESCRIPTION
## Summary
- add documentation describing the GPT-assisted quiz question generation flow in quiz-manager, including a mermaid sequence diagram
- update the Flashoffer documentation index to reference the new quiz-manager guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7022471ac83218e63ca4106e2f26f