### PR TITLE
Add create question workflow to quiz manager

### DIFF
--- a/app/flashoffer/quiz-manager/src/App.jsx
+++ b/app/flashoffer/quiz-manager/src/App.jsx
@@ -1,26 +1,125 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
-import GeneratorPage from './GeneratorPage'
-import {Typography, AppBar, Box, Toolbar, CssBaseline} from '@mui/material'
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
 
-function App() {
-  const [count, setCount] = useState(0)
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AppBar,
+  Box,
+  Button,
+  Container,
+  CssBaseline,
+  Stack,
+  Toolbar,
+  Typography
+} from '@mui/material';
+import CreateQuestionContainer from './CreateQuestionContainer.jsx';
+import GeneratorPage from './GeneratorPage.jsx';
+
+const NAVIGATION_ITEMS = [
+  { id: 'create', label: 'Create Question' },
+  { id: 'generate', label: 'GPT-5 Drafts' }
+];
+
+/**
+ * Renders the quiz manager shell with navigation and page state.
+ * @returns {JSX.Element} Quiz manager root component.
+ */
+export default function App() {
+  const [activePage, setActivePage] = useState('create');
+  const [generatorPrompt, setGeneratorPrompt] = useState('');
+  const [generatorStatus, setGeneratorStatus] = useState('idle');
+  const [generatorError, setGeneratorError] = useState('');
+  const generationTimerRef = useRef();
+
+  const navigationItems = useMemo(() => NAVIGATION_ITEMS, []);
+
+  const handleSelectPage = useCallback((pageId) => {
+    setActivePage(pageId);
+  }, []);
+
+  const handleGeneratorPromptChange = useCallback((event) => {
+    setGeneratorPrompt(event.target.value);
+  }, []);
+
+  const handleGenerate = useCallback(() => {
+    setGeneratorError('');
+    setGeneratorStatus('loading');
+
+    if (generationTimerRef.current) {
+      window.clearTimeout(generationTimerRef.current);
+    }
+
+    generationTimerRef.current = window.setTimeout(() => {
+      setGeneratorStatus('idle');
+      setGeneratorError('Generation API is not connected yet.');
+    }, 600);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (generationTimerRef.current) {
+        window.clearTimeout(generationTimerRef.current);
+      }
+    };
+  }, []);
+
+  const content = useMemo(() => {
+    if (activePage === 'create') {
+      return <CreateQuestionContainer />;
+    }
+    return (
+      <GeneratorPage
+        generatorError={generatorError}
+        generatorPrompt={generatorPrompt}
+        generatorStatus={generatorStatus}
+        handleGenerate={handleGenerate}
+        handleGeneratorPromptChange={handleGeneratorPromptChange}
+      />
+    );
+  }, [
+    activePage,
+    generatorError,
+    generatorPrompt,
+    generatorStatus,
+    handleGenerate,
+    handleGeneratorPromptChange
+  ]);
 
   return (
     <>
-      <CssBaseline/>
-      <AppBar>
-      <Toolbar>
-      <Typography>foobar</Typography>
-      </Toolbar>
-      </AppBar>
-      <Box component="main">
-      <GeneratorPage/>
+      <CssBaseline />
+      <Box className="quiz-manager__layout">
+        <AppBar position="static" color="transparent" elevation={0}>
+          <Toolbar className="quiz-manager__toolbar">
+            <Box className="quiz-manager__title-group">
+              <Typography variant="h5" component="h1">
+                Quiz Manager
+              </Typography>
+              <Typography variant="body2" color="textSecondary">
+                Create, preview, and manage questions for Flashoffer campaigns.
+              </Typography>
+            </Box>
+            <Box sx={{ flexGrow: 1 }} />
+            <Stack direction="row" spacing={1} className="quiz-manager__nav-buttons">
+              {navigationItems.map((item) => (
+                <Button
+                  key={item.id}
+                  color="inherit"
+                  variant={activePage === item.id ? 'contained' : 'outlined'}
+                  onClick={() => handleSelectPage(item.id)}
+                >
+                  {item.label}
+                </Button>
+              ))}
+            </Stack>
+          </Toolbar>
+        </AppBar>
+        <Container maxWidth="md" className="quiz-manager__content">
+          {content}
+        </Container>
       </Box>
     </>
-  )
+  );
 }
-
-export default App

--- a/app/flashoffer/quiz-manager/src/CreateQuestionContainer.jsx
+++ b/app/flashoffer/quiz-manager/src/CreateQuestionContainer.jsx
@@ -1,0 +1,548 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import CreateQuestionPage from './CreateQuestionPage.jsx';
+
+const DEFAULT_CELEBRATION = 'off';
+const CELEBRATION_OPTIONS = ['off', 'classic', 'streamers', 'burst'];
+const CELEBRATION_LABELS = {
+  off: 'None',
+  classic: 'Classic confetti',
+  streamers: 'Streamer launch',
+  burst: 'Grand finale'
+};
+const MIN_OPTIONS = 3;
+
+/**
+ * Indicates that the submitted form data failed validation rules.
+ */
+class FormValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'FormValidationError';
+  }
+}
+
+/**
+ * Produces an empty answer option template.
+ * @returns {{ id: string, label: string, description: string }} Blank option.
+ */
+function emptyOption() {
+  return { id: '', label: '', description: '' };
+}
+
+/**
+ * Resolves the current date in ISO-8601 (YYYY-MM-DD) format.
+ * @returns {string} Today's date string.
+ */
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Builds a pristine form object with default values.
+ * @returns {object} Empty form state.
+ */
+function createEmptyForm() {
+  return {
+    slug: '',
+    question: '',
+    helper_text: '',
+    explanation: '',
+    success_message: '',
+    error_message: '',
+    published_on: todayIso(),
+    expires_on: '',
+    correct_option_id: '',
+    celebration: DEFAULT_CELEBRATION,
+    options: [emptyOption(), emptyOption(), emptyOption()]
+  };
+}
+
+/**
+ * Converts unknown values into trimmed strings.
+ * @param {unknown} value - Arbitrary input to normalize.
+ * @returns {string} Trimmed string representation.
+ */
+function trimValue(value) {
+  return String(value ?? '').trim();
+}
+
+/**
+ * Normalizes optional string inputs while preserving empty state.
+ * @param {unknown} value - Candidate value to normalize.
+ * @returns {string} Trimmed value or an empty string.
+ */
+function optionalTrimmed(value) {
+  const trimmed = trimValue(value);
+  return trimmed || '';
+}
+
+/**
+ * Generates a trimmed ISO date, defaulting to a fallback when empty.
+ * @param {unknown} value - Candidate date value.
+ * @param {string} fallback - Replacement when the value is empty.
+ * @returns {string} ISO formatted date.
+ */
+function isoDateValue(value, fallback) {
+  const base = trimValue(value) || fallback;
+  return base.slice(0, 10);
+}
+
+/**
+ * Produces an optional ISO date string truncated to the first ten characters.
+ * @param {unknown} value - Date-like value.
+ * @returns {string} ISO formatted date or an empty string.
+ */
+function optionalIsoDate(value) {
+  const trimmed = trimValue(value);
+  return trimmed ? trimmed.slice(0, 10) : '';
+}
+
+/**
+ * Normalizes incoming option entries to ensure predictable structure.
+ * @param {unknown} options - Raw options from user input or imports.
+ * @returns {Array<{ id: string, label: string, description: string }>} Normalized options.
+ */
+function normalizeOptionEntries(options) {
+  if (!Array.isArray(options) || options.length === 0) {
+    return [emptyOption(), emptyOption(), emptyOption()];
+  }
+  return options.map((option) => ({
+    id: trimValue(option.id),
+    label: trimValue(option.label),
+    description: optionalTrimmed(option.description)
+  }));
+}
+
+/**
+ * Maps backend question payloads into the interactive form shape.
+ * @param {object} [question] - Optional question payload from storage.
+ * @returns {object} Prepared form state.
+ */
+function buildFormStateForQuestion(question) {
+  const normalizedOptions = normalizeOptionEntries(question?.options);
+  const formState = {
+    ...createEmptyForm(),
+    options: normalizedOptions
+  };
+
+  if (question) {
+    formState.slug = trimValue(question.slug);
+    formState.question = String(question.question ?? '');
+    formState.helper_text = optionalTrimmed(question.helper_text);
+    formState.explanation = optionalTrimmed(question.explanation);
+    formState.success_message = optionalTrimmed(question.success_message);
+    formState.error_message = optionalTrimmed(question.error_message);
+    formState.published_on = isoDateValue(question.published_on, todayIso());
+    formState.expires_on = optionalIsoDate(question.expires_on);
+    formState.correct_option_id = trimValue(question.correct_option_id);
+    const celebration = trimValue(question.celebration);
+    formState.celebration = CELEBRATION_OPTIONS.includes(celebration)
+      ? celebration
+      : DEFAULT_CELEBRATION;
+  }
+
+  if (!formState.correct_option_id && normalizedOptions.length > 0) {
+    formState.correct_option_id = normalizedOptions[0].id;
+  }
+
+  return formState;
+}
+
+/**
+ * Resolves the most appropriate correct answer identifier.
+ * @param {Array<{ id: string }>} normalizedOptions - Validated answer options.
+ * @param {string} preferredId - Desired correct answer identifier.
+ * @returns {string} Selected correct identifier.
+ */
+function resolvePreferredCorrectId(normalizedOptions, preferredId) {
+  if (preferredId && normalizedOptions.some((option) => option.id === preferredId)) {
+    return preferredId;
+  }
+  return normalizedOptions[0]?.id ?? '';
+}
+
+/**
+ * Determines the option collection that should power the live preview.
+ * @param {object} formState - Current form data.
+ * @returns {Array<{ id: string, label: string, description: string }>} Options to preview.
+ */
+function getPreviewOptionsSource(formState) {
+  if (Array.isArray(formState.options) && formState.options.length > 0) {
+    return formState.options;
+  }
+  return [emptyOption(), emptyOption(), emptyOption()];
+}
+
+/**
+ * Converts a raw option into a preview-safe variant with fallbacks.
+ * @param {{ id: string, label: string, description: string }} option - Source option.
+ * @param {number} index - Option index for fallback values.
+ * @returns {{ id: string, label: string, description?: string }} Preview-ready option.
+ */
+function toPreviewOption(option, index) {
+  const id = trimValue(option.id);
+  const label = trimValue(option.label);
+  const description = optionalTrimmed(option.description) || undefined;
+  return {
+    id: id || `option-${index + 1}`,
+    label: label || id || `Option ${index + 1}`,
+    description
+  };
+}
+
+/**
+ * Determines whether any option contains meaningful preview content.
+ * @param {Array<{ label: string, description?: string }>} options - Preview candidates.
+ * @returns {boolean} True when at least one option has content.
+ */
+function previewOptionsHaveContent(options) {
+  return options.some((option) => Boolean(option.label || option.description));
+}
+
+/**
+ * Checks if any preview field includes user-provided data.
+ * @param {Array<unknown>} parts - Preview fragments to inspect.
+ * @returns {boolean} True when at least one fragment is truthy.
+ */
+function previewHasContent(parts) {
+  return parts.some(Boolean);
+}
+
+/**
+ * Builds the live preview question payload derived from the form state.
+ * @param {object} formState - Current form values.
+ * @returns {object | undefined} Preview question or undefined when empty.
+ */
+function resolvePreviewQuestion(formState) {
+  const normalizedOptions = getPreviewOptionsSource(formState).map((option, index) =>
+    toPreviewOption(option, index)
+  );
+
+  const questionText = trimValue(formState.question);
+  const helperText = optionalTrimmed(formState.helper_text);
+  const explanation = optionalTrimmed(formState.explanation);
+  const successMessage = optionalTrimmed(formState.success_message);
+  const errorMessage = optionalTrimmed(formState.error_message);
+  const celebrationValue = trimValue(formState.celebration);
+  const resolvedCelebration = CELEBRATION_OPTIONS.includes(celebrationValue)
+    ? celebrationValue
+    : DEFAULT_CELEBRATION;
+  const hasOptionContent = previewOptionsHaveContent(normalizedOptions);
+  const hasContent = previewHasContent([
+    questionText,
+    helperText,
+    explanation,
+    successMessage,
+    errorMessage,
+    hasOptionContent
+  ]);
+
+  if (!hasContent) {
+    return undefined;
+  }
+
+  const resolvedCorrect = resolvePreferredCorrectId(
+    normalizedOptions,
+    trimValue(formState.correct_option_id)
+  );
+
+  return {
+    question: questionText || 'Untitled question',
+    helperText: helperText || undefined,
+    options: normalizedOptions,
+    correctOptionId: resolvedCorrect,
+    explanation: explanation || undefined,
+    successMessage: successMessage || undefined,
+    errorMessage: errorMessage || undefined,
+    celebration: resolvedCelebration
+  };
+}
+
+/**
+ * Converts form options into the payload structure expected by the backend.
+ * @param {Array<{ id: string, label: string, description: string }>} formOptions - Form options.
+ * @returns {Array<{ id: string, label: string, description?: string }>} Payload-ready options.
+ */
+function normalizePayloadOptions(formOptions) {
+  return formOptions
+    .map((option) => ({
+      id: trimValue(option.id),
+      label: trimValue(option.label),
+      description: trimValue(option.description)
+    }))
+    .filter((option) => option.id || option.label)
+    .map((option) => {
+      const nextOption = {
+        id: option.id,
+        label: option.label || option.id
+      };
+      if (option.description) {
+        nextOption.description = option.description;
+      }
+      return nextOption;
+    });
+}
+
+/**
+ * Throws a validation error when a constraint is not satisfied.
+ * @param {boolean} condition - Constraint to evaluate.
+ * @param {string} message - Error message when the condition fails.
+ */
+function assertCondition(condition, message) {
+  if (!condition) {
+    throw new FormValidationError(message);
+  }
+}
+
+/**
+ * Validates option input and selects the correct answer identifier.
+ * @param {Array<{ id: string, label: string, description: string }>} formOptions - Option entries.
+ * @param {string} preferredId - Preferred correct option identifier.
+ * @returns {{ normalizedOptions: Array<object>, correctOptionId: string }} Normalized results.
+ */
+function normalizeAndValidateOptions(formOptions, preferredId) {
+  const normalizedOptions = normalizePayloadOptions(formOptions);
+  assertCondition(normalizedOptions.length >= MIN_OPTIONS, 'Provide at least three answer options.');
+
+  const optionIds = normalizedOptions.map((option) => option.id);
+  assertCondition(optionIds.every((value) => Boolean(value)), 'Each option must include a non-empty id.');
+  assertCondition(new Set(optionIds).size === optionIds.length, 'Each option id must be unique.');
+
+  const correctOptionId = resolvePreferredCorrectId(normalizedOptions, trimValue(preferredId));
+  assertCondition(Boolean(correctOptionId), 'Correct option must reference one of the option ids.');
+
+  return {
+    normalizedOptions,
+    correctOptionId
+  };
+}
+
+/**
+ * Converts validation failures into user-facing error messages when appropriate.
+ * @param {unknown} error - Error thrown during payload construction.
+ * @param {boolean} silent - When true, suppresses inline error messaging.
+ * @param {(message: string) => void} setFormError - Setter for form error state.
+ * @returns {null} Always returns null for handled validation errors.
+ */
+function handlePayloadError(error, silent, setFormError) {
+  if (!silent && error instanceof FormValidationError) {
+    setFormError(error.message);
+  }
+  if (error instanceof FormValidationError) {
+    return null;
+  }
+  throw error;
+}
+
+/**
+ * Coordinates form state and interaction handlers for the create-question view.
+ * @returns {JSX.Element} Rendered create question workflow.
+ */
+export default function CreateQuestionContainer() {
+  const [form, setForm] = useState(() => createEmptyForm());
+  const [formMode, setFormMode] = useState('create');
+  const [formError, setFormError] = useState('');
+  const [formSuccess, setFormSuccess] = useState('');
+  const [fileError, setFileError] = useState('');
+  const [fileName, setFileName] = useState('');
+
+  const applyQuestionToForm = useCallback((question, mode) => {
+    setForm(buildFormStateForQuestion(question));
+    setFormMode(mode);
+    setFormError('');
+    setFormSuccess('');
+  }, []);
+
+  const resetForm = useCallback(() => {
+    setForm(createEmptyForm());
+    setFormMode('create');
+    setFormError('');
+    setFormSuccess('');
+    setFileError('');
+    setFileName('');
+  }, []);
+
+  const handleFieldChange = useCallback((field) => (event) => {
+    const { value } = event.target;
+    setForm((prev) => ({
+      ...prev,
+      [field]: value
+    }));
+  }, []);
+
+  const handleOptionChange = useCallback((index, field) => (event) => {
+    const { value } = event.target;
+    setForm((prev) => {
+      const nextOptions = prev.options.map((option, optionIndex) => {
+        if (optionIndex !== index) {
+          return option;
+        }
+        return {
+          ...option,
+          [field]: value
+        };
+      });
+      return {
+        ...prev,
+        options: nextOptions
+      };
+    });
+  }, []);
+
+  const handleAddOption = useCallback(() => {
+    setForm((prev) => ({
+      ...prev,
+      options: [...prev.options, emptyOption()]
+    }));
+  }, []);
+
+  const handleRemoveOption = useCallback((index) => {
+    setForm((prev) => {
+      if (prev.options.length <= MIN_OPTIONS) {
+        return prev;
+      }
+      const nextOptions = prev.options.filter((_, optionIndex) => optionIndex !== index);
+      let nextCorrect = prev.correct_option_id;
+      if (!nextOptions.some((option) => option.id === nextCorrect)) {
+        nextCorrect = nextOptions[0]?.id ?? '';
+      }
+      return {
+        ...prev,
+        options: nextOptions,
+        correct_option_id: nextCorrect
+      };
+    });
+  }, []);
+
+  const handleCorrectOptionChange = useCallback((event) => {
+    setForm((prev) => ({ ...prev, correct_option_id: event.target.value }));
+  }, []);
+
+  const buildPayload = useCallback((targetForm, options = { silent: false }) => {
+    const { silent } = options;
+
+    try {
+      const slug = trimValue(targetForm.slug);
+      assertCondition(slug, 'Slug is required.');
+
+      const questionText = trimValue(targetForm.question);
+      assertCondition(questionText, 'Question prompt is required.');
+
+      const { normalizedOptions, correctOptionId } = normalizeAndValidateOptions(
+        targetForm.options,
+        targetForm.correct_option_id
+      );
+
+      const publishedOn = trimValue(targetForm.published_on);
+      assertCondition(/^\d{4}-\d{2}-\d{2}$/.test(publishedOn), 'Published date must be in YYYY-MM-DD format.');
+
+      const expiresOn = trimValue(targetForm.expires_on);
+      const celebrationValue = trimValue(targetForm.celebration) || DEFAULT_CELEBRATION;
+      const celebration = CELEBRATION_OPTIONS.includes(celebrationValue)
+        ? celebrationValue
+        : DEFAULT_CELEBRATION;
+
+      return {
+        slug,
+        question: questionText,
+        helper_text: optionalTrimmed(targetForm.helper_text) || undefined,
+        explanation: optionalTrimmed(targetForm.explanation) || undefined,
+        success_message: optionalTrimmed(targetForm.success_message) || undefined,
+        error_message: optionalTrimmed(targetForm.error_message) || undefined,
+        options: normalizedOptions,
+        correct_option_id: correctOptionId,
+        published_on: publishedOn,
+        expires_on: expiresOn ? expiresOn : undefined,
+        celebration
+      };
+    } catch (error) {
+      return handlePayloadError(error, silent, setFormError);
+    }
+  }, []);
+
+  const previewPayload = useMemo(() => buildPayload(form, { silent: true }), [buildPayload, form]);
+
+  const preview = useMemo(() => {
+    if (!previewPayload) {
+      return '';
+    }
+    return JSON.stringify(previewPayload, null, 2);
+  }, [previewPayload]);
+
+  const previewQuestion = useMemo(() => resolvePreviewQuestion(form), [form]);
+
+  const handleSubmit = useCallback(() => {
+    const payload = buildPayload(form);
+    if (!payload) {
+      return;
+    }
+    setFormSuccess(`Preview ready for question ${payload.slug}`);
+  }, [buildPayload, form]);
+
+  const handleFileChange = useCallback((event) => {
+    const [file] = event.target.files ?? [];
+    setFileName('');
+    setFileError('');
+
+    if (!file) {
+      return;
+    }
+
+    setFileName(file.name);
+    file
+      .text()
+      .then((rawText) => {
+        try {
+          const parsed = JSON.parse(rawText);
+          if (Array.isArray(parsed)) {
+            if (parsed.length !== 1) {
+              throw new Error('When providing an array, include exactly one question');
+            }
+            applyQuestionToForm(parsed[0], 'create');
+          } else {
+            applyQuestionToForm(parsed, 'create');
+          }
+        } catch (parseError) {
+          setFileError(
+            parseError instanceof Error ? parseError.message : 'Invalid JSON payload'
+          );
+        }
+      })
+      .catch(() => {
+        setFileError('Unable to read the selected file');
+      });
+  }, [applyQuestionToForm]);
+
+  const formDisabled = false;
+  const canSubmit = Boolean(previewPayload);
+
+  return (
+    <CreateQuestionPage
+      canSubmit={canSubmit}
+      celebrationLabels={CELEBRATION_LABELS}
+      celebrationOptions={CELEBRATION_OPTIONS}
+      fileError={fileError}
+      fileName={fileName}
+      form={form}
+      formDisabled={formDisabled}
+      formError={formError}
+      formMode={formMode}
+      formSuccess={formSuccess}
+      handleAddOption={handleAddOption}
+      handleCorrectOptionChange={handleCorrectOptionChange}
+      handleFieldChange={handleFieldChange}
+      handleFileChange={handleFileChange}
+      handleOptionChange={handleOptionChange}
+      handleRemoveOption={handleRemoveOption}
+      handleSubmit={handleSubmit}
+      preview={preview}
+      previewQuestion={previewQuestion}
+      resetForm={resetForm}
+    />
+  );
+}

--- a/app/flashoffer/quiz-manager/src/CreateQuestionPage.jsx
+++ b/app/flashoffer/quiz-manager/src/CreateQuestionPage.jsx
@@ -22,6 +22,31 @@ import AddCircleIcon from '@mui/icons-material/AddCircle';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { FlashofferThemeProvider, MultipleChoiceQuiz } from 'flashoffer-react';
 
+/**
+ * Renders the interactive form used to build and preview quiz questions.
+ * @param {object} props - Component props.
+ * @param {boolean} props.canSubmit - Indicates whether the form meets submission requirements.
+ * @param {Record<string, string>} props.celebrationLabels - Human readable celebration labels.
+ * @param {string[]} props.celebrationOptions - Available celebration presets.
+ * @param {string} props.fileError - Error message from file imports.
+ * @param {string} props.fileName - Name of the imported file.
+ * @param {object} props.form - Mutable form state.
+ * @param {boolean} props.formDisabled - Disables controls when true.
+ * @param {string} props.formError - Inline form error message.
+ * @param {'create' | 'update'} props.formMode - Current form mode.
+ * @param {string} props.formSuccess - Success status message.
+ * @param {() => void} props.handleAddOption - Handler to append a new answer option.
+ * @param {(event: import('react').ChangeEvent<HTMLInputElement>) => void} props.handleCorrectOptionChange - Handler for selecting the correct option.
+ * @param {(field: string) => (event: import('react').ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void} props.handleFieldChange - Field change handler factory.
+ * @param {(event: import('react').ChangeEvent<HTMLInputElement>) => void} props.handleFileChange - File upload handler.
+ * @param {(index: number, field: string) => (event: import('react').ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void} props.handleOptionChange - Option change handler factory.
+ * @param {(index: number) => void} props.handleRemoveOption - Removes an option at the given index.
+ * @param {() => void} props.handleSubmit - Submission handler.
+ * @param {string} props.preview - JSON payload preview string.
+ * @param {object} [props.previewQuestion] - Preview question payload for live demo.
+ * @param {() => void} props.resetForm - Resets the form to its initial state.
+ * @returns {JSX.Element} Create question layout.
+ */
 export default function CreateQuestionPage({
   canSubmit,
   celebrationLabels,

--- a/app/flashoffer/quiz-manager/src/GeneratorPage.jsx
+++ b/app/flashoffer/quiz-manager/src/GeneratorPage.jsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
 import {
   Alert,
   Button,
@@ -7,23 +12,34 @@ import {
   Typography
 } from '@mui/material';
 
+/**
+ * Presents the generator workflow used to request GPT-assisted quiz drafts.
+ * @param {object} props - Component props.
+ * @param {string} props.generatorError - Current generator error message.
+ * @param {string} props.generatorPrompt - Prompt text supplied by the operator.
+ * @param {'idle' | 'loading'} props.generatorStatus - Generator request status.
+ * @param {() => void} props.handleGenerate - Callback triggered to draft a question.
+ * @param {(event: import('react').ChangeEvent<HTMLInputElement>) => void} props.handleGeneratorPromptChange - Prompt change handler.
+ * @returns {JSX.Element} Generator layout.
+ */
 export default function GeneratorPage({
-  generatorError,
-  generatorPrompt,
-  generatorStatus,
+  generatorError = '',
+  generatorPrompt = '',
+  generatorStatus = 'idle',
   handleGenerate,
   handleGeneratorPromptChange
 }) {
   return (
+    <Paper elevation={6} className="quiz-manager__panel">
       <Stack spacing={2}>
         <Typography variant="h5" component="h2">
           GPT-5 Drafts
         </Typography>
-        <Typography variant="body2">
+        <Typography variant="body2" color="textSecondary">
           Provide a short prompt and the manager will request a draft question
           from the backend generator endpoint.
         </Typography>
-        <Stack spacing={2}>
+        <Stack spacing={2} className="quiz-manager__generator">
           <TextField
             label="AI Prompt (optional)"
             value={generatorPrompt}
@@ -33,12 +49,11 @@ export default function GeneratorPage({
             minRows={3}
             fullWidth
           />
-          {generatorError ? (
-            <Alert severity="error">{generatorError}</Alert>
-          ) : null}
+          {generatorError ? <Alert severity="error">{generatorError}</Alert> : null}
           <Stack direction="row" spacing={2} justifyContent="flex-end">
             <Button
               variant="outlined"
+              color="inherit"
               onClick={handleGenerate}
               disabled={generatorStatus === 'loading'}
             >
@@ -47,5 +62,6 @@ export default function GeneratorPage({
           </Stack>
         </Stack>
       </Stack>
+    </Paper>
   );
 }

--- a/app/flashoffer/quiz-manager/src/index.css
+++ b/app/flashoffer/quiz-manager/src/index.css
@@ -1,68 +1,96 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  min-height: 100vh;
+  font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
+  background-color: #0d1520;
+  color: #f5f8ff;
+}
+
+#root {
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+.quiz-manager__layout {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem;
+  box-sizing: border-box;
 }
 
-button {
+.quiz-manager__toolbar {
+  background-color: rgba(19, 32, 50, 0.95);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .quiz-manager__toolbar {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+.quiz-manager__title-group {
+  max-width: 420px;
+}
+
+.quiz-manager__nav-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.quiz-manager__content {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-bottom: 4rem;
+}
+
+.quiz-manager__panel {
+  background-color: rgba(19, 32, 50, 0.95);
+  padding: 1.5rem;
+  border-radius: 12px;
+  color: #f5f8ff;
+  width: 100%;
+}
+
+.quiz-manager__generator {
+  background-color: rgba(6, 11, 18, 0.4);
+  padding: 1rem;
   border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.quiz-manager__form {
+  width: 100%;
+}
+
+.quiz-manager__option {
+  padding: 1rem;
+  background-color: rgba(6, 11, 18, 0.5);
+}
+
+.quiz-manager__preview {
+  max-height: 320px;
+  overflow: auto;
+  background-color: #060b12;
+  color: #95c4ff;
+  padding: 1rem;
+  border-radius: 4px;
+  font-family: 'Fira Code', 'Courier New', monospace;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.quiz-manager__quiz-preview {
+  padding: 1.25rem;
+  border-radius: 8px;
+  background-color: #f5f8ff;
+  color: #091222;
 }


### PR DESCRIPTION
## Summary
- add a material-ui toolbar that switches between generator and create-question views
- port the legacy create question workflow into the new quiz manager via a stateful container
- refresh the generator panel and shared styles to match the previous quiz manager experience

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68f7e63bed948321bc333246a85f56bd