### PR TITLE
Apply Flashoffer coding standard across quiz manager

### DIFF
--- a/app/flashoffer/AGENTS.md
+++ b/app/flashoffer/AGENTS.md
@@ -10,6 +10,11 @@
 - Convert UTC timestamps to a viewer's local timezone before displaying them.
 - Pin all Flashoffer Docker Node base images to `node:22-slim`.
 - Pin all Flashoffer Docker Python base images to `python:3.14-slim`.
+- Use PEP 8 as the default Python style unless a language-specific override in
+  this file states otherwise.
+- Apply the per-language overrides described here on top of the default style
+  expectations for each language.
+- Declare all global constants in source code using ALL_CAPS names.
 
 ## Flashoffer React Components
 

--- a/app/flashoffer/quiz-manager/src/ExistingQuestionsContainer.jsx
+++ b/app/flashoffer/quiz-manager/src/ExistingQuestionsContainer.jsx
@@ -6,6 +6,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import ExistingQuestionsPage from './ExistingQuestionsPage.jsx';
 
+const API_BASE_URL = 'http://localhost:8002';
 const QUESTIONS_ENDPOINT = '/api/quiz/questions';
 
 /**
@@ -28,7 +29,7 @@ export default function ExistingQuestionsContainer() {
 
     try {
       const url = new URL(
-        'http://localhost:8002' + QUESTIONS_ENDPOINT,
+        API_BASE_URL + QUESTIONS_ENDPOINT,
         window.location.origin,
       );
       url.searchParams.set('limit', '50');

--- a/app/flashoffer/quiz-manager/vite.config.js
+++ b/app/flashoffer/quiz-manager/vite.config.js
@@ -3,19 +3,22 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
 
-const toPosixPath = (value) => value.split(sep).join('/');
-const projectRoot = fileURLToPath(new URL('./', import.meta.url));
+function toPosixPath(value) {
+  return value.split(sep).join('/');
+}
 
-const nodeModulesDir = resolvePath(projectRoot, 'node_modules');
-const materialBase = toPosixPath(resolvePath(nodeModulesDir, '@mui/material'));
-const muiUtilsBase = toPosixPath(resolvePath(nodeModulesDir, '@mui/utils'));
+const PROJECT_ROOT = fileURLToPath(new URL('./', import.meta.url));
 
-const flashofferSource = fileURLToPath(
+const NODE_MODULES_DIR = resolvePath(PROJECT_ROOT, 'node_modules');
+const MATERIAL_BASE = toPosixPath(resolvePath(NODE_MODULES_DIR, '@mui/material'));
+const MUI_UTILS_BASE = toPosixPath(resolvePath(NODE_MODULES_DIR, '@mui/utils'));
+
+const FLASHOFFER_SOURCE = fileURLToPath(
   new URL('../flashoffer-react/src/index.ts', import.meta.url),
 );
 
-const canvasConfettiModule = toPosixPath(
-  resolvePath(nodeModulesDir, 'canvas-confetti', 'dist', 'confetti.module.mjs'),
+const CANVAS_CONFETTI_MODULE = toPosixPath(
+  resolvePath(NODE_MODULES_DIR, 'canvas-confetti', 'dist', 'confetti.module.mjs'),
 );
 
 // https://vite.dev/config/
@@ -25,27 +28,27 @@ export default defineConfig({
     alias: [
       {
         find: 'flashoffer-react',
-        replacement: flashofferSource,
+        replacement: FLASHOFFER_SOURCE,
       },
       {
         find: /^canvas-confetti$/,
-        replacement: canvasConfettiModule,
+        replacement: CANVAS_CONFETTI_MODULE,
       },
       {
         find: /^@mui\/material$/i,
-        replacement: `${materialBase}/index.js`,
+        replacement: `${MATERIAL_BASE}/index.js`,
       },
       {
         find: /^@mui\/material\/(.*)$/i,
-        replacement: `${materialBase}/$1`,
+        replacement: `${MATERIAL_BASE}/$1`,
       },
       {
         find: /^@mui\/utils$/i,
-        replacement: `${muiUtilsBase}/index.js`,
+        replacement: `${MUI_UTILS_BASE}/index.js`,
       },
       {
         find: /^@mui\/utils\/(.*)$/i,
-        replacement: `${muiUtilsBase}/$1`,
+        replacement: `${MUI_UTILS_BASE}/$1`,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- add an explicit API_BASE_URL constant to the existing questions container
- rename Vite config globals to ALL_CAPS and convert the shared path helper into a function so it is exempt from the constant rule

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f94c5858908321a1d8867029f43e51