### PR TITLE
quiz-backend: persist celebration preset

### DIFF
--- a/app/flashoffer/docs/quiz-backend/question-of-day-schema.md
+++ b/app/flashoffer/docs/quiz-backend/question-of-day-schema.md
@@ -19,6 +19,8 @@ service uses and the access patterns maintained by `quiz_backend.db`.
 - `correct_option_id TEXT NOT NULL` – answer identifier flagged as correct.
 - `published_on DATE NOT NULL` – first UTC date the question should be served.
 - `expires_on DATE` – exclusive UTC date after which the prompt is retired.
+- `celebration TEXT NOT NULL DEFAULT 'off'` – confetti preset triggered once
+  a learner submits the correct answer.
 - `created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()` – insertion timestamp.
 - `updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()` – last modification timestamp.
 

--- a/app/flashoffer/quiz-backend/quiz_backend/app.py
+++ b/app/flashoffer/quiz-backend/quiz_backend/app.py
@@ -29,6 +29,13 @@ except Exception:  # noqa: BLE001 - optional dependency
 
 HEALTHCHECK_QUERY = "SELECT 1 -- confirm quiz database connectivity"
 
+QUIZ_CELEBRATION_PRESETS = {
+    "off",
+    "classic",
+    "streamers",
+    "burst",
+}
+
 
 def _coerce_bool(value: Any, *, field: str) -> bool:
     if isinstance(value, bool):
@@ -154,6 +161,16 @@ def _load_question_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     success_message = _normalize_optional_text(payload.get("success_message"))
     error_message = _normalize_optional_text(payload.get("error_message"))
 
+    celebration_value = payload.get("celebration")
+    celebration = "off"
+    if celebration_value is not None:
+        celebration = str(celebration_value).strip() or "off"
+    if celebration not in QUIZ_CELEBRATION_PRESETS:
+        allowed = ", ".join(sorted(QUIZ_CELEBRATION_PRESETS))
+        raise ValueError(
+            f"Field 'celebration' must be one of: {allowed}"
+        )
+
     return {
         "slug": slug,
         "question": question,
@@ -165,6 +182,7 @@ def _load_question_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
         "correct_option_id": correct_option_id,
         "published_on": published_on,
         "expires_on": normalized_expires_on,
+        "celebration": celebration,
     }
 
 

--- a/app/flashoffer/quiz-backend/quiz_backend/db.py
+++ b/app/flashoffer/quiz-backend/quiz_backend/db.py
@@ -34,6 +34,10 @@ ENSURE_CAMPAIGN_ID_COLUMN_SQL = _load_sql("ensure_campaign_id_column.sql")
 
 CREATE_QUIZ_QUESTIONS_TABLE_SQL = _load_sql("create_quiz_questions_table.sql")
 
+ENSURE_QUIZ_QUESTION_CELEBRATION_COLUMN_SQL = _load_sql(
+    "ensure_quiz_question_celebration_column.sql"
+)
+
 FETCH_QUESTION_OF_DAY_SQL = _load_sql("fetch_question_of_day.sql")
 
 LIST_QUIZ_QUESTIONS_SQL = _load_sql("list_quiz_questions.sql")
@@ -58,6 +62,7 @@ class QuizResultsStore(PostgresPool):
                 cur.execute(CREATE_QUIZ_RESULTS_TABLE_SQL)
                 cur.execute(ENSURE_CAMPAIGN_ID_COLUMN_SQL)
                 cur.execute(CREATE_QUIZ_QUESTIONS_TABLE_SQL)
+                cur.execute(ENSURE_QUIZ_QUESTION_CELEBRATION_COLUMN_SQL)
                 cur.execute(ENSURE_QUIZ_QUESTIONS_INDEX_SQL)
                 cur.execute(CREATE_QUIZ_STATS_TABLE_SQL)
             conn.commit()
@@ -180,6 +185,7 @@ class QuizResultsStore(PostgresPool):
                         question["correct_option_id"],
                         published_on,
                         expires_on,
+                        question["celebration"],
                     ),
                 )
                 row = cur.fetchone()
@@ -216,6 +222,7 @@ class QuizResultsStore(PostgresPool):
                         question["correct_option_id"],
                         published_on,
                         expires_on,
+                        question["celebration"],
                         slug,
                     ),
                 )
@@ -284,6 +291,7 @@ class QuizResultsStore(PostgresPool):
             "correct_option_id": serialized["correct_option_id"],
             "published_on": serialized["published_on"],
             "expires_on": serialized["expires_on"],
+            "celebration": serialized["celebration"],
         }
 
     def fetch_quiz_stats(self, quiz_id: str) -> Optional[Dict[str, Any]]:
@@ -333,6 +341,7 @@ def _serialize_question_row(row: Any) -> Dict[str, Any]:
         correct_option_id,
         stored_published_on,
         stored_expires_on,
+        celebration,
         created_at,
         updated_at,
     ) = row
@@ -359,6 +368,7 @@ def _serialize_question_row(row: Any) -> Dict[str, Any]:
             if stored_expires_on is not None and hasattr(stored_expires_on, "isoformat")
             else (str(stored_expires_on) if stored_expires_on is not None else None)
         ),
+        "celebration": celebration,
         "created_at": _parse_timestamp(created_at).isoformat(),
         "updated_at": _parse_timestamp(updated_at).isoformat(),
     }

--- a/app/flashoffer/quiz-backend/quiz_backend/sql/create_quiz_questions_table.sql
+++ b/app/flashoffer/quiz-backend/quiz_backend/sql/create_quiz_questions_table.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS quiz_questions (
     correct_option_id TEXT NOT NULL,
     published_on DATE NOT NULL,
     expires_on DATE,
+    celebration TEXT NOT NULL DEFAULT 'off',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/app/flashoffer/quiz-backend/quiz_backend/sql/fetch_question_of_day.sql
+++ b/app/flashoffer/quiz-backend/quiz_backend/sql/fetch_question_of_day.sql
@@ -11,6 +11,7 @@ SELECT
     correct_option_id,
     published_on,
     expires_on,
+    celebration,
     created_at,
     updated_at
 FROM quiz_questions

--- a/app/flashoffer/quiz-backend/quiz_backend/sql/insert_quiz_question.sql
+++ b/app/flashoffer/quiz-backend/quiz_backend/sql/insert_quiz_question.sql
@@ -9,8 +9,10 @@ INSERT INTO quiz_questions (
     options,
     correct_option_id,
     published_on,
-    expires_on
+    expires_on,
+    celebration
 ) VALUES (
+    %s,
     %s,
     %s,
     %s,
@@ -34,5 +36,6 @@ RETURNING
     correct_option_id,
     published_on,
     expires_on,
+    celebration,
     created_at,
     updated_at;

--- a/app/flashoffer/quiz-backend/quiz_backend/sql/list_quiz_questions.sql
+++ b/app/flashoffer/quiz-backend/quiz_backend/sql/list_quiz_questions.sql
@@ -11,6 +11,7 @@ SELECT
     correct_option_id,
     published_on,
     expires_on,
+    celebration,
     created_at,
     updated_at
 FROM quiz_questions

--- a/app/flashoffer/quiz-backend/quiz_backend/sql/update_quiz_question.sql
+++ b/app/flashoffer/quiz-backend/quiz_backend/sql/update_quiz_question.sql
@@ -10,6 +10,7 @@ SET
     correct_option_id = %s,
     published_on = %s,
     expires_on = %s,
+    celebration = %s,
     updated_at = NOW()
 WHERE slug = %s
 RETURNING
@@ -24,5 +25,6 @@ RETURNING
     correct_option_id,
     published_on,
     expires_on,
+    celebration,
     created_at,
     updated_at;

--- a/app/flashoffer/quiz-backend/tests/test_app.py
+++ b/app/flashoffer/quiz-backend/tests/test_app.py
@@ -39,7 +39,13 @@ def _build_payload(
     }
 
 
-def _build_question_payload(*, slug: str, published_on: date, correct_option_id: str = "reminder") -> dict:
+def _build_question_payload(
+    *,
+    slug: str,
+    published_on: date,
+    correct_option_id: str = "reminder",
+    celebration: str = "classic",
+) -> dict:
     return {
         "slug": slug,
         "question": f"Prompt for {slug}?",
@@ -60,6 +66,7 @@ def _build_question_payload(*, slug: str, published_on: date, correct_option_id:
         "published_on": published_on.isoformat(),
         "success_message": "Exactly right.",
         "error_message": "Not quite.",
+        "celebration": celebration,
     }
 
 
@@ -186,8 +193,9 @@ def test_quiz_question_today_returns_active_question(client, flask_app):
                     error_message,
                     options,
                     correct_option_id,
-                    published_on
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    published_on,
+                    celebration
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     "flashoffer-demo",
@@ -199,6 +207,7 @@ def test_quiz_question_today_returns_active_question(client, flask_app):
                     Json(options),
                     "reminder",
                     date.today(),
+                    "classic",
                 ),
             )
         conn.commit()
@@ -209,6 +218,7 @@ def test_quiz_question_today_returns_active_question(client, flask_app):
     assert body["question"]["slug"] == "flashoffer-demo"
     assert body["question"]["correct_option_id"] == "reminder"
     assert len(body["question"]["options"]) == 2
+    assert body["question"]["celebration"] == "classic"
 
 
 def test_create_quiz_question_persists_payload(client, flask_app):
@@ -222,13 +232,14 @@ def test_create_quiz_question_persists_payload(client, flask_app):
     assert created["correct_option_id"] == payload["correct_option_id"]
     assert created["published_on"] == payload["published_on"]
     assert len(created["options"]) == 2
+    assert created["celebration"] == payload["celebration"]
 
     pool: QuizResultsStore = flask_app.config["DB_POOL"]
     with pool.connection() as conn:  # type: ignore[assignment]
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT slug, correct_option_id, published_on
+                SELECT slug, correct_option_id, published_on, celebration
                 FROM quiz_questions
                 WHERE slug = %s
                 """,
@@ -239,11 +250,20 @@ def test_create_quiz_question_persists_payload(client, flask_app):
     assert row[0] == payload["slug"]
     assert row[1] == payload["correct_option_id"]
     assert row[2].isoformat() == payload["published_on"]
+    assert row[3] == payload["celebration"]
 
 
 def test_list_quiz_questions_supports_pagination(client):
-    older = _build_question_payload(slug="alpha-question", published_on=date(2024, 7, 1))
-    newer = _build_question_payload(slug="beta-question", published_on=date(2024, 8, 1))
+    older = _build_question_payload(
+        slug="alpha-question",
+        published_on=date(2024, 7, 1),
+        celebration="off",
+    )
+    newer = _build_question_payload(
+        slug="beta-question",
+        published_on=date(2024, 8, 1),
+        celebration="streamers",
+    )
 
     client.post("/api/quiz/questions", json=older)
     client.post("/api/quiz/questions", json=newer)
@@ -253,6 +273,7 @@ def test_list_quiz_questions_supports_pagination(client):
     first_payload = first_page.get_json()
     assert first_payload["pagination"]["count"] == 1
     assert first_payload["questions"][0]["slug"] == "beta-question"
+    assert first_payload["questions"][0]["celebration"] == "streamers"
 
     second_page = client.get(
         "/api/quiz/questions",
@@ -261,6 +282,7 @@ def test_list_quiz_questions_supports_pagination(client):
     assert second_page.status_code == 200
     second_payload = second_page.get_json()
     assert second_payload["questions"][0]["slug"] == "alpha-question"
+    assert second_payload["questions"][0]["celebration"] == "off"
 
 
 def test_update_quiz_question_overwrites_prompt(client):
@@ -282,6 +304,7 @@ def test_update_quiz_question_overwrites_prompt(client):
             }
         ],
         "correct_option_id": "nudge",
+        "celebration": "burst",
     }
 
     client.post("/api/quiz/questions", json=original)
@@ -292,6 +315,7 @@ def test_update_quiz_question_overwrites_prompt(client):
     assert body["question"]["question"] == updated["question"]
     assert body["question"]["correct_option_id"] == "nudge"
     assert len(body["question"]["options"]) == 2
+    assert body["question"]["celebration"] == "burst"
 
 
 def test_generate_quiz_question_requires_api_key(client, monkeypatch):
@@ -350,6 +374,7 @@ def test_generate_quiz_question_uses_https_without_proxy(client, monkeypatch):
         "correct_option_id": "cta-a",
         "published_on": "2024-01-01",
         "expires_on": None,
+        "celebration": "classic",
     }
 
     class DummyOpenAI:
@@ -384,6 +409,7 @@ def test_generate_quiz_question_uses_https_without_proxy(client, monkeypatch):
     assert response.status_code == 200
     body = response.get_json()
     assert body["question"]["slug"] == "draft-slug"
+    assert body["question"]["celebration"] == "classic"
     assert len(DummyOpenAI.calls) == 1
     base_url, used_client = DummyOpenAI.calls[0]
     assert base_url.startswith("https://")


### PR DESCRIPTION
## Summary
- validate and persist the quiz celebration preset included in create/update payloads
- expose the celebration field from list and question-of-day queries so the manager UI can edit it
- document the new column and extend backend tests to assert the celebration value is stored

## Testing
- not run (requires Postgres service)


------
https://chatgpt.com/codex/tasks/task_e_68f7af6da37c83218b77a27f00c47368