### PR TITLE
Update Flashoffer coding standards

### DIFF
--- a/app/flashoffer/AGENTS.md
+++ b/app/flashoffer/AGENTS.md
@@ -10,6 +10,11 @@
 - Convert UTC timestamps to a viewer's local timezone before displaying them.
 - Pin all Flashoffer Docker Node base images to `node:22-slim`.
 - Pin all Flashoffer Docker Python base images to `python:3.14-slim`.
+- Use PEP 8 as the default Python style unless a language-specific override in
+  this file states otherwise.
+- Apply the per-language overrides described here on top of the default style
+  expectations for each language.
+- Declare all global constants in source code using ALL_CAPS names.
 
 ## Flashoffer React Components
 


### PR DESCRIPTION
## Summary
- set PEP 8 as the default Flashoffer Python code style
- clarify that language-specific overrides augment the defaults
- require global constants in source code to use ALL_CAPS names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f94c5858908321a1d8867029f43e51