### PR TITLE
Use structured JSON schema for quiz question generation

### DIFF
--- a/app/flashoffer/quiz-backend/quiz_backend/app.py
+++ b/app/flashoffer/quiz-backend/quiz_backend/app.py
@@ -220,6 +220,7 @@ def _build_generation_system_prompt() -> str:
         "The JSON must NOT be wrapped in any additional words or Markdown. "
         "Structure the object with these keys: slug, question, helper_text, explanation, "
         "success_message, error_message, options, correct_option_id, published_on, expires_on. "
+        "Include celebration with a value of off, classic, streamers, or burst. "
         "Rules: slug must be lowercase kebab-case (letters, digits, hyphen) with a maximum length of 48 characters. "
         "question should be concise plain text without HTML. "
         "Provide helper_text, explanation, success_message, and error_message when useful; otherwise use null. "
@@ -338,13 +339,93 @@ def _request_generated_question(
     system_prompt = _build_generation_system_prompt()
     user_prompt = prompt.strip() or _DEFAULT_GENERATION_USER_PROMPT
 
+    schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "slug": {
+                "type": "string",
+                "pattern": "^[a-z0-9][a-z0-9-]{0,47}$",
+                "description": "Lowercase kebab-case identifier",
+            },
+            "question": {
+                "type": "string",
+                "description": "Quiz question text",
+            },
+            "helper_text": {
+                "type": ["string", "null"],
+            },
+            "explanation": {
+                "type": ["string", "null"],
+            },
+            "success_message": {
+                "type": ["string", "null"],
+            },
+            "error_message": {
+                "type": ["string", "null"],
+            },
+            "options": {
+                "type": "array",
+                "minItems": 3,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "pattern": "^[a-z][a-z0-9-]{0,47}$",
+                        },
+                        "label": {
+                            "type": "string",
+                        },
+                        "description": {
+                            "type": ["string", "null"],
+                            "maxLength": 140,
+                        },
+                    },
+                    "required": ["id", "label"],
+                },
+            },
+            "correct_option_id": {
+                "type": "string",
+            },
+            "published_on": {
+                "type": "string",
+                "format": "date",
+            },
+            "expires_on": {
+                "type": ["string", "null"],
+                "format": "date",
+            },
+            "celebration": {
+                "type": "string",
+                "enum": sorted(QUIZ_CELEBRATION_PRESETS),
+            },
+        },
+        "required": [
+            "slug",
+            "question",
+            "options",
+            "correct_option_id",
+            "published_on",
+            "celebration",
+        ],
+    }
+
     completion = client.chat.completions.create(  # type: ignore[attr-defined]
         model=model,
         messages=[
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt},
         ],
-        response_format={"type": "json_object"},
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": "quiz_question",
+                "schema": schema,
+                "strict": True,
+            },
+        },
     )
 
     try:

--- a/app/flashoffer/quiz-backend/tests/test_app.py
+++ b/app/flashoffer/quiz-backend/tests/test_app.py
@@ -388,17 +388,30 @@ def test_generate_quiz_question_uses_https_without_proxy(client, monkeypatch):
             assert base_url.startswith("https://")
             assert isinstance(http_client, DummyHttpClient)
             self.chat = SimpleNamespace(
-                completions=SimpleNamespace(
-                    create=lambda **kwargs: SimpleNamespace(
-                        choices=[
-                            SimpleNamespace(
-                                message=SimpleNamespace(
-                                    content=json.dumps(generated_question)
-                                )
-                            )
-                        ]
+                completions=SimpleNamespace(create=self._create_completion)
+            )
+
+        def _create_completion(self, **kwargs):
+            response_format = kwargs.get("response_format")
+            assert response_format is not None
+            assert response_format["type"] == "json_schema"
+            schema = response_format["json_schema"]["schema"]
+            required_fields = schema["required"]
+            assert "celebration" in required_fields
+            assert schema["properties"]["celebration"]["enum"] == [
+                "burst",
+                "classic",
+                "off",
+                "streamers",
+            ]
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            content=json.dumps(generated_question)
+                        )
                     )
-                )
+                ]
             )
 
     monkeypatch.setattr("quiz_backend.app.httpx.Client", DummyHttpClient)
@@ -467,6 +480,7 @@ def test_generate_quiz_question_batches_requests(client, monkeypatch):
             )
 
         def _create_completion(self, **_kwargs):
+            assert _kwargs["response_format"]["type"] == "json_schema"
             slug = f"batched-question-{self._counter}"
             self._counter += 1
             payload = {


### PR DESCRIPTION
## Summary
- request quiz questions from GPT using a JSON schema response format that includes celebration options
- validate generated content against the existing loader while documenting the celebration requirement in the system prompt
- update quiz generation tests to assert that the OpenAI client receives the structured output schema

## Testing
- PYTHONPATH=app/flashoffer/quiz-backend pytest app/flashoffer/quiz-backend/tests/test_app.py *(fails: database containers not available in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f9513c98fc8321823053cfae65784d