### PR TITLE
Add existing questions view to quiz manager toolbar

### DIFF
--- a/app/flashoffer/quiz-manager/src/App.jsx
+++ b/app/flashoffer/quiz-manager/src/App.jsx
@@ -15,10 +15,12 @@ import {
   Typography
 } from '@mui/material';
 import CreateQuestionContainer from './CreateQuestionContainer.jsx';
+import ExistingQuestionsContainer from './ExistingQuestionsContainer.jsx';
 import GeneratorPage from './GeneratorPage.jsx';
 
 const NAVIGATION_ITEMS = [
   { id: 'create', label: 'Create Question' },
+  { id: 'questions', label: 'Existing Questions' },
   { id: 'generate', label: 'GPT-5 Drafts' }
 ];
 
@@ -68,6 +70,9 @@ export default function App() {
   const content = useMemo(() => {
     if (activePage === 'create') {
       return <CreateQuestionContainer />;
+    }
+    if (activePage === 'questions') {
+      return <ExistingQuestionsContainer />;
     }
     return (
       <GeneratorPage

--- a/app/flashoffer/quiz-manager/src/ExistingQuestionsContainer.jsx
+++ b/app/flashoffer/quiz-manager/src/ExistingQuestionsContainer.jsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import ExistingQuestionsPage from './ExistingQuestionsPage.jsx';
+
+const QUESTIONS_ENDPOINT = '/api/quiz/questions';
+
+/**
+ * Manages loading and selection state for the existing questions view.
+ * @returns {JSX.Element} Existing questions container.
+ */
+export default function ExistingQuestionsContainer() {
+  const [questions, setQuestions] = useState([]);
+  const [questionsStatus, setQuestionsStatus] = useState('idle');
+  const [questionsError, setQuestionsError] = useState('');
+  const [selectedSlug, setSelectedSlug] = useState('');
+
+  const fetchQuestions = useCallback(async () => {
+    if (typeof window === 'undefined') {
+      return [];
+    }
+
+    setQuestionsStatus('loading');
+    setQuestionsError('');
+
+    try {
+      const url = new URL(QUESTIONS_ENDPOINT, window.location.origin);
+      url.searchParams.set('limit', '50');
+      url.searchParams.set('offset', '0');
+
+      const response = await fetch(url.toString());
+      const body = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        const message =
+          body?.error ?? `Failed to load questions (${response.status})`;
+        throw new Error(message);
+      }
+
+      const items = Array.isArray(body?.questions) ? body.questions : [];
+      setQuestions(items);
+      setQuestionsStatus('success');
+      return items;
+    } catch (error) {
+      setQuestionsStatus('error');
+      setQuestionsError(
+        error instanceof Error ? error.message : 'Unable to load questions'
+      );
+      setQuestions([]);
+      throw error;
+    }
+  }, []);
+
+  const handleSelectQuestion = useCallback((question) => {
+    if (!question) {
+      return;
+    }
+    setSelectedSlug(question.slug ?? '');
+  }, []);
+
+  useEffect(() => {
+    fetchQuestions().catch(() => {
+      /* error captured in state */
+    });
+  }, [fetchQuestions]);
+
+  return (
+    <ExistingQuestionsPage
+      fetchQuestions={fetchQuestions}
+      handleSelectQuestion={handleSelectQuestion}
+      questions={questions}
+      questionsError={questionsError}
+      questionsStatus={questionsStatus}
+      selectedSlug={selectedSlug}
+    />
+  );
+}

--- a/app/flashoffer/quiz-manager/src/ExistingQuestionsPage.jsx
+++ b/app/flashoffer/quiz-manager/src/ExistingQuestionsPage.jsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Flashoffer Developers
+ * Released under the MIT license.
+ */
+
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography
+} from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+
+/**
+ * Renders a tabular overview of existing quiz questions.
+ * @param {object} props - Component props.
+ * @param {() => Promise<unknown>} props.fetchQuestions - Reload callback.
+ * @param {(question: object) => void} props.handleSelectQuestion - Select handler.
+ * @param {Array<object>} props.questions - Loaded quiz questions.
+ * @param {string} props.questionsError - Error message for failed fetches.
+ * @param {'idle' | 'loading' | 'error' | 'success'} props.questionsStatus - Fetch
+ * status.
+ * @param {string} props.selectedSlug - Currently highlighted question slug.
+ * @returns {JSX.Element} Existing questions layout.
+ */
+export default function ExistingQuestionsPage({
+  fetchQuestions,
+  handleSelectQuestion,
+  questions,
+  questionsError,
+  questionsStatus,
+  selectedSlug
+}) {
+  return (
+    <Paper
+      elevation={6}
+      className="quiz-manager__panel quiz-manager__table-wrapper"
+    >
+      <Stack spacing={2}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Typography variant="h5" component="h2">
+            Existing Questions
+          </Typography>
+          <Button
+            variant="outlined"
+            color="inherit"
+            startIcon={<RefreshIcon />}
+            onClick={() => fetchQuestions().catch(() => {})}
+            disabled={questionsStatus === 'loading'}
+          >
+            Refresh
+          </Button>
+        </Stack>
+
+        {questionsStatus === 'error' ? (
+          <Alert severity="error">{questionsError}</Alert>
+        ) : null}
+
+        {questionsStatus === 'loading' ? (
+          <Box className="quiz-manager__loader">
+            <CircularProgress size={28} />
+          </Box>
+        ) : null}
+
+        {questionsStatus === 'success' && questions.length === 0 ? (
+          <Typography variant="body2" color="textSecondary">
+            No questions found. Upload a JSON payload or use the form to seed the
+            catalog.
+          </Typography>
+        ) : null}
+
+        {questions.length > 0 ? (
+          <TableContainer className="quiz-manager__table">
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Slug</TableCell>
+                  <TableCell>Prompt</TableCell>
+                  <TableCell>Published</TableCell>
+                  <TableCell>Expires</TableCell>
+                  <TableCell>Correct Option</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {questions.map((item) => (
+                  <TableRow
+                    key={item.id}
+                    hover
+                    selected={selectedSlug === item.slug}
+                    onClick={() => handleSelectQuestion(item)}
+                    sx={{ cursor: 'pointer' }}
+                  >
+                    <TableCell width={160} sx={{ fontWeight: 600 }}>
+                      {item.slug}
+                    </TableCell>
+                    <TableCell sx={{ maxWidth: 360 }}>
+                      <Typography
+                        variant="body2"
+                        color="textPrimary"
+                        noWrap
+                        title={item.question}
+                      >
+                        {item.question}
+                      </Typography>
+                    </TableCell>
+                    <TableCell width={120}>{item.published_on}</TableCell>
+                    <TableCell width={120}>{item.expires_on ?? '—'}</TableCell>
+                    <TableCell width={160}>{item.correct_option_id}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        ) : null}
+      </Stack>
+    </Paper>
+  );
+}

--- a/app/flashoffer/quiz-manager/src/index.css
+++ b/app/flashoffer/quiz-manager/src/index.css
@@ -91,3 +91,25 @@ body {
   background-color: #f5f8ff;
   color: #091222;
 }
+
+.quiz-manager__table-wrapper {
+  background-color: rgba(6, 11, 18, 0.4);
+}
+
+.quiz-manager__table {
+  max-height: 320px;
+  border-radius: 6px;
+  overflow: auto;
+  background-color: rgba(6, 11, 18, 0.6);
+}
+
+.quiz-manager__table table {
+  min-width: 720px;
+}
+
+.quiz-manager__loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+}


### PR DESCRIPTION
## Summary
- port the existing questions page from the legacy quiz manager into the new client
- wire the toolbar navigation to open the existing questions view via a container
- extend the quiz manager styles to support the table and loading state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7ee19aa1083219419592ffe0b04e7