### PR TITLE
Add Prettier setup for quiz manager

### DIFF
--- a/app/flashoffer/quiz-manager/.prettierignore
+++ b/app/flashoffer/quiz-manager/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+build
+dist
+coverage

--- a/app/flashoffer/quiz-manager/package-lock.json
+++ b/app/flashoffer/quiz-manager/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.22",
         "globals": "^16.4.0",
+        "prettier": "^3.6.2",
         "vite": "^7.1.7"
       }
     },
@@ -3117,6 +3118,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/app/flashoffer/quiz-manager/package.json
+++ b/app/flashoffer/quiz-manager/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "format": "prettier --check .",
+    "format:write": "prettier --write .",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -28,6 +30,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.22",
     "globals": "^16.4.0",
+    "prettier": "^3.6.2",
     "vite": "^7.1.7"
   }
 }

--- a/app/flashoffer/quiz-manager/prettier.config.js
+++ b/app/flashoffer/quiz-manager/prettier.config.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Flashoffer Developers.
+ * Licensed under the MIT license.
+ */
+
+export default {
+  printWidth: 80,
+  tabWidth: 2,
+  singleQuote: true,
+  trailingComma: 'all',
+  semi: true,
+};


### PR DESCRIPTION
## Summary
- add a Prettier configuration and ignore file for the quiz manager frontend
- install the Prettier dev dependency and expose npm scripts to check or write formatting

## Testing
- npm run format -- --version

------
https://chatgpt.com/codex/tasks/task_e_68f93c79336c8321885dda5533b8de29