### PR TITLE
Add batch quiz generation workflow

### DIFF
--- a/app/flashoffer/docs/api/quiz-backend.md
+++ b/app/flashoffer/docs/api/quiz-backend.md
@@ -114,12 +114,16 @@ curl -s \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $QUIZ_TOKEN" \
   https://quiz.flashoffer.example/api/quiz/questions/generate \
-  -d '{"topic": "cashback basics", "difficulty": "easy"}' |
+  -d '{"count": 2, "topic": "cashback basics", "difficulty": "easy"}' |
   jq
 ```
 
-The generator responds with a draft question and choices that your moderation
-workflow can review before publishing.
+The generator responds with a list of draft questions plus the raw completions
+returned by the model. Quiz Manager surfaces one question at a time so
+moderators can step through the batch and publish only the approved entries.
+Responses include a `questions` array and a matching `raw_batch`.
+The first entry is also exposed as `question` for backwards
+compatibility with older clients.
 
 ## Tracking Quiz Performance
 

--- a/app/flashoffer/docs/quiz-manager/gpt-assisted-question-generation.md
+++ b/app/flashoffer/docs/quiz-manager/gpt-assisted-question-generation.md
@@ -15,13 +15,13 @@ sequenceDiagram
   participant GPT as OpenAI Completions
   participant Store as Quiz Database
 
-  Editor->>Backend: POST /api/quiz/questions/generate with topic brief
+  Editor->>Backend: POST /api/quiz/questions/generate with count + topic brief
   Backend->>Backend: Enrich prompt with validation rules and metadata
   Backend->>GPT: Submit OpenAI request with system + user prompts
   GPT-->>Backend: Return proposed question JSON payload
   Backend->>Backend: Validate schema, sanitize HTML, score difficulty
-  Backend-->>Editor: Respond with question preview + reasoning trace
-  Editor->>Editor: Present preview, allow edits, stage publish action
+  Backend-->>Editor: Respond with question previews + reasoning trace
+  Editor->>Editor: Present per-question review flow, stage publish action
   Editor->>Backend: POST /api/quiz/questions with final question body
   Backend->>Store: Persist record and versioned GPT audit trail
   Backend-->>Editor: Confirm creation with canonical slug
@@ -33,6 +33,9 @@ sequenceDiagram
   never see malformed payloads.
 - Quiz Manager stores the final prompt, completion, and moderator overrides to
   maintain provenance for compliance reviews.
+- Editors can request up to five drafts at a time. The UI tracks generation
+  duration, provides a progress bar while reviewing the batch, and lets
+  moderators step through each question sequentially.
 - Editors can iteratively regenerate prompts; only the approved payload is
   persisted to the quiz database.
 
@@ -47,6 +50,7 @@ curl -X POST \
   -H "Authorization: Bearer OPENAI_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
+    "count": 3,
     "topic": "Spring espresso trivia",
     "target_audience": "baristas",
     "difficulty": "intermediate"

--- a/app/flashoffer/quiz-backend/quiz_backend/app.py
+++ b/app/flashoffer/quiz-backend/quiz_backend/app.py
@@ -199,12 +199,17 @@ class GenerationModelError(RuntimeError):
     """Raised when the OpenAI response cannot be converted into a question."""
 
 
+MIN_GENERATION_COUNT = 1
+MAX_GENERATION_COUNT = 5
+
+
 @dataclass(frozen=True)
 class GenerationRequest:
     """Validated parameters for generating a quiz question."""
 
     prompt: str
     model: str
+    count: int
 
 
 def _build_generation_system_prompt() -> str:
@@ -262,6 +267,53 @@ def _load_generation_payload(flask_request: Request) -> Dict[str, Any]:
     return payload
 
 
+def _normalize_generation_count(value: Any) -> int:
+    """Coerce the inbound generation count into a bounded integer."""
+
+    if value is None:
+        return MIN_GENERATION_COUNT
+
+    if isinstance(value, bool):
+        raise GenerationRequestError(
+            f"count must be an integer between {MIN_GENERATION_COUNT}"
+            f" and {MAX_GENERATION_COUNT}"
+        )
+
+    if isinstance(value, int):
+        count = value
+    elif isinstance(value, float):
+        if not value.is_integer():
+            raise GenerationRequestError(
+                f"count must be an integer between {MIN_GENERATION_COUNT}"
+                f" and {MAX_GENERATION_COUNT}"
+            )
+        count = int(value)
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return MIN_GENERATION_COUNT
+        try:
+            count = int(stripped, 10)
+        except ValueError as exc:
+            raise GenerationRequestError(
+                f"count must be an integer between {MIN_GENERATION_COUNT}"
+                f" and {MAX_GENERATION_COUNT}"
+            ) from exc
+    else:
+        raise GenerationRequestError(
+            f"count must be an integer between {MIN_GENERATION_COUNT}"
+            f" and {MAX_GENERATION_COUNT}"
+        )
+
+    if count < MIN_GENERATION_COUNT or count > MAX_GENERATION_COUNT:
+        raise GenerationRequestError(
+            f"count must be an integer between {MIN_GENERATION_COUNT}"
+            f" and {MAX_GENERATION_COUNT}"
+        )
+
+    return count
+
+
 def _parse_generation_request(flask_request: Request) -> GenerationRequest:
     payload = _load_generation_payload(flask_request)
 
@@ -275,7 +327,9 @@ def _parse_generation_request(flask_request: Request) -> GenerationRequest:
 
     model = str(payload.get("model") or "gpt-5").strip() or "gpt-5"
 
-    return GenerationRequest(prompt=prompt, model=model)
+    count = _normalize_generation_count(payload.get("count"))
+
+    return GenerationRequest(prompt=prompt, model=model, count=count)
 
 
 def _request_generated_question(
@@ -498,11 +552,17 @@ def create_app() -> Flask:
                 return jsonify({"error": f"openai_client_init_failed: {exc}"}), 502
 
             try:
-                question_payload, generated = _request_generated_question(
-                    client,
-                    model=generation_request.model,
-                    prompt=generation_request.prompt,
-                )
+                questions: list[Dict[str, Any]] = []
+                raw_batch: list[Dict[str, Any]] = []
+
+                for _ in range(generation_request.count):
+                    question_payload, generated = _request_generated_question(
+                        client,
+                        model=generation_request.model,
+                        prompt=generation_request.prompt,
+                    )
+                    questions.append(question_payload)
+                    raw_batch.append(generated)
             except GenerationModelError as exc:
                 return jsonify({"error": str(exc)}), 502
             except Exception as exc:  # noqa: BLE001 - surface API error
@@ -511,7 +571,16 @@ def create_app() -> Flask:
                 )
                 return jsonify({"error": f"openai_request_failed: {exc}"}), 502
 
-            return jsonify({"question": question_payload, "raw": generated})
+            response_payload: Dict[str, Any] = {
+                "questions": questions,
+                "raw_batch": raw_batch,
+            }
+            if questions:
+                response_payload["question"] = questions[0]
+            if raw_batch:
+                response_payload["raw"] = raw_batch[0]
+
+            return jsonify(response_payload)
         finally:
             if managed_http_client is not None:
                 managed_http_client.close()

--- a/app/flashoffer/quiz-backend/tests/test_app.py
+++ b/app/flashoffer/quiz-backend/tests/test_app.py
@@ -410,6 +410,8 @@ def test_generate_quiz_question_uses_https_without_proxy(client, monkeypatch):
     body = response.get_json()
     assert body["question"]["slug"] == "draft-slug"
     assert body["question"]["celebration"] == "classic"
+    assert body["questions"] == [generated_question]
+    assert body["raw_batch"] == [generated_question]
     assert len(DummyOpenAI.calls) == 1
     base_url, used_client = DummyOpenAI.calls[0]
     assert base_url.startswith("https://")
@@ -425,6 +427,86 @@ def test_generate_quiz_question_rejects_non_string_prompt(client, monkeypatch):
     assert response.status_code == 400
     body = response.get_json()
     assert body["error"] == "prompt must be a string"
+
+
+def test_generate_quiz_question_rejects_invalid_count(client, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "unit-test-key")
+
+    response = client.post(
+        "/api/quiz/questions/generate",
+        json={"prompt": "", "count": 0},
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert "count must be an integer" in body["error"]
+
+
+def test_generate_quiz_question_batches_requests(client, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "unit-test-key")
+
+    class DummyHttpClient:
+        instances: list["DummyHttpClient"] = []
+
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+            self.closed = False
+            DummyHttpClient.instances.append(self)
+
+        def close(self):
+            self.closed = True
+
+    class DummyOpenAI:
+        def __init__(self, *, api_key, base_url, http_client):
+            self.api_key = api_key
+            self.base_url = base_url
+            self.http_client = http_client
+            self._counter = 0
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=self._create_completion)
+            )
+
+        def _create_completion(self, **_kwargs):
+            slug = f"batched-question-{self._counter}"
+            self._counter += 1
+            payload = {
+                "slug": slug,
+                "question": f"Question #{self._counter}?",
+                "helper_text": None,
+                "explanation": None,
+                "success_message": None,
+                "error_message": None,
+                "options": [
+                    {"id": "a", "label": "First"},
+                    {"id": "b", "label": "Second"},
+                    {"id": "c", "label": "Third"},
+                ],
+                "correct_option_id": "a",
+                "published_on": "2024-01-01",
+                "expires_on": None,
+                "celebration": "off",
+            }
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content=json.dumps(payload))
+                    )
+                ]
+            )
+
+    monkeypatch.setattr("quiz_backend.app.httpx.Client", DummyHttpClient)
+    monkeypatch.setattr("quiz_backend.app.OpenAI", DummyOpenAI)
+
+    response = client.post(
+        "/api/quiz/questions/generate",
+        json={"prompt": "", "count": 3},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert len(body["questions"]) == 3
+    assert len(body["raw_batch"]) == 3
+    assert body["question"]["slug"] == "batched-question-0"
 
 
 def test_generate_quiz_question_handles_openai_error(client, monkeypatch):

--- a/app/flashoffer/quiz-manager/src/GeneratorPage.jsx
+++ b/app/flashoffer/quiz-manager/src/GeneratorPage.jsx
@@ -17,6 +17,7 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  LinearProgress,
   Paper,
   Stack,
   TextField,
@@ -29,6 +30,34 @@ const GENERATOR_ENDPOINT = '/api/quiz/questions/generate';
 const QUESTIONS_ENDPOINT = '/api/quiz/questions';
 const GENERATOR_PROMPT_STORAGE_KEY = 'quiz-manager:last-generator-prompt';
 const DEFAULT_CELEBRATION = 'off';
+const MIN_GENERATION_COUNT = 1;
+const MAX_GENERATION_COUNT = 5;
+
+/**
+ * Formats a millisecond duration into a compact string.
+ * @param {number} milliseconds - Duration in milliseconds.
+ * @returns {string} Human friendly representation.
+ */
+function formatDuration(milliseconds) {
+  if (!Number.isFinite(milliseconds) || milliseconds <= 0) {
+    return '0s';
+  }
+
+  if (milliseconds < 1000) {
+    return `${Math.round(milliseconds)}ms`;
+  }
+
+  const totalSeconds = milliseconds / 1000;
+  if (totalSeconds < 60) {
+    const precision = totalSeconds < 10 ? 1 : 0;
+    return `${totalSeconds.toFixed(precision)}s`;
+  }
+
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = Math.floor(totalSeconds % 60);
+  const paddedSeconds = String(seconds).padStart(2, '0');
+  return `${minutes}m ${paddedSeconds}s`;
+}
 
 /**
  * Trims arbitrary values into normalized strings.
@@ -208,7 +237,12 @@ export default function GeneratorPage() {
   const [generatorStatus, setGeneratorStatus] = useState('idle');
   const [generatorError, setGeneratorError] = useState('');
   const [generatorSuccess, setGeneratorSuccess] = useState('');
-  const [generatedQuestion, setGeneratedQuestion] = useState(null);
+  const [questionCount, setQuestionCount] = useState(MIN_GENERATION_COUNT);
+  const [generatedQuestions, setGeneratedQuestions] = useState([]);
+  const [rawGenerations, setRawGenerations] = useState([]);
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
+  const [generationStartedAt, setGenerationStartedAt] = useState(null);
+  const [generationElapsedMs, setGenerationElapsedMs] = useState(0);
   const [createStatus, setCreateStatus] = useState('idle');
   const [createDialog, setCreateDialog] = useState({
     open: false,
@@ -216,38 +250,54 @@ export default function GeneratorPage() {
     message: '',
   });
 
+  const currentQuestion = useMemo(() => {
+    if (
+      currentQuestionIndex < 0 ||
+      currentQuestionIndex >= generatedQuestions.length
+    ) {
+      return null;
+    }
+
+    const candidate = generatedQuestions[currentQuestionIndex];
+    if (!candidate || typeof candidate !== 'object') {
+      return null;
+    }
+
+    return candidate;
+  }, [generatedQuestions, currentQuestionIndex]);
+
   const previewQuestion = useMemo(() => {
-    if (!generatedQuestion || typeof generatedQuestion !== 'object') {
+    if (!currentQuestion || typeof currentQuestion !== 'object') {
       return null;
     }
 
     const questionText =
-      typeof generatedQuestion.question === 'string'
-        ? generatedQuestion.question.trim()
+      typeof currentQuestion.question === 'string'
+        ? currentQuestion.question.trim()
         : '';
 
     const helperText =
-      typeof generatedQuestion.helper_text === 'string'
-        ? generatedQuestion.helper_text.trim()
+      typeof currentQuestion.helper_text === 'string'
+        ? currentQuestion.helper_text.trim()
         : '';
 
     const explanation =
-      typeof generatedQuestion.explanation === 'string'
-        ? generatedQuestion.explanation.trim()
+      typeof currentQuestion.explanation === 'string'
+        ? currentQuestion.explanation.trim()
         : '';
 
     const successMessage =
-      typeof generatedQuestion.success_message === 'string'
-        ? generatedQuestion.success_message.trim()
+      typeof currentQuestion.success_message === 'string'
+        ? currentQuestion.success_message.trim()
         : '';
 
     const errorMessage =
-      typeof generatedQuestion.error_message === 'string'
-        ? generatedQuestion.error_message.trim()
+      typeof currentQuestion.error_message === 'string'
+        ? currentQuestion.error_message.trim()
         : '';
 
-    const options = Array.isArray(generatedQuestion.options)
-      ? generatedQuestion.options
+    const options = Array.isArray(currentQuestion.options)
+      ? currentQuestion.options
           .map((option) => ({
             id: typeof option?.id === 'string' ? option.id : '',
             label: typeof option?.label === 'string' ? option.label : '',
@@ -264,14 +314,14 @@ export default function GeneratorPage() {
     }
 
     const correctOptionId =
-      typeof generatedQuestion.correct_option_id === 'string'
-        ? generatedQuestion.correct_option_id
+      typeof currentQuestion.correct_option_id === 'string'
+        ? currentQuestion.correct_option_id
         : undefined;
 
     const celebration =
-      typeof generatedQuestion.celebration === 'string' &&
-      generatedQuestion.celebration
-        ? generatedQuestion.celebration
+      typeof currentQuestion.celebration === 'string' &&
+      currentQuestion.celebration
+        ? currentQuestion.celebration
         : undefined;
 
     return {
@@ -284,10 +334,65 @@ export default function GeneratorPage() {
       errorMessage: errorMessage || undefined,
       celebration,
     };
-  }, [generatedQuestion]);
+  }, [currentQuestion]);
+
+  const currentRawGeneration = useMemo(() => {
+    if (
+      currentQuestionIndex < 0 ||
+      currentQuestionIndex >= rawGenerations.length
+    ) {
+      return null;
+    }
+
+    const candidate = rawGenerations[currentQuestionIndex];
+    if (!candidate || typeof candidate !== 'object') {
+      return null;
+    }
+
+    return candidate;
+  }, [rawGenerations, currentQuestionIndex]);
+
+  const totalQuestions = generatedQuestions.length;
+  const reviewProgress = totalQuestions
+    ? Math.round(((currentQuestionIndex + 1) / totalQuestions) * 100)
+    : 0;
+  const generatorInFlight = generatorStatus === 'loading';
+  const generationTimeLabel = formatDuration(generationElapsedMs);
+  const currentSlug =
+    currentQuestion && typeof currentQuestion.slug === 'string'
+      ? currentQuestion.slug.trim()
+      : '';
+  const rawSummaryLabel = totalQuestions > 1
+    ? `Raw JSON payload (Question ${currentQuestionIndex + 1})`
+    : 'Raw JSON payload';
+  const generateButtonLabel = useMemo(() => {
+    if (generatorInFlight) {
+      return 'Generating…';
+    }
+    if (questionCount > 1) {
+      return 'Generate questions with GPT-5';
+    }
+    return 'Generate question with GPT-5';
+  }, [generatorInFlight, questionCount]);
 
   const handleGeneratorPromptChange = useCallback((event) => {
     setGeneratorPrompt(event.target.value);
+    setGeneratorError('');
+  }, []);
+
+  const handleQuestionCountChange = useCallback((event) => {
+    const nextValue = Number.parseInt(event.target.value, 10);
+    if (Number.isNaN(nextValue)) {
+      setQuestionCount(MIN_GENERATION_COUNT);
+      setGeneratorError('');
+      return;
+    }
+
+    const clamped = Math.min(
+      MAX_GENERATION_COUNT,
+      Math.max(MIN_GENERATION_COUNT, nextValue),
+    );
+    setQuestionCount(clamped);
     setGeneratorError('');
   }, []);
 
@@ -299,10 +404,26 @@ export default function GeneratorPage() {
 
     const trimmedPrompt = generatorPrompt.trim();
 
+    const desiredCount = Math.min(
+      MAX_GENERATION_COUNT,
+      Math.max(MIN_GENERATION_COUNT, Number.isFinite(questionCount)
+        ? questionCount
+        : MIN_GENERATION_COUNT),
+    );
+
+    if (desiredCount !== questionCount) {
+      setQuestionCount(desiredCount);
+    }
+
     setGeneratorStatus('loading');
     setGeneratorError('');
     setGeneratorSuccess('');
-
+    setGeneratedQuestions([]);
+    setRawGenerations([]);
+    setCurrentQuestionIndex(0);
+    const startTime = Date.now();
+    setGenerationStartedAt(startTime);
+    setGenerationElapsedMs(0);
     try {
       const url = new URL(
         'http://localhost:8002' + GENERATOR_ENDPOINT,
@@ -315,6 +436,7 @@ export default function GeneratorPage() {
         },
         body: JSON.stringify({
           prompt: trimmedPrompt || undefined,
+          count: desiredCount,
         }),
       });
 
@@ -325,28 +447,75 @@ export default function GeneratorPage() {
         throw new Error(message);
       }
 
-      if (!body?.question) {
-        throw new Error('Generation did not return a question payload.');
+      let questions = Array.isArray(body?.questions) ? body.questions : [];
+      if (!questions.length && body?.question) {
+        questions = [body.question];
       }
 
-      setGeneratedQuestion(body.question);
-      const slug = body.question?.slug?.trim();
-      const questionLabel = slug
-        ? `Drafted question ${slug}`
-        : 'Drafted question';
-      setGeneratorSuccess(`${questionLabel} from GPT-5.`);
+      if (!questions.length) {
+        throw new Error('Generation did not return any question payloads.');
+      }
+
+      const rawBatch = Array.isArray(body?.raw_batch) ? body.raw_batch : [];
+      const legacyRaw = body?.raw;
+      const normalizedRaw = questions.map((question, index) => {
+        if (rawBatch[index] && typeof rawBatch[index] === 'object') {
+          return rawBatch[index];
+        }
+
+        if (Array.isArray(legacyRaw) && legacyRaw[index] && typeof legacyRaw[index] === 'object') {
+          return legacyRaw[index];
+        }
+
+        if (legacyRaw && !Array.isArray(legacyRaw) && typeof legacyRaw === 'object' && index === 0) {
+          return legacyRaw;
+        }
+
+        return question;
+      });
+
+      setGeneratedQuestions(questions);
+      setRawGenerations(normalizedRaw);
+      setCurrentQuestionIndex(0);
+
+      const durationMs = Date.now() - startTime;
+      let successLabel = `Drafted ${questions.length} questions in ${formatDuration(
+        durationMs,
+      )} with GPT-5.`;
+      if (questions.length === 1) {
+        successLabel = `Drafted 1 question in ${formatDuration(durationMs)} with GPT-5.`;
+      }
+      setGeneratorSuccess(successLabel);
       setCreateDialog({ open: false, severity: 'success', message: '' });
     } catch (error) {
-      setGeneratedQuestion(null);
+      setGeneratedQuestions([]);
+      setRawGenerations([]);
       setGeneratorError(
         error instanceof Error
           ? error.message
           : 'Generation failed unexpectedly.',
       );
     } finally {
+      const finishedAt = Date.now();
+      const elapsed = Math.max(0, finishedAt - startTime);
+      setGenerationElapsedMs(elapsed);
+      setGenerationStartedAt(null);
       setGeneratorStatus('idle');
     }
-  }, [generatorPrompt]);
+  }, [generatorPrompt, questionCount]);
+
+  const handleSelectPrevious = useCallback(() => {
+    setCurrentQuestionIndex((previous) => (previous > 0 ? previous - 1 : previous));
+  }, []);
+
+  const handleSelectNext = useCallback(() => {
+    setCurrentQuestionIndex((previous) => {
+      if (previous + 1 >= totalQuestions) {
+        return previous;
+      }
+      return previous + 1;
+    });
+  }, [totalQuestions]);
 
   const handleCreateQuestion = useCallback(async () => {
     if (typeof window === 'undefined') {
@@ -358,11 +527,20 @@ export default function GeneratorPage() {
       return;
     }
 
+    if (!currentQuestion) {
+      setCreateDialog({
+        open: true,
+        severity: 'error',
+        message: 'Generate a question before creating it.',
+      });
+      return;
+    }
+
     setCreateStatus('loading');
     setCreateDialog({ open: false, severity: 'success', message: '' });
 
     try {
-      const payload = buildCreationPayload(generatedQuestion);
+      const payload = buildCreationPayload(currentQuestion);
       const url = new URL(
         'http://localhost:8002' + QUESTIONS_ENDPOINT,
         window.location.origin,
@@ -383,7 +561,14 @@ export default function GeneratorPage() {
       }
 
       if (body?.question && typeof body.question === 'object') {
-        setGeneratedQuestion(body.question);
+        setGeneratedQuestions((previous) => {
+          if (!previous.length) {
+            return previous;
+          }
+          const updated = [...previous];
+          updated[currentQuestionIndex] = body.question;
+          return updated;
+        });
       }
 
       const slug = trimValue(body?.question?.slug ?? payload.slug);
@@ -407,7 +592,7 @@ export default function GeneratorPage() {
     } finally {
       setCreateStatus('idle');
     }
-  }, [generatedQuestion]);
+  }, [currentQuestion, currentQuestionIndex]);
 
   /**
    * Closes the modal dialog used to communicate creation results.
@@ -415,6 +600,22 @@ export default function GeneratorPage() {
   const handleCloseCreateDialog = useCallback(() => {
     setCreateDialog((previous) => ({ ...previous, open: false }));
   }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    if (generatorStatus !== 'loading' || !generationStartedAt) {
+      return undefined;
+    }
+
+    const interval = window.setInterval(() => {
+      setGenerationElapsedMs(Date.now() - generationStartedAt);
+    }, 200);
+
+    return () => window.clearInterval(interval);
+  }, [generatorStatus, generationStartedAt]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -457,14 +658,84 @@ export default function GeneratorPage() {
             minRows={3}
             fullWidth
           />
+          <TextField
+            label={`Number of questions (${MIN_GENERATION_COUNT}-${MAX_GENERATION_COUNT})`}
+            type="number"
+            value={questionCount}
+            onChange={handleQuestionCountChange}
+            inputProps={{
+              min: MIN_GENERATION_COUNT,
+              max: MAX_GENERATION_COUNT,
+            }}
+            helperText={`Generate up to ${MAX_GENERATION_COUNT} questions per request.`}
+            fullWidth
+          />
           {generatorError ? (
             <Alert severity="error">{generatorError}</Alert>
           ) : null}
           {generatorSuccess ? (
             <Alert severity="success">{generatorSuccess}</Alert>
           ) : null}
-          {generatedQuestion ? (
+          {generatorInFlight ? (
+            <Stack spacing={1}>
+              <LinearProgress color="secondary" />
+              <Typography variant="caption" color="textSecondary">
+                Generating {questionCount > 1 ? `${questionCount} questions` : 'question'}…
+                {' '}
+                Elapsed {generationTimeLabel}
+              </Typography>
+            </Stack>
+          ) : null}
+          {totalQuestions ? (
             <Stack spacing={2}>
+              <Stack spacing={1}>
+                <Typography variant="subtitle2" color="textSecondary">
+                  Review progress
+                </Typography>
+                <LinearProgress
+                  variant="determinate"
+                  value={reviewProgress}
+                  color="secondary"
+                />
+                <Stack direction="row" justifyContent="space-between">
+                  <Typography variant="body2">
+                    Question {currentQuestionIndex + 1} of {totalQuestions}
+                  </Typography>
+                  <Typography variant="body2">
+                    Draft time: {generationTimeLabel}
+                  </Typography>
+                </Stack>
+              </Stack>
+              <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Typography variant="h6">
+                  {currentSlug || `Question ${currentQuestionIndex + 1}`}
+                </Typography>
+                <Stack direction="row" spacing={1}>
+                  <Button
+                    variant="outlined"
+                    color="inherit"
+                    onClick={handleSelectPrevious}
+                    disabled={currentQuestionIndex === 0 || createStatus === 'loading'}
+                  >
+                    Previous
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    color="inherit"
+                    onClick={handleSelectNext}
+                    disabled={
+                      currentQuestionIndex + 1 >= totalQuestions ||
+                      createStatus === 'loading'
+                    }
+                  >
+                    Next
+                  </Button>
+                </Stack>
+              </Stack>
               {previewQuestion ? (
                 <Paper variant="outlined" sx={{ p: 2 }}>
                   <Stack spacing={2}>
@@ -502,7 +773,7 @@ export default function GeneratorPage() {
               ) : null}
               <Accordion>
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                  <Typography variant="subtitle1">Raw JSON payload</Typography>
+                  <Typography variant="subtitle1">{rawSummaryLabel}</Typography>
                 </AccordionSummary>
                 <AccordionDetails>
                   <Box
@@ -515,7 +786,11 @@ export default function GeneratorPage() {
                         'Menlo, Consolas, "Liberation Mono", monospace',
                     }}
                   >
-                    {JSON.stringify(generatedQuestion, null, 2)}
+                    {JSON.stringify(
+                      currentRawGeneration ?? currentQuestion ?? {},
+                      null,
+                      2,
+                    )}
                   </Box>
                 </AccordionDetails>
               </Accordion>
@@ -526,7 +801,7 @@ export default function GeneratorPage() {
               variant="contained"
               color="primary"
               onClick={handleCreateQuestion}
-              disabled={createStatus === 'loading' || !generatedQuestion}
+              disabled={createStatus === 'loading' || !currentQuestion}
             >
               {createStatus === 'loading' ? 'Creating…' : 'Create question'}
             </Button>
@@ -534,11 +809,9 @@ export default function GeneratorPage() {
               variant="outlined"
               color="inherit"
               onClick={handleGenerate}
-              disabled={generatorStatus === 'loading'}
+              disabled={generatorInFlight}
             >
-              {generatorStatus === 'loading'
-                ? 'Generating…'
-                : 'Generate with GPT-5'}
+              {generateButtonLabel}
             </Button>
           </Stack>
         </Stack>


### PR DESCRIPTION
## Summary
- allow Quiz Manager editors to request multiple draft questions, monitor generation progress, and review each item sequentially
- extend the quiz-backend generator endpoint to accept a `count` parameter and return batched question/trace payloads
- refresh automated tests and documentation to describe the batched workflow and new response schema

## Testing
- PYTHONPATH=app/flashoffer/quiz-backend:app/shell/py/pie:app/flashoffer/backend-common pytest app/flashoffer/quiz-backend/tests *(fails: database containers/env vars are required in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f942ff1fe88321bd9c3e83008dc51a