### PR TITLE
Refactor quiz manager with redux and react-hook-form

### DIFF
--- a/app/quiz/package-lock.json
+++ b/app/quiz/package-lock.json
@@ -12,8 +12,11 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^7.1.0",
         "@mui/material": "^7.1.0",
+        "@reduxjs/toolkit": "^2.5.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-hook-form": "^7.54.2",
+        "react-redux": "^9.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -71,7 +74,6 @@
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -387,7 +389,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -431,7 +432,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1230,7 +1230,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.1.0.tgz",
       "integrity": "sha512-ahUJdrhEv+mCp4XHW+tHIEYzZMSRLg8z4AjUOsj44QpD1ZaMxQoVOG2xiHvLFdcsIPbgSRx1bg1eQSheHBgvtg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.1",
         "@mui/core-downloads-tracker": "^7.1.0",
@@ -1431,6 +1430,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.10.1.tgz",
+      "integrity": "sha512-/U17EXQ9Do9Yx4DlNGU6eVNfZvFJfYpUtRRdLf19PbPjdWBxNlxGZXywQZ1p1Nz8nMkWplTI7iD/23m07nolDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.2.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1713,6 +1738,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1789,7 +1826,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
       "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1812,6 +1848,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.4.1",
@@ -1853,7 +1895,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1985,7 +2026,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -2434,7 +2474,6 @@
       "integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2648,7 +2687,6 @@
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -3033,6 +3071,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -3592,7 +3640,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3737,7 +3784,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3747,7 +3793,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -3755,11 +3800,50 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.66.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.1.tgz",
+      "integrity": "sha512-2KnjpgG2Rhbi+CIiIBQQ9Df6sMGH5ExNyFl4Hw9qO7pIqMBR8Bvu9RQyjl3JM4vehzCh9soiNUM/xYMswb2EiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
       "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -3786,6 +3870,27 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -4241,6 +4346,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -4257,7 +4371,6 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4386,7 +4499,6 @@
       "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/app/quiz/package.json
+++ b/app/quiz/package.json
@@ -14,8 +14,11 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
+    "@reduxjs/toolkit": "^2.5.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-hook-form": "^7.54.2",
+    "react-redux": "^9.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/app/quiz/src/Quiz.jsx
+++ b/app/quiz/src/Quiz.jsx
@@ -1,4 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchQuiz, submitQuiz } from './features/quizSlice';
 
 /**
  * @fileoverview Interactive multiple-choice quiz component.
@@ -20,50 +23,54 @@ import React, { useEffect, useState } from 'react';
  * @returns {JSX.Element}
  */
 const Quiz = ({ src = "/study/key_terms.json" }) => {
-  const [questions, setQuestions] = useState([]);
-  const [selected, setSelected] = useState({});
-  const [showAnswers, setShowAnswers] = useState(false);
-  const [score, setScore] = useState(null);
+  const dispatch = useDispatch();
+  const { answers, error, questions, score, showAnswers, status } = useSelector(
+    (state) => state.quiz,
+  );
+
+  const {
+    handleSubmit,
+    register,
+    reset,
+    watch,
+  } = useForm({
+    defaultValues: { answers: {} },
+  });
+
+  const watchedAnswers = watch('answers');
 
   // Fetch quiz questions whenever the `src` prop changes.
   useEffect(() => {
-    fetch(src)
-      .then((res) => res.json())
-      .then(setQuestions)
-      .catch(console.error);
-  }, [src]);
+    dispatch(fetchQuiz(src));
+  }, [dispatch, src]);
 
-  /**
-   * Record the choice a user selects for a given question.
-   *
-   * Selections are ignored after the quiz has been submitted.
-   *
-   * @param {number} qIndex - Index of the question.
-   * @param {number} cIndex - Index of the choice.
-   */
-  const handleSelect = (qIndex, cIndex) => {
-    if (showAnswers) return;
-    setSelected((prev) => ({ ...prev, [qIndex]: cIndex }));
-  };
+  useEffect(() => {
+    const defaults = questions.reduce((acc, _question, index) => {
+      const persisted = answers[index];
+      acc[index] = persisted ?? '';
+      return acc;
+    }, {});
 
-  /**
-   * Tally the user's answers and reveal the results.
-   */
-  const handleSubmit = () => {
-    const newScore = questions.reduce((acc, q, qIndex) => {
-      const correctIndex = q.a[0];
-      return acc + (selected[qIndex] === correctIndex ? 1 : 0);
-    }, 0);
+    reset({ answers: defaults });
+  }, [answers, questions, reset]);
 
-    setScore(newScore);
-    setShowAnswers(true);
+  const onSubmit = (data) => {
+    dispatch(submitQuiz({ answers: data.answers ?? {} }));
   };
 
   return (
-    <div className="quiz-container">
+    <form className="quiz-container" onSubmit={handleSubmit(onSubmit)}>
+      {status === 'loading' && <p>Loading quiz...</p>}
+      {status === 'failed' && (
+        <p className="error">{error || 'Unable to load quiz.'}</p>
+      )}
+
       {questions.map((q, qIndex) => {
         const correctIndex = q.a[0];
         const explanation = q.a[1];
+        const currentSelection = showAnswers
+          ? answers[qIndex]
+          : watchedAnswers?.[qIndex];
 
         return (
           <div key={qIndex} className="question-block">
@@ -74,7 +81,7 @@ const Quiz = ({ src = "/study/key_terms.json" }) => {
 
             <ul className="choices">
               {q.c.map((choice, cIndex) => {
-                const isSelected = selected[qIndex] === cIndex;
+                const isSelected = String(currentSelection) === String(cIndex);
                 const isCorrect = cIndex === correctIndex;
                 const isWrong = isSelected && !isCorrect;
 
@@ -87,12 +94,19 @@ const Quiz = ({ src = "/study/key_terms.json" }) => {
                 }
 
                 return (
-                  <li
-                    key={cIndex}
-                    className={className}
-                    onClick={() => handleSelect(qIndex, cIndex)}
-                    dangerouslySetInnerHTML={{ __html: choice }}
-                  />
+                  <li key={cIndex} className={className}>
+                    <label>
+                      <input
+                        type="radio"
+                        value={cIndex}
+                        disabled={showAnswers}
+                        {...register(`answers.${qIndex}`)}
+                      />
+                      <span
+                        dangerouslySetInnerHTML={{ __html: choice }}
+                      />
+                    </label>
+                  </li>
                 );
               })}
             </ul>
@@ -110,7 +124,7 @@ const Quiz = ({ src = "/study/key_terms.json" }) => {
       })}
 
       {!showAnswers ? (
-        <button className="submit-btn" onClick={handleSubmit}>
+        <button className="submit-btn" type="submit">
           Submit Answers
         </button>
       ) : (
@@ -118,7 +132,7 @@ const Quiz = ({ src = "/study/key_terms.json" }) => {
           <h2>Your Score: {score} / {questions.length}</h2>
         </div>
       )}
-    </div>
+    </form>
   );
 };
 

--- a/app/quiz/src/features/quizSlice.js
+++ b/app/quiz/src/features/quizSlice.js
@@ -1,0 +1,74 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+export const fetchQuiz = createAsyncThunk(
+  'quiz/fetchQuiz',
+  async (src) => {
+    const response = await fetch(src);
+    if (!response.ok) {
+      throw new Error('Failed to load quiz content');
+    }
+
+    return response.json();
+  },
+);
+
+const initialState = {
+  answers: {},
+  error: null,
+  questions: [],
+  score: null,
+  showAnswers: false,
+  status: 'idle',
+};
+
+const quizSlice = createSlice({
+  name: 'quiz',
+  initialState,
+  reducers: {
+    resetQuiz: (state) => {
+      state.answers = {};
+      state.score = null;
+      state.showAnswers = false;
+    },
+    submitQuiz: (state, action) => {
+      const submittedAnswers = action.payload?.answers ?? {};
+      let computedScore = 0;
+
+      state.questions.forEach((question, index) => {
+        const correctIndex = question.a[0];
+        const choice = submittedAnswers[index];
+        const choiceIndex =
+          choice === undefined || choice === '' ? null : Number(choice);
+
+        if (choiceIndex === correctIndex) {
+          computedScore += 1;
+        }
+      });
+
+      state.answers = submittedAnswers;
+      state.score = computedScore;
+      state.showAnswers = true;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchQuiz.pending, (state) => {
+        state.status = 'loading';
+        state.error = null;
+      })
+      .addCase(fetchQuiz.fulfilled, (state, action) => {
+        state.status = 'succeeded';
+        state.questions = action.payload;
+        state.answers = {};
+        state.showAnswers = false;
+        state.score = null;
+      })
+      .addCase(fetchQuiz.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.error.message;
+      });
+  },
+});
+
+export const { resetQuiz, submitQuiz } = quizSlice.actions;
+export default quizSlice.reducer;

--- a/app/quiz/src/main.jsx
+++ b/app/quiz/src/main.jsx
@@ -8,9 +8,11 @@
  */
 
 import { StrictMode } from 'react';
+import { Provider } from 'react-redux';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import Quiz from './Quiz';
+import { store } from './store';
 
 /**
  * Bootstraps and renders the SearchIndex component into the DOM.
@@ -31,7 +33,9 @@ function initializeSearchIndex() {
   const root = createRoot(mount);
   root.render(
     <StrictMode>
-      <Quiz src={mount.getAttribute('data-src')} />
+      <Provider store={store}>
+        <Quiz src={mount.getAttribute('data-src')} />
+      </Provider>
     </StrictMode>
   );
 }

--- a/app/quiz/src/store.js
+++ b/app/quiz/src/store.js
@@ -1,0 +1,8 @@
+import { configureStore } from '@reduxjs/toolkit';
+import quizReducer from './features/quizSlice';
+
+export const store = configureStore({
+  reducer: {
+    quiz: quizReducer,
+  },
+});


### PR DESCRIPTION
## Summary
- add a Redux Toolkit slice and store to manage quiz loading, answers, and scoring
- wrap the quiz entry point with a Redux provider and refactor the component to use react-hook-form for selections
- include new dependencies for React Redux, React Hook Form, and Redux Toolkit

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920bf5b1ed08321bafa02934719a6c1)