### PR TITLE
Add live generator preview and payload accordion

### DIFF
--- a/app/flashoffer/quiz-manager/src/App.jsx
+++ b/app/flashoffer/quiz-manager/src/App.jsx
@@ -3,18 +3,16 @@
  * Released under the MIT license.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   AppBar,
   Box,
   Button,
   Container,
   CssBaseline,
-  Menu,
-  MenuItem,
+  Stack,
   Toolbar,
-  Typography,
-    Stack,
+  Typography
 } from '@mui/material';
 import CreateQuestionContainer from './CreateQuestionContainer.jsx';
 import ExistingQuestionsContainer from './ExistingQuestionsContainer.jsx';
@@ -32,51 +30,10 @@ const NAVIGATION_ITEMS = [
  */
 export default function App() {
   const [activePage, setActivePage] = useState('draft');
-  const [navigationMenuAnchor, setNavigationMenuAnchor] = useState(null);
-  const [generatorPrompt, setGeneratorPrompt] = useState('');
-  const [generatorStatus, setGeneratorStatus] = useState('idle');
-  const [generatorError, setGeneratorError] = useState('');
-  const generationTimerRef = useRef();
-
   const navigationItems = useMemo(() => NAVIGATION_ITEMS, []);
 
   const handleSelectPage = useCallback((pageId) => {
     setActivePage(pageId);
-    setNavigationMenuAnchor(null);
-  }, []);
-
-  const handleOpenNavigationMenu = useCallback((event) => {
-    setNavigationMenuAnchor(event.currentTarget);
-  }, []);
-
-  const handleCloseNavigationMenu = useCallback(() => {
-    setNavigationMenuAnchor(null);
-  }, []);
-
-  const handleGeneratorPromptChange = useCallback((event) => {
-    setGeneratorPrompt(event.target.value);
-  }, []);
-
-  const handleGenerate = useCallback(() => {
-    setGeneratorError('');
-    setGeneratorStatus('loading');
-
-    if (generationTimerRef.current) {
-      window.clearTimeout(generationTimerRef.current);
-    }
-
-    generationTimerRef.current = window.setTimeout(() => {
-      setGeneratorStatus('idle');
-      setGeneratorError('Generation API is not connected yet.');
-    }, 600);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (generationTimerRef.current) {
-        window.clearTimeout(generationTimerRef.current);
-      }
-    };
   }, []);
 
   const content = useMemo(() => {
@@ -86,23 +43,8 @@ export default function App() {
     if (activePage === 'browse') {
       return <ExistingQuestionsContainer />;
     }
-    return (
-      <GeneratorPage
-        generatorError={generatorError}
-        generatorPrompt={generatorPrompt}
-        generatorStatus={generatorStatus}
-        handleGenerate={handleGenerate}
-        handleGeneratorPromptChange={handleGeneratorPromptChange}
-      />
-    );
-  }, [
-    activePage,
-    generatorError,
-    generatorPrompt,
-    generatorStatus,
-    handleGenerate,
-    handleGeneratorPromptChange
-  ]);
+    return <GeneratorPage />;
+  }, [activePage]);
 
   return (
     <>
@@ -120,15 +62,15 @@ export default function App() {
             </Box>
             <Box sx={{ flexGrow: 1 }} />
             <Stack direction="row" spacing={1} alignItems="center">
-                {navigationItems.map((item) => (
-                  <Button
-                    key={item.id}
-                    onClick={() => handleSelectPage(item.id)}
-                    variant={(activePage == item.id) ? "contained":"outlined"}
-                  >
-                    {item.label}
-                    </Button>
-                ))}
+              {navigationItems.map((item) => (
+                <Button
+                  key={item.id}
+                  onClick={() => handleSelectPage(item.id)}
+                  variant={activePage === item.id ? 'contained' : 'outlined'}
+                >
+                  {item.label}
+                </Button>
+              ))}
             </Stack>
           </Toolbar>
         </AppBar>

--- a/app/flashoffer/quiz-manager/src/GeneratorPage.jsx
+++ b/app/flashoffer/quiz-manager/src/GeneratorPage.jsx
@@ -3,7 +3,13 @@
  * Released under the MIT license.
  */
 
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  AlertTitle,
+  Box,
   Alert,
   Button,
   Paper,
@@ -11,24 +17,172 @@ import {
   TextField,
   Typography
 } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { FlashofferThemeProvider, MultipleChoiceQuiz } from 'flashoffer-react';
+
+const GENERATOR_ENDPOINT = '/api/quiz/questions/generate';
+const GENERATOR_PROMPT_STORAGE_KEY = 'quiz-manager:last-generator-prompt';
 
 /**
  * Presents the generator workflow used to request GPT-assisted quiz drafts.
- * @param {object} props - Component props.
- * @param {string} props.generatorError - Current generator error message.
- * @param {string} props.generatorPrompt - Prompt text supplied by the operator.
- * @param {'idle' | 'loading'} props.generatorStatus - Generator request status.
- * @param {() => void} props.handleGenerate - Callback triggered to draft a question.
- * @param {(event: import('react').ChangeEvent<HTMLInputElement>) => void} props.handleGeneratorPromptChange - Prompt change handler.
+ * Manages the prompt form state and coordinates the async draft request.
  * @returns {JSX.Element} Generator layout.
  */
-export default function GeneratorPage({
-  generatorError = '',
-  generatorPrompt = '',
-  generatorStatus = 'idle',
-  handleGenerate,
-  handleGeneratorPromptChange
-}) {
+export default function GeneratorPage() {
+  const [generatorPrompt, setGeneratorPrompt] = useState(() => {
+    if (typeof window === 'undefined') {
+      return '';
+    }
+    try {
+      return window.localStorage.getItem(GENERATOR_PROMPT_STORAGE_KEY) ?? '';
+    } catch {
+      return '';
+    }
+  });
+  const [generatorStatus, setGeneratorStatus] = useState('idle');
+  const [generatorError, setGeneratorError] = useState('');
+  const [generatorSuccess, setGeneratorSuccess] = useState('');
+  const [generatedQuestion, setGeneratedQuestion] = useState(null);
+
+  const previewQuestion = useMemo(() => {
+    if (!generatedQuestion || typeof generatedQuestion !== 'object') {
+      return null;
+    }
+
+    const questionText =
+      typeof generatedQuestion.question === 'string'
+        ? generatedQuestion.question.trim()
+        : '';
+
+    const helperText =
+      typeof generatedQuestion.helper_text === 'string'
+        ? generatedQuestion.helper_text.trim()
+        : '';
+
+    const explanation =
+      typeof generatedQuestion.explanation === 'string'
+        ? generatedQuestion.explanation.trim()
+        : '';
+
+    const successMessage =
+      typeof generatedQuestion.success_message === 'string'
+        ? generatedQuestion.success_message.trim()
+        : '';
+
+    const errorMessage =
+      typeof generatedQuestion.error_message === 'string'
+        ? generatedQuestion.error_message.trim()
+        : '';
+
+    const options = Array.isArray(generatedQuestion.options)
+      ? generatedQuestion.options
+          .map((option) => ({
+            id: typeof option?.id === 'string' ? option.id : '',
+            label: typeof option?.label === 'string' ? option.label : '',
+            description:
+              typeof option?.description === 'string' && option.description
+                ? option.description
+                : undefined
+          }))
+          .filter((option) => option.id && option.label)
+      : [];
+
+    if (!questionText || options.length === 0) {
+      return null;
+    }
+
+    const correctOptionId =
+      typeof generatedQuestion.correct_option_id === 'string'
+        ? generatedQuestion.correct_option_id
+        : undefined;
+
+    const celebration =
+      typeof generatedQuestion.celebration === 'string' && generatedQuestion.celebration
+        ? generatedQuestion.celebration
+        : undefined;
+
+    return {
+      question: questionText,
+      helperText: helperText || undefined,
+      options,
+      correctOptionId,
+      explanation: explanation || undefined,
+      successMessage: successMessage || undefined,
+      errorMessage: errorMessage || undefined,
+      celebration
+    };
+  }, [generatedQuestion]);
+
+  const handleGeneratorPromptChange = useCallback((event) => {
+    setGeneratorPrompt(event.target.value);
+    setGeneratorError('');
+  }, []);
+
+  const handleGenerate = useCallback(async () => {
+    if (typeof window === 'undefined') {
+      setGeneratorError('Generator is not available in this environment.');
+      return;
+    }
+
+    const trimmedPrompt = generatorPrompt.trim();
+
+    setGeneratorStatus('loading');
+    setGeneratorError('');
+    setGeneratorSuccess('');
+
+    try {
+      const url = new URL(GENERATOR_ENDPOINT, window.location.origin);
+      const response = await fetch(url.toString(), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          prompt: trimmedPrompt || undefined
+        })
+      });
+
+      const body = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        const message = body?.error ?? `Generation failed (${response.status})`;
+        throw new Error(message);
+      }
+
+      if (!body?.question) {
+        throw new Error('Generation did not return a question payload.');
+      }
+
+      setGeneratedQuestion(body.question);
+      const slug = body.question?.slug?.trim();
+      const questionLabel = slug ? `Drafted question ${slug}` : 'Drafted question';
+      setGeneratorSuccess(`${questionLabel} from GPT-5.`);
+    } catch (error) {
+      setGeneratedQuestion(null);
+      setGeneratorError(
+        error instanceof Error ? error.message : 'Generation failed unexpectedly.'
+      );
+    } finally {
+      setGeneratorStatus('idle');
+    }
+  }, [generatorPrompt]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      if (generatorPrompt) {
+        window.localStorage.setItem(GENERATOR_PROMPT_STORAGE_KEY, generatorPrompt);
+      } else {
+        window.localStorage.removeItem(GENERATOR_PROMPT_STORAGE_KEY);
+      }
+    } catch (error) {
+      console.warn('Unable to persist generator prompt', error);
+    }
+  }, [generatorPrompt]);
+
   return (
     <Paper elevation={6} className="quiz-manager__panel">
       <Stack spacing={2}>
@@ -50,6 +204,62 @@ export default function GeneratorPage({
             fullWidth
           />
           {generatorError ? <Alert severity="error">{generatorError}</Alert> : null}
+          {generatorSuccess ? (
+            <Alert severity="success">{generatorSuccess}</Alert>
+          ) : null}
+          {generatedQuestion ? (
+            <Stack spacing={2}>
+              {previewQuestion ? (
+                <Paper variant="outlined" sx={{ p: 2 }}>
+                  <Stack spacing={2}>
+                    <Alert severity="info">
+                      <AlertTitle>Live Preview</AlertTitle>
+                      Interact with the draft question exactly as learners will see it.
+                    </Alert>
+                    <FlashofferThemeProvider>
+                      <Box className="quiz-manager__quiz-preview">
+                        <MultipleChoiceQuiz
+                          question={previewQuestion.question}
+                          helperText={previewQuestion.helperText}
+                          options={previewQuestion.options}
+                          correctOptionId={previewQuestion.correctOptionId}
+                          explanation={previewQuestion.explanation}
+                          successMessage={previewQuestion.successMessage}
+                          errorMessage={previewQuestion.errorMessage}
+                          allowRetry
+                          confetti={
+                            previewQuestion.celebration === 'off'
+                              ? { enabled: false }
+                              : previewQuestion.celebration
+                              ? { enabled: true, preset: previewQuestion.celebration }
+                              : undefined
+                          }
+                        />
+                      </Box>
+                    </FlashofferThemeProvider>
+                  </Stack>
+                </Paper>
+              ) : null}
+              <Accordion defaultExpanded>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="subtitle1">Raw JSON payload</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Box
+                    component="pre"
+                    sx={{
+                      m: 0,
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                      fontFamily: 'Menlo, Consolas, "Liberation Mono", monospace'
+                    }}
+                  >
+                    {JSON.stringify(generatedQuestion, null, 2)}
+                  </Box>
+                </AccordionDetails>
+              </Accordion>
+            </Stack>
+          ) : null}
           <Stack direction="row" spacing={2} justifyContent="flex-end">
             <Button
               variant="outlined"


### PR DESCRIPTION
## Summary
- render generated questions with MultipleChoiceQuiz so editors can interact with drafts immediately
- move the raw JSON payload into an expandable accordion for easier scanning while keeping the preview visible

## Testing
- npm --prefix app/flashoffer/quiz-manager run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68f9021cd41c8321a1bc99d7d5929765