### PR TITLE
Add create question action to quiz generator

### DIFF
--- a/app/flashoffer/quiz-manager/src/GeneratorPage.jsx
+++ b/app/flashoffer/quiz-manager/src/GeneratorPage.jsx
@@ -21,7 +21,165 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { FlashofferThemeProvider, MultipleChoiceQuiz } from 'flashoffer-react';
 
 const GENERATOR_ENDPOINT = '/api/quiz/questions/generate';
+const QUESTIONS_ENDPOINT = '/api/quiz/questions';
 const GENERATOR_PROMPT_STORAGE_KEY = 'quiz-manager:last-generator-prompt';
+const DEFAULT_CELEBRATION = 'off';
+
+/**
+ * Trims arbitrary values into normalized strings.
+ * @param {unknown} value - Candidate value to normalize.
+ * @returns {string} Trimmed string value.
+ */
+function trimValue(value) {
+  return String(value ?? '').trim();
+}
+
+/**
+ * Returns a trimmed string while preserving empty values.
+ * @param {unknown} value - Optional input to normalize.
+ * @returns {string} Trimmed string or an empty string.
+ */
+function optionalTrimmed(value) {
+  const trimmed = trimValue(value);
+  return trimmed || '';
+}
+
+/**
+ * Resolves an ISO date string using a fallback when missing.
+ * @param {unknown} value - Date-like input value.
+ * @param {string} fallback - Replacement when the value is empty.
+ * @returns {string} ISO formatted date string.
+ */
+function isoDateValue(value, fallback) {
+  const base = trimValue(value) || fallback;
+  return base.slice(0, 10);
+}
+
+/**
+ * Produces an optional ISO date truncated to ten characters.
+ * @param {unknown} value - Candidate optional date.
+ * @returns {string} ISO date string or an empty string.
+ */
+function optionalIsoDate(value) {
+  const trimmed = trimValue(value);
+  return trimmed ? trimmed.slice(0, 10) : '';
+}
+
+/**
+ * Maps raw options into payload-ready entries.
+ * @param {unknown} options - Arbitrary option collection.
+ * @returns {Array<{ id: string, label: string, description?: string }>} Normalized options.
+ */
+function normalizePayloadOptions(options) {
+  return (Array.isArray(options) ? options : [])
+    .map((option) => ({
+      id: trimValue(option?.id),
+      label: trimValue(option?.label),
+      description: trimValue(option?.description)
+    }))
+    .filter((option) => option.id || option.label)
+    .map((option) => {
+      const nextOption = {
+        id: option.id,
+        label: option.label || option.id
+      };
+      if (option.description) {
+        nextOption.description = option.description;
+      }
+      return nextOption;
+    });
+}
+
+/**
+ * Validates option content and resolves the correct answer identifier.
+ * @param {unknown} options - Generated question options.
+ * @param {unknown} preferredId - Desired correct option identifier.
+ * @returns {{ normalizedOptions: Array<object>, correctOptionId: string }} Normalized results.
+ */
+function normalizeAndValidateOptions(options, preferredId) {
+  const normalizedOptions = normalizePayloadOptions(options);
+
+  if (normalizedOptions.length < 3) {
+    throw new Error('Generated question must include at least three answer options.');
+  }
+
+  const optionIds = normalizedOptions.map((option) => option.id);
+  if (!optionIds.every((value) => Boolean(value))) {
+    throw new Error('Each answer option must include a non-empty id.');
+  }
+
+  if (new Set(optionIds).size !== optionIds.length) {
+    throw new Error('Each answer option id must be unique.');
+  }
+
+  let correctOptionId = trimValue(preferredId);
+  const hasPreferred =
+    correctOptionId && normalizedOptions.some((option) => option.id === correctOptionId);
+  if (!hasPreferred) {
+    correctOptionId = normalizedOptions[0]?.id ?? '';
+  }
+
+  if (!correctOptionId) {
+    throw new Error('Generated question is missing a valid correct option id.');
+  }
+
+  return {
+    normalizedOptions,
+    correctOptionId
+  };
+}
+
+/**
+ * Builds the payload used to persist a generated question.
+ * @param {unknown} generated - Question returned from the generator endpoint.
+ * @returns {object} Backend payload ready for creation.
+ */
+function buildCreationPayload(generated) {
+  if (!generated || typeof generated !== 'object') {
+    throw new Error('Generate a question before creating it.');
+  }
+
+  const slug = trimValue(generated.slug);
+  if (!slug) {
+    throw new Error('Generated question is missing a slug.');
+  }
+
+  const questionText = trimValue(generated.question);
+  if (!questionText) {
+    throw new Error('Generated question is missing the prompt.');
+  }
+
+  const { normalizedOptions, correctOptionId } = normalizeAndValidateOptions(
+    generated.options,
+    generated.correct_option_id
+  );
+
+  const today = new Date().toISOString().slice(0, 10);
+  const publishedOn = isoDateValue(generated.published_on, today);
+  const expiresOn = optionalIsoDate(generated.expires_on);
+
+  const celebrationValue = trimValue(generated.celebration);
+  const celebration = celebrationValue || DEFAULT_CELEBRATION;
+
+  const payload = {
+    slug,
+    question: questionText,
+    helper_text: optionalTrimmed(generated.helper_text) || undefined,
+    explanation: optionalTrimmed(generated.explanation) || undefined,
+    success_message: optionalTrimmed(generated.success_message) || undefined,
+    error_message: optionalTrimmed(generated.error_message) || undefined,
+    options: normalizedOptions,
+    correct_option_id: correctOptionId,
+    published_on: publishedOn,
+    celebration
+  };
+
+  if (expiresOn) {
+    payload.expires_on = expiresOn;
+  }
+
+  return payload;
+}
 
 /**
  * Presents the generator workflow used to request GPT-assisted quiz drafts.
@@ -43,6 +201,9 @@ export default function GeneratorPage() {
   const [generatorError, setGeneratorError] = useState('');
   const [generatorSuccess, setGeneratorSuccess] = useState('');
   const [generatedQuestion, setGeneratedQuestion] = useState(null);
+  const [createStatus, setCreateStatus] = useState('idle');
+  const [createError, setCreateError] = useState('');
+  const [createSuccess, setCreateSuccess] = useState('');
 
   const previewQuestion = useMemo(() => {
     if (!generatedQuestion || typeof generatedQuestion !== 'object') {
@@ -157,6 +318,8 @@ export default function GeneratorPage() {
       const slug = body.question?.slug?.trim();
       const questionLabel = slug ? `Drafted question ${slug}` : 'Drafted question';
       setGeneratorSuccess(`${questionLabel} from GPT-5.`);
+      setCreateSuccess('');
+      setCreateError('');
     } catch (error) {
       setGeneratedQuestion(null);
       setGeneratorError(
@@ -166,6 +329,53 @@ export default function GeneratorPage() {
       setGeneratorStatus('idle');
     }
   }, [generatorPrompt]);
+
+  const handleCreateQuestion = useCallback(async () => {
+    if (typeof window === 'undefined') {
+      setCreateError('Creation is not available in this environment.');
+      return;
+    }
+
+    setCreateStatus('loading');
+    setCreateError('');
+    setCreateSuccess('');
+
+    try {
+      const payload = buildCreationPayload(generatedQuestion);
+      const url = new URL(
+        "http://localhost:8002" + QUESTIONS_ENDPOINT,
+        window.location.origin
+      );
+      const response = await fetch(url.toString(), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+
+      const body = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        const message = body?.error ?? `Creation failed (${response.status})`;
+        throw new Error(message);
+      }
+
+      if (body?.question && typeof body.question === 'object') {
+        setGeneratedQuestion(body.question);
+      }
+
+      const slug = trimValue(body?.question?.slug ?? payload.slug);
+      const questionLabel = slug ? `Created question ${slug}` : 'Created question';
+      setCreateSuccess(questionLabel);
+    } catch (error) {
+      setCreateError(
+        error instanceof Error ? error.message : 'Creation failed unexpectedly.'
+      );
+    } finally {
+      setCreateStatus('idle');
+    }
+  }, [generatedQuestion]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -207,6 +417,8 @@ export default function GeneratorPage() {
           {generatorSuccess ? (
             <Alert severity="success">{generatorSuccess}</Alert>
           ) : null}
+          {createError ? <Alert severity="error">{createError}</Alert> : null}
+          {createSuccess ? <Alert severity="success">{createSuccess}</Alert> : null}
           {generatedQuestion ? (
             <Stack spacing={2}>
               {previewQuestion ? (
@@ -261,6 +473,14 @@ export default function GeneratorPage() {
             </Stack>
           ) : null}
           <Stack direction="row" spacing={2} justifyContent="flex-end">
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleCreateQuestion}
+              disabled={createStatus === 'loading' || !generatedQuestion}
+            >
+              {createStatus === 'loading' ? 'Creating…' : 'Create question'}
+            </Button>
             <Button
               variant="outlined"
               color="inherit"


### PR DESCRIPTION
## Summary
- add helpers that normalize generated quiz payloads for submission
- expose a Create question button on the generator page and post drafts to the quiz API

## Testing
- npm run lint *(fails: missing @eslint/js package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f9136ae2c08321ae49aabe43e53cfc