### PR TITLE
Implement GPT-5 draft workflow in quiz manager

### DIFF
--- a/app/flashoffer/quiz-manager/src/App.jsx
+++ b/app/flashoffer/quiz-manager/src/App.jsx
@@ -24,16 +24,56 @@ const NAVIGATION_ITEMS = [
   { id: 'generate', label: 'GPT-5 Drafts' }
 ];
 
+const QUESTIONS_ENDPOINT = '/api/quiz/questions';
+const GENERATOR_ENDPOINT = `${QUESTIONS_ENDPOINT.replace(/\/$/, '')}/generate`;
+const GENERATOR_PROMPT_STORAGE_KEY = 'flashoffer.quiz_manager.generator_prompt';
+
+async function requestGeneratedQuestion(endpoint, prompt) {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      prompt: prompt || undefined
+    })
+  });
+
+  const body = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const message = body?.error ?? `Generation failed (${response.status})`;
+    throw new Error(message);
+  }
+
+  if (!body?.question) {
+    throw new Error('Generation did not return a question payload');
+  }
+
+  return body;
+}
+
 /**
  * Renders the quiz manager shell with navigation and page state.
  * @returns {JSX.Element} Quiz manager root component.
  */
 export default function App() {
   const [activePage, setActivePage] = useState('create');
-  const [generatorPrompt, setGeneratorPrompt] = useState('');
+  const [generatorPrompt, setGeneratorPrompt] = useState(() => {
+    if (typeof window === 'undefined') {
+      return '';
+    }
+    try {
+      return window.localStorage.getItem(GENERATOR_PROMPT_STORAGE_KEY) ?? '';
+    } catch {
+      return '';
+    }
+  });
   const [generatorStatus, setGeneratorStatus] = useState('idle');
   const [generatorError, setGeneratorError] = useState('');
-  const generationTimerRef = useRef();
+  const [pendingGeneratedQuestion, setPendingGeneratedQuestion] = useState(null);
+  const [pendingGeneratedMessage, setPendingGeneratedMessage] = useState('');
+  const createContainerRef = useRef(null);
 
   const navigationItems = useMemo(() => NAVIGATION_ITEMS, []);
 
@@ -45,52 +85,58 @@ export default function App() {
     setGeneratorPrompt(event.target.value);
   }, []);
 
-  const handleGenerate = useCallback(() => {
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      if (generatorPrompt) {
+        window.localStorage.setItem(GENERATOR_PROMPT_STORAGE_KEY, generatorPrompt);
+      } else {
+        window.localStorage.removeItem(GENERATOR_PROMPT_STORAGE_KEY);
+      }
+    } catch {
+      /* ignore storage errors */
+    }
+  }, [generatorPrompt]);
+
+  const handleGenerate = useCallback(async () => {
     setGeneratorError('');
     setGeneratorStatus('loading');
+    const trimmedPrompt = generatorPrompt.trim();
 
-    if (generationTimerRef.current) {
-      window.clearTimeout(generationTimerRef.current);
-    }
-
-    generationTimerRef.current = window.setTimeout(() => {
+    try {
+      const body = await requestGeneratedQuestion(
+        GENERATOR_ENDPOINT,
+        trimmedPrompt
+      );
+      const slug = body.question?.slug;
+      setPendingGeneratedQuestion(body.question);
+      setPendingGeneratedMessage(
+        slug ? `Drafted question ${slug}` : 'Drafted question ready'
+      );
+      setActivePage('create');
+    } catch (error) {
+      setGeneratorError(
+        error instanceof Error ? error.message : 'Generation failed'
+      );
+    } finally {
       setGeneratorStatus('idle');
-      setGeneratorError('Generation API is not connected yet.');
-    }, 600);
-  }, []);
+    }
+  }, [generatorPrompt]);
 
   useEffect(() => {
-    return () => {
-      if (generationTimerRef.current) {
-        window.clearTimeout(generationTimerRef.current);
-      }
-    };
-  }, []);
-
-  const content = useMemo(() => {
-    if (activePage === 'create') {
-      return <CreateQuestionContainer />;
+    if (!pendingGeneratedQuestion || !createContainerRef.current) {
+      return;
     }
-    if (activePage === 'questions') {
-      return <ExistingQuestionsContainer />;
-    }
-    return (
-      <GeneratorPage
-        generatorError={generatorError}
-        generatorPrompt={generatorPrompt}
-        generatorStatus={generatorStatus}
-        handleGenerate={handleGenerate}
-        handleGeneratorPromptChange={handleGeneratorPromptChange}
-      />
+    createContainerRef.current.applyQuestionToForm(
+      pendingGeneratedQuestion,
+      'create',
+      pendingGeneratedMessage
     );
-  }, [
-    activePage,
-    generatorError,
-    generatorPrompt,
-    generatorStatus,
-    handleGenerate,
-    handleGeneratorPromptChange
-  ]);
+    setPendingGeneratedQuestion(null);
+    setPendingGeneratedMessage('');
+  }, [pendingGeneratedMessage, pendingGeneratedQuestion, createContainerRef]);
 
   return (
     <>
@@ -121,7 +167,21 @@ export default function App() {
           </Toolbar>
         </AppBar>
         <Container maxWidth="md" className="quiz-manager__content">
-          {content}
+          <Box sx={{ display: activePage === 'create' ? 'block' : 'none' }}>
+            <CreateQuestionContainer ref={createContainerRef} />
+          </Box>
+          {activePage === 'questions' ? (
+            <ExistingQuestionsContainer />
+          ) : null}
+          {activePage === 'generate' ? (
+            <GeneratorPage
+              generatorError={generatorError}
+              generatorPrompt={generatorPrompt}
+              generatorStatus={generatorStatus}
+              handleGenerate={handleGenerate}
+              handleGeneratorPromptChange={handleGeneratorPromptChange}
+            />
+          ) : null}
         </Container>
       </Box>
     </>

--- a/app/flashoffer/quiz-manager/src/CreateQuestionContainer.jsx
+++ b/app/flashoffer/quiz-manager/src/CreateQuestionContainer.jsx
@@ -3,7 +3,7 @@
  * Released under the MIT license.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useMemo, useState } from 'react';
 import CreateQuestionPage from './CreateQuestionPage.jsx';
 
 const DEFAULT_CELEBRATION = 'off';
@@ -343,7 +343,8 @@ function handlePayloadError(error, silent, setFormError) {
  * Coordinates form state and interaction handlers for the create-question view.
  * @returns {JSX.Element} Rendered create question workflow.
  */
-export default function CreateQuestionContainer() {
+const CreateQuestionContainer = forwardRef(function CreateQuestionContainer(props, ref) {
+  void props;
   const [form, setForm] = useState(() => createEmptyForm());
   const [formMode, setFormMode] = useState('create');
   const [formError, setFormError] = useState('');
@@ -351,11 +352,13 @@ export default function CreateQuestionContainer() {
   const [fileError, setFileError] = useState('');
   const [fileName, setFileName] = useState('');
 
-  const applyQuestionToForm = useCallback((question, mode) => {
+  const applyQuestionToForm = useCallback((question, mode, successMessage = '') => {
     setForm(buildFormStateForQuestion(question));
     setFormMode(mode);
     setFormError('');
-    setFormSuccess('');
+    setFormSuccess(successMessage);
+    setFileError('');
+    setFileName('');
   }, []);
 
   const resetForm = useCallback(() => {
@@ -366,6 +369,18 @@ export default function CreateQuestionContainer() {
     setFileError('');
     setFileName('');
   }, []);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      applyQuestionToForm,
+      resetForm,
+      setFormSuccess(message) {
+        setFormSuccess(message);
+      }
+    }),
+    [applyQuestionToForm, resetForm]
+  );
 
   const handleFieldChange = useCallback((field) => (event) => {
     const { value } = event.target;
@@ -545,4 +560,6 @@ export default function CreateQuestionContainer() {
       resetForm={resetForm}
     />
   );
-}
+});
+
+export default CreateQuestionContainer;


### PR DESCRIPTION
## Summary
- integrate the GPT-5 generator endpoint into the refreshed quiz manager UI
- persist draft prompts locally and hydrate generated questions back into the creation form
- expose imperative hooks on the create question container so the generator flow can reuse the form state

## Testing
- npm run lint (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68f7efd15de48321a1b71d714a19c93a